### PR TITLE
GH-4104: fix issue with Instant, turn it into datetimestamp value

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -14,6 +14,7 @@ package org.eclipse.rdf4j.model.base;
 import static java.lang.Math.abs;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.INSTANT_SECONDS;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
@@ -522,7 +523,7 @@ public abstract class AbstractLiteral implements Literal {
 		private static final ChronoField[] FIELDS = {
 				YEAR, MONTH_OF_YEAR, DAY_OF_MONTH,
 				HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE, NANO_OF_SECOND,
-				OFFSET_SECONDS
+				OFFSET_SECONDS, INSTANT_SECONDS
 		};
 
 		private static final DateTimeFormatter LOCAL_TIME_FORMATTER = new DateTimeFormatterBuilder()
@@ -584,6 +585,12 @@ public abstract class AbstractLiteral implements Literal {
 
 				.toFormatter();
 
+		private static final DateTimeFormatter DATETIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+
+				.appendInstant()
+
+				.toFormatter();
+
 		private static final DateTimeFormatter DASH_FORMATTER = new DateTimeFormatterBuilder()
 
 				.appendLiteral("--")
@@ -620,13 +627,16 @@ public abstract class AbstractLiteral implements Literal {
 			int time = key(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE);
 			int nano = key(NANO_OF_SECOND);
 			int zone = key(OFFSET_SECONDS);
+			int instant = key(INSTANT_SECONDS);
 
 			Map<Integer, CoreDatatype.XSD> datatypes = new HashMap<>();
-
 			datatypes.put(date + time, CoreDatatype.XSD.DATETIME);
 			datatypes.put(date + time + nano, CoreDatatype.XSD.DATETIME);
 			datatypes.put((date + time + zone), CoreDatatype.XSD.DATETIME);
 			datatypes.put((date + time + nano + zone), CoreDatatype.XSD.DATETIME);
+			datatypes.put((date + time + instant + zone), CoreDatatype.XSD.DATETIME);
+			datatypes.put((date + time + instant + nano + zone), CoreDatatype.XSD.DATETIME);
+			datatypes.put((instant + nano), CoreDatatype.XSD.DATETIMESTAMP);
 
 			datatypes.put(time, CoreDatatype.XSD.TIME);
 			datatypes.put(time + nano, CoreDatatype.XSD.TIME);
@@ -649,6 +659,7 @@ public abstract class AbstractLiteral implements Literal {
 
 			final Map<CoreDatatype.XSD, DateTimeFormatter> formatters = new EnumMap<>(CoreDatatype.XSD.class);
 
+			formatters.put(CoreDatatype.XSD.DATETIMESTAMP, DATETIMESTAMP_FORMATTER);
 			formatters.put(CoreDatatype.XSD.DATETIME, DATETIME_FORMATTER);
 			formatters.put(CoreDatatype.XSD.TIME, OFFSET_TIME_FORMATTER);
 			formatters.put(CoreDatatype.XSD.DATE, OFFSET_DATE_FORMATTER);
@@ -705,18 +716,17 @@ public abstract class AbstractLiteral implements Literal {
 		private final CoreDatatype.XSD datatype;
 
 		TemporalAccessorLiteral(TemporalAccessor value) {
-
 			this.value = value;
 
-			datatype = DATATYPES.get(key(value));
+			datatype = DATATYPES.get(key(this.value));
 
 			if (datatype == null) {
 				throw new IllegalArgumentException(String.format(
-						"value <%s> cannot be represented by an XML Schema date/time datatype", value
+						"value <%s> cannot be represented by an XML Schema date/time datatype", this.value
 				));
 			}
 
-			this.label = FORMATTERS.get(datatype).format(value);
+			this.label = FORMATTERS.get(datatype).format(this.value);
 		}
 
 		@Override

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.Date;
@@ -506,6 +507,18 @@ public class ValuesTest {
 				.isInstanceOf(NullPointerException.class)
 				.hasMessageContaining("value may not be null");
 
+	}
+
+	@Test
+	public void testTemporalAccessorLiteralInstant() {
+		final Instant value = Instant.ofEpochSecond(1234567890, 12);
+		Literal literal = literal(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype()).isEqualTo(XSD.DATETIMESTAMP);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.DATETIMESTAMP);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #4104 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
- add formatter to convert Instant to xsd:dateTimestamp
- added test
- 
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

