### PR TITLE
GH-4232 performance issue in VALUES clause query

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/BindingSetAssignmentInlinerOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/BindingSetAssignmentInlinerOptimizer.java
@@ -85,4 +85,5 @@ public class BindingSetAssignmentInlinerOptimizer implements QueryOptimizer {
 			super.meetNode(node);
 		}
 	}
+
 }

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.query.algebra.And;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
@@ -63,6 +64,8 @@ public class GraphPattern {
 	 * The boolean constraints in this graph pattern.
 	 */
 	private List<ValueExpr> constraints = new ArrayList<>();
+
+	private BindingSetAssignment inlineData;
 
 	/**
 	 * Creates a new graph pattern.
@@ -156,6 +159,7 @@ public class GraphPattern {
 		requiredTEs.clear();
 		optionalTEs.clear();
 		constraints.clear();
+		inlineData = null;
 	}
 
 	/**
@@ -195,7 +199,19 @@ public class GraphPattern {
 			result = new Filter(result, constraint);
 		}
 
+		if (getInlineData() != null) {
+			result = new Join(getInlineData(), result);
+		}
+
 		return result;
+	}
+
+	public BindingSetAssignment getInlineData() {
+		return inlineData;
+	}
+
+	public void setInlineData(BindingSetAssignment bsa) {
+		this.inlineData = bsa;
 	}
 
 }

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -2077,7 +2077,22 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		bsa.setBindingSets(bindingSets);
 
-		graphPattern.addRequiredTE(bsa);
+		if (graphPattern.getInlineData() != null) {
+			GraphPattern parentGP = graphPattern;
+			graphPattern = new GraphPattern(parentGP);
+
+			graphPattern.setInlineData(bsa);
+
+			TupleExpr te = graphPattern.buildTupleExpr();
+			if (node.isScopeChange()) {
+				((VariableScopeChange) te).setVariableScopeChange(true);
+			}
+			parentGP.addRequiredTE(te);
+
+			graphPattern = parentGP;
+		} else {
+			graphPattern.setInlineData(bsa);
+		}
 		return bsa;
 	}
 

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilderTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilderTest.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.Order;
 import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.Service;
@@ -79,6 +81,29 @@ public class TupleExprBuilderTest {
 			e.printStackTrace();
 			fail("should parse ask query with solution modifiers");
 		}
+
+	}
+
+	@Test
+	public void testValuesOptionalQuery() throws Exception {
+		String query = "select ?parent ?child\n"
+				+ "where {\n"
+				+ "    values ?type {<owl:Class>}\n"
+				+ "    ?parent <rdf:type> ?type .\n"
+				+ "    optional {\n"
+				+ "        ?child <rdfs:subClassOf> ?parent ;\n"
+				+ "               <rdf:type> ?type .\n"
+				+ "    }\n"
+				+ "}";
+
+		TupleExprBuilder builder = new TupleExprBuilder(SimpleValueFactory.getInstance());
+		ASTQueryContainer qc = SyntaxTreeBuilder.parseQuery(query);
+		TupleExpr result = builder.visit(qc, null);
+
+		assertThat(result).isInstanceOf(Projection.class);
+		Join topJoin = (Join) ((Projection) result).getArg();
+
+		assertThat(topJoin.getLeftArg()).isInstanceOf(BindingSetAssignment.class);
 
 	}
 

--- a/core/sail/memory/src/test/resources/benchmarkFiles/query-values.qr
+++ b/core/sail/memory/src/test/resources/benchmarkFiles/query-values.qr
@@ -1,0 +1,13 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+
+select ?parent ?child
+where {
+    values ?type {owl:Class}
+    ?parent rdf:type ?type .
+    optional {
+        ?child rdfs:subClassOf ?parent ;
+               rdf:type ?type .
+    }
+}

--- a/core/sail/memory/src/test/resources/benchmarkFiles/query-without-values.qr
+++ b/core/sail/memory/src/test/resources/benchmarkFiles/query-without-values.qr
@@ -1,0 +1,12 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+
+select ?parent ?child
+where {
+    ?parent rdf:type owl:Class .
+    optional {
+        ?child rdfs:subClassOf ?parent ;
+               rdf:type owl:Class .
+    }
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ValuesClauseTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ValuesClauseTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.explanation.Explanation;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Jeen Broekstra
+ */
+public class ValuesClauseTest {
+
+	private static SailRepository repository;
+
+	public static TemporaryFolder tempDir = new TemporaryFolder();
+
+	private static final String query1;
+	private static final String query2;
+
+	static {
+		try {
+			query1 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query-values.qr"), StandardCharsets.UTF_8);
+			query2 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query-without-values.qr"),
+					StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@BeforeClass
+	public static void beforeClass() throws IOException {
+		tempDir.create();
+		File file = tempDir.newFolder();
+
+		repository = new SailRepository(new NativeStore(file, "spoc,posc,cspo,opsc"));
+
+		int numberOfItems = 2;
+		int numberOfChildren = 2;
+		int numberOfTypeOwlClassStatements = 500;
+		int numberOfSubClassOfStatements = 10_000;
+
+		try (var conn = repository.getConnection()) {
+			conn.begin(IsolationLevels.NONE);
+			for (int i = 0; i < numberOfItems; i++) {
+
+				var parent = iri("http://example.org/parent_" + i);
+
+				Model m = new ModelBuilder().setNamespace(OWL.NS)
+						.setNamespace("ex", "http://example.org/")
+						.subject(parent)
+						.add(RDF.TYPE, OWL.CLASS)
+						.add(RDF.TYPE, RDFS.CLASS)
+						.add(RDFS.LABEL, "parent " + i)
+						.build();
+				conn.add(m);
+				if (i % 2 == 0) {
+					for (int j = 0; j < numberOfChildren; j++) {
+						m = new ModelBuilder().setNamespace(OWL.NS)
+								.setNamespace("ex", "http://example.org/")
+								.subject("ex:child_" + i + "_" + j)
+								.add(RDF.TYPE, OWL.CLASS)
+								.add(RDF.TYPE, RDFS.CLASS)
+								.add(RDFS.SUBCLASSOF, parent)
+								.add(RDFS.LABEL, "child of " + i)
+								.build();
+						conn.add(m);
+					}
+				}
+
+			}
+			for (int i = 0; i < numberOfTypeOwlClassStatements; i++) {
+				conn.add(Values.bnode(), RDF.TYPE, OWL.CLASS);
+			}
+
+			for (int i = 0; i < numberOfSubClassOfStatements; i++) {
+				conn.add(Values.bnode(), RDFS.SUBCLASSOF, Values.bnode());
+			}
+			conn.commit();
+		}
+	}
+
+	@AfterClass
+	public static void afterClass() throws IOException {
+		tempDir.delete();
+		repository.shutDown();
+		tempDir = null;
+		repository = null;
+	}
+
+	@Test
+	public void valuesOptionalQuery() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			System.out.println(connection.prepareTupleQuery(query1).explain(Explanation.Level.Executed));
+			assertThat(connection.prepareTupleQuery(query1).evaluate().stream().count()).isEqualTo(505);
+		}
+	}
+
+	@Test
+	public void simpleEquivalentQuery() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			System.out.println(connection.prepareTupleQuery(query2).explain(Explanation.Level.Executed));
+			assertThat(connection.prepareTupleQuery(query2).evaluate().stream().count()).isEqualTo(505);
+		}
+	}
+
+	private static InputStream getResourceAsStream(String name) {
+		return ValuesClauseTest.class.getClassLoader().getResourceAsStream(name);
+	}
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/SPARQLValuesClauseBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/SPARQLValuesClauseBenchmark.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.nativerdf.benchmark;
+
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * @author Jeen Broekstra
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms1G", "-Xmx1G" })
+//@Fork(value = 1, jvmArgs = {"-Xms1G", "-Xmx1G", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class SPARQLValuesClauseBenchmark {
+
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
+	private SailRepository repository;
+
+	private static final String query_with_values_clause;
+	private static final String query_without_values_clause;
+
+	static {
+		try {
+			query_with_values_clause = IOUtils.toString(
+					getResourceAsStream("benchmarkFiles/query-values.qr"), StandardCharsets.UTF_8);
+
+			query_without_values_clause = IOUtils.toString(
+					getResourceAsStream("benchmarkFiles/query-without-values.qr"), StandardCharsets.UTF_8);
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static void main(String[] args) throws RunnerException, IOException, InterruptedException {
+		Options opt = new OptionsBuilder()
+				.include("SPARQLValuesClauseBenchmark") // adapt to run other benchmark tests
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+
+	}
+
+	@Setup(Level.Trial)
+	public void beforeClass() throws IOException, InterruptedException {
+		tempDir.create();
+		File file = tempDir.newFolder();
+
+		repository = new SailRepository(new NativeStore(file, "spoc,posc,cspo,opsc"));
+
+		int numberOfItems = 10_000;
+		int numberOfChildren = 10_000;
+
+		try (var conn = repository.getConnection()) {
+			conn.begin(IsolationLevels.NONE);
+			for (int i = 0; i < numberOfItems; i++) {
+
+				var parent = iri("http://example.org/parent_" + i);
+
+				Model m = new ModelBuilder().setNamespace(OWL.NS)
+						.setNamespace("ex", "http://example.org/")
+						.subject(parent)
+						.add(RDF.TYPE, OWL.CLASS)
+						.add(RDF.TYPE, RDFS.CLASS)
+						.add(RDFS.LABEL, "parent " + i)
+						.build();
+				conn.add(m);
+				if (i % 2 == 0) {
+					for (int j = 0; j < numberOfChildren; j++) {
+						m = new ModelBuilder().setNamespace(OWL.NS)
+								.setNamespace("ex", "http://example.org/")
+								.subject("ex:child_" + i + "_" + j)
+								.add(RDF.TYPE, OWL.CLASS)
+								.add(RDF.TYPE, RDFS.CLASS)
+								.add(RDFS.SUBCLASSOF, parent)
+								.add(RDFS.LABEL, "child of " + i)
+								.build();
+						conn.add(m);
+					}
+				}
+			}
+			conn.commit();
+		}
+	}
+
+	@TearDown(Level.Trial)
+	public void afterClass() {
+		repository.shutDown();
+	}
+
+	@Benchmark
+	public long valuesOptionalQuery() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query_with_values_clause)
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+
+	@Benchmark
+	public long simpleEquivalentQuery() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query_without_values_clause)
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+
+	/* private methods */
+
+	private static InputStream getResourceAsStream(String filename) {
+		return SPARQLValuesClauseBenchmark.class.getClassLoader().getResourceAsStream(filename);
+	}
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/SPARQLValuesClauseBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/SPARQLValuesClauseBenchmark.java
@@ -23,6 +23,7 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -99,8 +100,10 @@ public class SPARQLValuesClauseBenchmark {
 
 		repository = new SailRepository(new NativeStore(file, "spoc,posc,cspo,opsc"));
 
-		int numberOfItems = 10_000;
-		int numberOfChildren = 10_000;
+		int numberOfItems = 2;
+		int numberOfChildren = 2;
+		int numberOfTypeOwlClassStatements = 500;
+		int numberOfSubClassOfStatements = 10_000;
 
 		try (var conn = repository.getConnection()) {
 			conn.begin(IsolationLevels.NONE);
@@ -129,6 +132,14 @@ public class SPARQLValuesClauseBenchmark {
 						conn.add(m);
 					}
 				}
+
+			}
+			for (int i = 0; i < numberOfTypeOwlClassStatements; i++) {
+				conn.add(Values.bnode(), RDF.TYPE, OWL.CLASS);
+			}
+
+			for (int i = 0; i < numberOfSubClassOfStatements; i++) {
+				conn.add(Values.bnode(), RDFS.SUBCLASSOF, Values.bnode());
 			}
 			conn.commit();
 		}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/SPARQLValuesClauseBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/SPARQLValuesClauseBenchmark.java
@@ -153,6 +153,19 @@ public class SPARQLValuesClauseBenchmark {
 	@Benchmark
 	public long valuesOptionalQuery() {
 		try (SailRepositoryConnection connection = repository.getConnection()) {
+//
+//			System.out.println("ONLY PARSED:");
+//			System.out.println(connection.prepareTupleQuery(query_with_values_clause));
+//			System.out.println("\nUNOPTIMIZED:");
+//			System.out.println(
+//					connection.prepareTupleQuery(query_with_values_clause).explain(Explanation.Level.Unoptimized));
+//
+//			System.out.println();
+//			System.out.println("OPTIMIZED:");
+//			System.out.println(
+//					connection.prepareTupleQuery(query_with_values_clause).explain(Explanation.Level.Optimized));
+
+//			return 0L;
 			return connection
 					.prepareTupleQuery(query_with_values_clause)
 					.evaluate()
@@ -164,6 +177,7 @@ public class SPARQLValuesClauseBenchmark {
 	@Benchmark
 	public long simpleEquivalentQuery() {
 		try (SailRepositoryConnection connection = repository.getConnection()) {
+
 			return connection
 					.prepareTupleQuery(query_without_values_clause)
 					.evaluate()

--- a/core/sail/nativerdf/src/test/resources/benchmarkFiles/query-values.qr
+++ b/core/sail/nativerdf/src/test/resources/benchmarkFiles/query-values.qr
@@ -7,7 +7,7 @@ where {
     values ?type {owl:Class}
     ?parent rdf:type ?type .
     optional {
-        ?child rdfs:subClassOf ?parent ;
-               rdf:type ?type .
+        ?child rdfs:subClassOf ?parent .
+        ?child rdf:type ?type .
     }
 }

--- a/core/sail/nativerdf/src/test/resources/benchmarkFiles/query-values.qr
+++ b/core/sail/nativerdf/src/test/resources/benchmarkFiles/query-values.qr
@@ -1,0 +1,13 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+
+select ?parent ?child
+where {
+    values ?type {owl:Class}
+    ?parent rdf:type ?type .
+    optional {
+        ?child rdfs:subClassOf ?parent ;
+               rdf:type ?type .
+    }
+}

--- a/core/sail/nativerdf/src/test/resources/benchmarkFiles/query-without-values.qr
+++ b/core/sail/nativerdf/src/test/resources/benchmarkFiles/query-without-values.qr
@@ -1,0 +1,12 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+
+select ?parent ?child
+where {
+    ?parent rdf:type owl:Class .
+    optional {
+        ?child rdfs:subClassOf ?parent ;
+               rdf:type owl:Class .
+    }
+}


### PR DESCRIPTION



GitHub issue resolved: #4232 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

-  ensure VALUES clause always covers entire group graph pattern. This is the generically correct way to parse VALUES clauses. An optimizer can potentially look at the ordering in the algebra to push the values clause down into the join tree (by inspecting which parts of the tree have variables bound in the VALUES clause).
- adding benchmarks 


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

