### PR TITLE
WIP: Migrate JUnit4 test suites to JUnit5 nested tests

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSPARQLComplianceTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSPARQLComplianceTest.java
@@ -15,15 +15,15 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreFactory;
 import org.eclipse.rdf4j.testsuite.sparql.RepositorySPARQLComplianceTestSuite;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * Test additional SPARQL functionality on LMDB store.
  */
 public class LmdbSPARQLComplianceTest extends RepositorySPARQLComplianceTestSuite {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpFactory() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -34,7 +34,7 @@ public class LmdbSPARQLComplianceTest extends RepositorySPARQLComplianceTestSuit
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownFactory() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySPARQLComplianceTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySPARQLComplianceTest.java
@@ -15,15 +15,15 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.memory.config.MemoryStoreFactory;
 import org.eclipse.rdf4j.testsuite.sparql.RepositorySPARQLComplianceTestSuite;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * @author jeen
  */
 public class MemorySPARQLComplianceTest extends RepositorySPARQLComplianceTestSuite {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpFactory() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -33,7 +33,7 @@ public class MemorySPARQLComplianceTest extends RepositorySPARQLComplianceTestSu
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownFactory() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSPARQLComplianceTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSPARQLComplianceTest.java
@@ -15,15 +15,15 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreFactory;
 import org.eclipse.rdf4j.testsuite.sparql.RepositorySPARQLComplianceTestSuite;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * @author jeen
  */
 public class NativeSPARQLComplianceTest extends RepositorySPARQLComplianceTestSuite {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpFactory() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -34,7 +34,7 @@ public class NativeSPARQLComplianceTest extends RepositorySPARQLComplianceTestSu
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownFactory() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryOptimisticIsolationTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.memory.config.MemoryStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class MemoryOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 		setRepositoryFactory(new SailRepositoryFactory() {
@@ -31,7 +31,7 @@ public class MemoryOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
@@ -19,28 +19,13 @@ import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.config.RepositoryFactory;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.DeadLockTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.DeleteInsertTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.IsolationLevelTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.LinearTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.ModificationTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.MonotonicTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.RemoveIsolationTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.SerializableTest;
-import org.eclipse.rdf4j.testsuite.repository.optimistic.SnapshotTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.jupiter.api.Nested;
 
 /**
  * @author James Leigh
  */
-@RunWith(Suite.class)
-@SuiteClasses({ DeadLockTest.class, DeleteInsertTest.class, LinearTest.class, ModificationTest.class,
-		RemoveIsolationTest.class, IsolationLevelTest.class, MonotonicTest.class, SnapshotTest.class,
-		SerializableTest.class })
 public abstract class OptimisticIsolationTest {
 
 	@BeforeClass
@@ -78,5 +63,41 @@ public abstract class OptimisticIsolationTest {
 			con.clearNamespaces();
 		}
 		return repository;
+	}
+
+	@Nested
+	class DeadLockTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.DeadLockTest {
+	}
+
+	@Nested
+	class DeleteInsertTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.DeleteInsertTest {
+	}
+
+	@Nested
+	class LinearTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.LinearTest {
+	}
+
+	@Nested
+	class ModificationTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.ModificationTest {
+	}
+
+	@Nested
+	class RemoveIsolationTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.RemoveIsolationTest {
+	}
+
+	@Nested
+	class IsolationLevelTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.IsolationLevelTest {
+	}
+
+	@Nested
+	class MonotonicTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.MonotonicTest {
+	}
+
+	@Nested
+	class SnapshotTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.SnapshotTest {
+	}
+
+	@Nested
+	class SerializableTest extends org.eclipse.rdf4j.testsuite.repository.optimistic.SerializableTest {
 	}
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/RepositorySPARQLComplianceTestSuite.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/RepositorySPARQLComplianceTestSuite.java
@@ -20,29 +20,9 @@ import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.config.RepositoryFactory;
-import org.eclipse.rdf4j.testsuite.sparql.tests.AggregateTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.ArbitraryLengthPathTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.BasicTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.BindTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.BuiltinFunctionTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.ConstructTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.DefaultGraphTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.DescribeTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.ExistsTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.GroupByTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.InTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.MinusTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.OptionalTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.OrderByTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.PropertyPathTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.SubselectTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.UnionTest;
-import org.eclipse.rdf4j.testsuite.sparql.tests.ValuesTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 
 /**
  * A suite of custom compliance tests on SPARQL query functionality for RDF4J Repositories.
@@ -52,7 +32,7 @@ import org.junit.runners.Suite.SuiteClasses;
  *
  * <pre>
  * <code>
- * 	&#64;BeforeClass
+ * 	&#64;BeforeAll
 	public static void setUpFactory() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			&#64;Override
@@ -62,7 +42,7 @@ import org.junit.runners.Suite.SuiteClasses;
 		});
 	}
 
-	&#64;AfterClass
+	&#64;AfterAll
 	public static void tearDownFactory() throws Exception {
 		setRepositoryFactory(null);
 	}
@@ -74,19 +54,14 @@ import org.junit.runners.Suite.SuiteClasses;
  *           make further improvements to its setup (including migrating to JUnit 5 when its suite support matures) in
  *           future minor releases.
  */
-@RunWith(Suite.class)
-@SuiteClasses({ AggregateTest.class, ArbitraryLengthPathTest.class, BasicTest.class, BindTest.class,
-		BuiltinFunctionTest.class, ConstructTest.class, DefaultGraphTest.class, DescribeTest.class, GroupByTest.class,
-		InTest.class, OptionalTest.class, PropertyPathTest.class, SubselectTest.class, UnionTest.class,
-		ValuesTest.class, OrderByTest.class, ExistsTest.class, MinusTest.class })
 @Experimental
 public abstract class RepositorySPARQLComplianceTestSuite {
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -116,5 +91,77 @@ public abstract class RepositorySPARQLComplianceTestSuite {
 			con.clearNamespaces();
 		}
 		return repository;
+	}
+
+	@Nested
+	class AggregateTest extends org.eclipse.rdf4j.testsuite.sparql.tests.AggregateTest {
+	}
+
+	@Nested
+	class ArbitraryLengthPathTest extends org.eclipse.rdf4j.testsuite.sparql.tests.ArbitraryLengthPathTest {
+	}
+
+	@Nested
+	class BasicTest extends org.eclipse.rdf4j.testsuite.sparql.tests.BasicTest {
+	}
+
+	@Nested
+	class BindTest extends org.eclipse.rdf4j.testsuite.sparql.tests.BindTest {
+	}
+
+	@Nested
+	class BuiltinFunctionTest extends org.eclipse.rdf4j.testsuite.sparql.tests.BuiltinFunctionTest {
+	}
+
+	@Nested
+	class ConstructTest extends org.eclipse.rdf4j.testsuite.sparql.tests.ConstructTest {
+	}
+
+	@Nested
+	class DefaultGraphTest extends org.eclipse.rdf4j.testsuite.sparql.tests.DefaultGraphTest {
+	}
+
+	@Nested
+	class DescribeTest extends org.eclipse.rdf4j.testsuite.sparql.tests.DescribeTest {
+	}
+
+	@Nested
+	class GroupByTest extends org.eclipse.rdf4j.testsuite.sparql.tests.GroupByTest {
+	}
+
+	@Nested
+	class InTest extends org.eclipse.rdf4j.testsuite.sparql.tests.InTest {
+	}
+
+	@Nested
+	class OptionalTest extends org.eclipse.rdf4j.testsuite.sparql.tests.OptionalTest {
+	}
+
+	@Nested
+	class PropertyPathTest extends org.eclipse.rdf4j.testsuite.sparql.tests.PropertyPathTest {
+	}
+
+	@Nested
+	class SubselectTest extends org.eclipse.rdf4j.testsuite.sparql.tests.SubselectTest {
+	}
+
+	@Nested
+	class UnionTest extends org.eclipse.rdf4j.testsuite.sparql.tests.UnionTest {
+	}
+
+	@Nested
+	class ValuesTest extends org.eclipse.rdf4j.testsuite.sparql.tests.ValuesTest {
+	}
+
+	@Nested
+	class OrderByTest extends org.eclipse.rdf4j.testsuite.sparql.tests.OrderByTest {
+	}
+
+	@Nested
+	class ExistsTest extends org.eclipse.rdf4j.testsuite.sparql.tests.ExistsTest {
+	}
+
+	@Nested
+	class MinusTest extends org.eclipse.rdf4j.testsuite.sparql.tests.MinusTest {
 	}
 }


### PR DESCRIPTION
I have been looking at migrating the JUnit4 test suites to JUnit5, and it is definitely not straightforward. If https://github.com/junit-team/junit5/issues/456 was resolved, that could help, but I am not sure if the JUnit5 test suite concept really is what we want.

This PR suggests migrating these test suites to JUnit5 by replacing the suite declaration with JUnit5 [nested tests](https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested). @abrokenjester @hmottestad WDYT? This can be improved further, but I tried to make minimal changes in the initial migration. I can create a new issue and PR if you think this looks promising. Please let me know.

