### PR TITLE
GH-4622 SHACL Validation Report preserve blank node IDs with remote repositories

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/shacl/RemoteShaclValidationException.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/shacl/RemoteShaclValidationException.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.rdf4j.http.client.shacl;
 
+import java.io.InputStream;
 import java.io.StringReader;
 
 import org.eclipse.rdf4j.common.annotation.Experimental;
@@ -31,6 +32,10 @@ public class RemoteShaclValidationException extends RDF4JException implements Va
 	private final RemoteValidation remoteValidation;
 
 	public RemoteShaclValidationException(StringReader stringReader, String s, RDFFormat format) {
+		remoteValidation = new RemoteValidation(stringReader, s, format);
+	}
+
+	public RemoteShaclValidationException(InputStream stringReader, String s, RDFFormat format) {
 		remoteValidation = new RemoteValidation(stringReader, s, format);
 	}
 

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/shacl/RemoteValidation.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/shacl/RemoteValidation.java
@@ -12,6 +12,7 @@
 package org.eclipse.rdf4j.http.client.shacl;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
 
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
@@ -25,30 +26,29 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
 
 @InternalUseOnly
 class RemoteValidation {
-
-	StringReader stringReader;
-	String baseUri;
-	RDFFormat format;
-
 	Model model;
 
+	RemoteValidation(InputStream inputStream, String baseUri, RDFFormat format) {
+		try {
+			ParserConfig parserConfig = new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
+			model = Rio.parse(inputStream, baseUri, format, parserConfig, SimpleValueFactory.getInstance(),
+					new ParseErrorLogger());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	RemoteValidation(StringReader stringReader, String baseUri, RDFFormat format) {
-		this.stringReader = stringReader;
-		this.baseUri = baseUri;
-		this.format = format;
+		try {
+			ParserConfig parserConfig = new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
+			model = Rio.parse(stringReader, baseUri, format, parserConfig, SimpleValueFactory.getInstance(),
+					new ParseErrorLogger());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	Model asModel() {
-		if (model == null) {
-			try {
-				ParserConfig parserConfig = new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
-				model = Rio.parse(stringReader, baseUri, format, parserConfig, SimpleValueFactory.getInstance(),
-						new ParseErrorLogger());
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
 		return model;
 	}
 

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/shacl/RemoteValidation.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/shacl/RemoteValidation.java
@@ -16,8 +16,12 @@ import java.io.StringReader;
 
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
 
 @InternalUseOnly
 class RemoteValidation {
@@ -37,7 +41,9 @@ class RemoteValidation {
 	Model asModel() {
 		if (model == null) {
 			try {
-				model = Rio.parse(stringReader, baseUri, format);
+				ParserConfig parserConfig = new ParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
+				model = Rio.parse(stringReader, baseUri, format, parserConfig, SimpleValueFactory.getInstance(),
+						new ParseErrorLogger());
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}

--- a/tools/server-spring/pom.xml
+++ b/tools/server-spring/pom.xml
@@ -28,6 +28,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-binary</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ProtocolExceptionResolver.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ProtocolExceptionResolver.java
@@ -78,15 +78,14 @@ public class ProtocolExceptionResolver implements HandlerExceptionResolver {
 
 			StringWriter stringWriter = new StringWriter();
 
-			// We choose NQUADS because we want to support streaming in the future, and because there could be a use for
-			// different graphs in the future
-			Rio.write(validationReportModel, stringWriter, RDFFormat.NQUADS);
+			// We choose RDFJSON because this format doesn't rename blank nodes.
+			Rio.write(validationReportModel, stringWriter, RDFFormat.RDFJSON);
 
 			statusCode = HttpServletResponse.SC_CONFLICT;
 			errMsg = stringWriter.toString();
 
 			Map<String, String> headers = new HashMap<>();
-			headers.put("Content-Type", "application/shacl-validation-report+n-quads");
+			headers.put("Content-Type", "application/shacl-validation-report+rdf+json");
 			model.put(SimpleResponseView.CUSTOM_HEADERS_KEY, headers);
 		}
 

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/ValidationExceptionView.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/ValidationExceptionView.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.statements;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.common.exception.ValidationException;
+import org.eclipse.rdf4j.common.webapp.views.SimpleResponseView;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.springframework.web.servlet.View;
+
+/**
+ * View used to export a ValidationException.
+ *
+ * @author Håvard Ottestad
+ */
+@InternalUseOnly
+public class ValidationExceptionView implements View {
+
+	public static final String FACTORY_KEY = "factory";
+
+	public static final String VALIDATION_EXCEPTION = "validationException";
+
+	private static final ValidationExceptionView INSTANCE = new ValidationExceptionView();
+
+	public static ValidationExceptionView getInstance() {
+		return INSTANCE;
+	}
+
+	private ValidationExceptionView() {
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public void render(Map model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+
+		RDFWriterFactory rdfWriterFactory = (RDFWriterFactory) model.get(FACTORY_KEY);
+
+		RDFFormat rdfFormat = rdfWriterFactory.getRDFFormat();
+
+		try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+			RDFWriter rdfWriter = rdfWriterFactory.getWriter(baos);
+
+			ValidationException validationException = (ValidationException) model.get(VALIDATION_EXCEPTION);
+
+			Model validationReportModel = validationException.validationReportAsModel();
+
+			rdfWriter.startRDF();
+			for (Namespace namespace : validationReportModel.getNamespaces()) {
+				rdfWriter.handleNamespace(namespace.getPrefix(), namespace.getName());
+			}
+			for (Statement statement : validationReportModel) {
+				rdfWriter.handleStatement(statement);
+			}
+			rdfWriter.endRDF();
+
+			try (OutputStream out = response.getOutputStream()) {
+				response.setStatus((int) model.get(SimpleResponseView.SC_KEY));
+
+				String mimeType = rdfFormat.getDefaultMIMEType();
+				if (rdfFormat.hasCharset()) {
+					Charset charset = rdfFormat.getCharset();
+					mimeType += "; charset=" + charset.name();
+				}
+
+				assert mimeType.startsWith("application/");
+				response.setContentType("application/shacl-validation-report+" + mimeType.replace("application/", ""));
+
+				out.write(baos.toByteArray());
+			}
+		}
+	}
+
+}

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ShaclValidationReportIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ShaclValidationReportIT.java
@@ -15,20 +15,30 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.exception.ValidationException;
+import org.eclipse.rdf4j.http.client.shacl.RemoteShaclValidationException;
 import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -65,11 +75,12 @@ public class ShaclValidationReportIT {
 			"ex:PersonShape\n" +
 			"\ta sh:NodeShape  ;\n" +
 			"\tsh:targetClass rdfs:Resource ;\n" +
-			"\tsh:property ex:PersonShapeProperty  .\n" +
+			"\tsh:property _:bnode  .\n" +
 			"\n" +
 			"\n" +
-			"ex:PersonShapeProperty\n" +
+			"_:bnode\n" +
 			"        sh:path rdfs:label ;\n" +
+			"        rdfs:label \"abc\" ;\n" +
 			"        sh:minCount 1 .";
 
 	@Test
@@ -123,6 +134,56 @@ public class ShaclValidationReportIT {
 				fail();
 			} catch (Exception e) {
 				assertExceptionIsShaclReport(e);
+			}
+		}
+
+	}
+
+	@Test
+	public void testBlankNodeIdsPreserved() throws IOException {
+
+		Repository repository = new HTTPRepository(
+				Protocol.getRepositoryLocation(TestServer.SERVER_URL, TestServer.TEST_SHACL_REPO_ID));
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			connection.add(new StringReader(shacl), "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			connection.commit();
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
+			connection.commit();
+		} catch (RepositoryException repositoryException) {
+
+			Model validationReport = ((RemoteShaclValidationException) repositoryException.getCause())
+					.validationReportAsModel();
+
+			BNode shapeBnode = (BNode) validationReport
+					.filter(null, SHACL.SOURCE_SHAPE, null)
+					.objects()
+					.stream()
+					.findAny()
+					.orElseThrow();
+
+			try (RepositoryConnection connection = repository.getConnection()) {
+				List<Statement> collect = connection
+						.getStatements(shapeBnode, null, null, RDF4J.SHACL_SHAPE_GRAPH)
+						.stream()
+						.collect(Collectors.toList());
+
+				Assertions.assertEquals(3, collect.size());
+
+				Value rdfsLabel = collect
+						.stream()
+						.filter(s -> s.getPredicate().equals(RDFS.LABEL))
+						.map(Statement::getObject)
+						.findAny()
+						.orElseThrow();
+
+				Assertions.assertEquals(Values.literal("abc"), rdfsLabel);
+
 			}
 		}
 

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TransactionSettingsIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TransactionSettingsIT.java
@@ -12,26 +12,17 @@ package org.eclipse.rdf4j.http.server;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.io.IOException;
 import java.io.StringReader;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.http.client.shacl.RemoteShaclValidationException;
 import org.eclipse.rdf4j.http.protocol.Protocol;
-import org.eclipse.rdf4j.model.BNode;
-import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -39,7 +30,6 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -238,56 +228,6 @@ public class TransactionSettingsIT {
 
 			}
 
-		}
-
-	}
-
-	@Test
-	public void testBlankNodeIdsPreserved() throws IOException {
-
-		Repository repository = new HTTPRepository(
-				Protocol.getRepositoryLocation(TestServer.SERVER_URL, TestServer.TEST_SHACL_REPO_ID));
-
-		try (RepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.add(new StringReader(shacl), "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
-			connection.commit();
-		}
-
-		try (RepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
-			connection.commit();
-		} catch (RepositoryException repositoryException) {
-
-			Model validationReport = ((RemoteShaclValidationException) repositoryException.getCause())
-					.validationReportAsModel();
-
-			BNode shapeBnode = (BNode) validationReport
-					.filter(null, SHACL.SOURCE_SHAPE, null)
-					.objects()
-					.stream()
-					.findAny()
-					.orElseThrow();
-
-			try (RepositoryConnection connection = repository.getConnection()) {
-				List<Statement> collect = connection
-						.getStatements(shapeBnode, null, null, RDF4J.SHACL_SHAPE_GRAPH)
-						.stream()
-						.collect(Collectors.toList());
-
-				Assertions.assertEquals(3, collect.size());
-
-				Value rdfsLabel = collect
-						.stream()
-						.filter(s -> s.getPredicate().equals(RDFS.LABEL))
-						.map(Statement::getObject)
-						.findAny()
-						.orElseThrow();
-
-				Assertions.assertEquals(Values.literal("abc"), rdfsLabel);
-
-			}
 		}
 
 	}

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TransactionSettingsIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TransactionSettingsIT.java
@@ -12,17 +12,26 @@ package org.eclipse.rdf4j.http.server;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.IOException;
 import java.io.StringReader;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.http.client.shacl.RemoteShaclValidationException;
 import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -30,6 +39,7 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,11 +77,12 @@ public class TransactionSettingsIT {
 			"ex:PersonShape\n" +
 			"\ta sh:NodeShape  ;\n" +
 			"\tsh:targetClass rdfs:Resource ;\n" +
-			"\tsh:property ex:PersonShapeProperty  .\n" +
+			"\tsh:property _:bnode  .\n" +
 			"\n" +
 			"\n" +
-			"ex:PersonShapeProperty\n" +
+			"_:bnode\n" +
 			"        sh:path rdfs:label ;\n" +
+			"        rdfs:label \"abc\" ;\n" +
 			"        sh:minCount 1 .";
 
 	@BeforeEach
@@ -227,6 +238,56 @@ public class TransactionSettingsIT {
 
 			}
 
+		}
+
+	}
+
+	@Test
+	public void testBlankNodeIdsPreserved() throws IOException {
+
+		Repository repository = new HTTPRepository(
+				Protocol.getRepositoryLocation(TestServer.SERVER_URL, TestServer.TEST_SHACL_REPO_ID));
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			connection.add(new StringReader(shacl), "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			connection.commit();
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
+			connection.commit();
+		} catch (RepositoryException repositoryException) {
+
+			Model validationReport = ((RemoteShaclValidationException) repositoryException.getCause())
+					.validationReportAsModel();
+
+			BNode shapeBnode = (BNode) validationReport
+					.filter(null, SHACL.SOURCE_SHAPE, null)
+					.objects()
+					.stream()
+					.findAny()
+					.orElseThrow();
+
+			try (RepositoryConnection connection = repository.getConnection()) {
+				List<Statement> collect = connection
+						.getStatements(shapeBnode, null, null, RDF4J.SHACL_SHAPE_GRAPH)
+						.stream()
+						.collect(Collectors.toList());
+
+				Assertions.assertEquals(3, collect.size());
+
+				Value rdfsLabel = collect
+						.stream()
+						.filter(s -> s.getPredicate().equals(RDFS.LABEL))
+						.map(Statement::getObject)
+						.findAny()
+						.orElseThrow();
+
+				Assertions.assertEquals(Values.literal("abc"), rdfsLabel);
+
+			}
 		}
 
 	}


### PR DESCRIPTION
GitHub issue resolved: #4622 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - switch to RDF4J Binary RDF since this format doesn't rename blank node IDs
 - add parser config option to preserve blank node IDs
 - add test

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

