### PR TITLE
GH-4646 remove intermediate join variables

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
+import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 
@@ -66,6 +67,8 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 	private static final String JOINVAR_PREFIX = "intermediate_join_";
 
+	private final Set<String> namedIntermediateJoins = new HashSet<>();
+
 	public PathIteration(EvaluationStrategy strategy, Scope scope, Var startVar,
 			TupleExpr pathExpression, Var endVar, Var contextVar, long minLength, BindingSet bindings)
 			throws QueryEvaluationException {
@@ -104,10 +107,10 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 			while (currentIter != null && currentIter.hasNext()) {
 				BindingSet potentialNextElement = currentIter.next();
-				MutableBindingSet nextElement;
+				QueryBindingSet nextElement;
 				// if it is not a compatible type of BindingSet
 				if (potentialNextElement instanceof QueryBindingSet) {
-					nextElement = (MutableBindingSet) potentialNextElement;
+					nextElement = (QueryBindingSet) potentialNextElement;
 				} else {
 					nextElement = new QueryBindingSet(potentialNextElement);
 				}
@@ -121,22 +124,10 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 					}
 				}
 
-				Value v1, v2;
+				ValuePair vp = valuePairFromStartAndEnd(nextElement);
 
-				if (startVarFixed && endVarFixed && currentLength > 2) {
-					v1 = getVarValue(startVar, startVarFixed, nextElement);
-					v2 = nextElement.getValue("END_" + JOINVAR_PREFIX + this.hashCode());
-				} else if (startVarFixed && endVarFixed && currentLength == 2) {
-					v1 = getVarValue(startVar, startVarFixed, nextElement);
-					v2 = nextElement.getValue(JOINVAR_PREFIX + (currentLength - 1) + "_" + this.hashCode());
-				} else {
-					v1 = getVarValue(startVar, startVarFixed, nextElement);
-					v2 = getVarValue(endVar, endVarFixed, nextElement);
-				}
+				if (!isCyclicPath(vp)) {
 
-				if (!isCyclicPath(v1, v2)) {
-
-					ValuePair vp = new ValuePair(v1, v2);
 					if (reportedValues.contains(vp)) {
 						// new arbitrary-length path semantics: filter out
 						// duplicates
@@ -151,21 +142,21 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 					if (startVarFixed && endVarFixed) {
 						Value endValue = getVarValue(endVar, endVarFixed, nextElement);
-						if (endValue.equals(v2)) {
+						if (endValue.equals(vp.endValue)) {
 							add(reportedValues, vp);
-							if (!v1.equals(v2)) {
+							if (!vp.startValue.equals(vp.endValue)) {
 								addToQueue(valueQueue, vp);
 							}
 							if (!nextElement.hasBinding(startVar.getName())) {
-								addBinding(nextElement, startVar.getName(), v1);
+								addBinding(nextElement, startVar.getName(), vp.startValue);
 							}
 							if (!nextElement.hasBinding(endVar.getName())) {
-								addBinding(nextElement, endVar.getName(), v2);
+								addBinding(nextElement, endVar.getName(), vp.endValue);
 							}
-							return nextElement;
+							return removeIntermediateJoinVars(nextElement);
 						} else {
 							if (add(unreportedValues, vp)) {
-								if (!v1.equals(v2)) {
+								if (!vp.startValue.equals(vp.endValue)) {
 									addToQueue(valueQueue, vp);
 								}
 							}
@@ -173,16 +164,16 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 						}
 					} else {
 						add(reportedValues, vp);
-						if (!v1.equals(v2)) {
+						if (!vp.startValue.equals(vp.endValue)) {
 							addToQueue(valueQueue, vp);
 						}
 						if (!nextElement.hasBinding(startVar.getName())) {
-							addBinding(nextElement, startVar.getName(), v1);
+							addBinding(nextElement, startVar.getName(), vp.startValue);
 						}
 						if (!nextElement.hasBinding(endVar.getName())) {
-							addBinding(nextElement, endVar.getName(), v2);
+							addBinding(nextElement, endVar.getName(), vp.endValue);
 						}
-						return nextElement;
+						return removeIntermediateJoinVars(nextElement);
 					}
 				} else {
 					continue again;
@@ -196,6 +187,27 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 			valueQueue.clear();
 			return null;
 		}
+	}
+
+	private BindingSet removeIntermediateJoinVars(QueryBindingSet nextElement) {
+		nextElement.removeAll(namedIntermediateJoins);
+		return nextElement;
+	}
+
+	private ValuePair valuePairFromStartAndEnd(MutableBindingSet nextElement) {
+		Value v1, v2;
+
+		if (startVarFixed && endVarFixed && currentLength > 2) {
+			v1 = getVarValue(startVar, startVarFixed, nextElement);
+			v2 = nextElement.getValue("END_" + JOINVAR_PREFIX + this.hashCode());
+		} else if (startVarFixed && endVarFixed && currentLength == 2) {
+			v1 = getVarValue(startVar, startVarFixed, nextElement);
+			v2 = nextElement.getValue(JOINVAR_PREFIX + (currentLength - 1) + "_" + this.hashCode());
+		} else {
+			v1 = getVarValue(startVar, startVarFixed, nextElement);
+			v2 = getVarValue(endVar, endVarFixed, nextElement);
+		}
+		return new ValuePair(v1, v2);
 	}
 
 	private void addBinding(MutableBindingSet bs, String name, Value value) {
@@ -242,12 +254,12 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 		return v;
 	}
 
-	private boolean isCyclicPath(Value v1, Value v2) {
+	private boolean isCyclicPath(ValuePair vp) {
 		if (currentLength <= 2) {
 			return false;
 		}
 
-		return reportedValues.contains(new ValuePair(v1, v2));
+		return reportedValues.contains(vp);
 
 	}
 
@@ -426,9 +438,12 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 	}
 
+	private Var createAnonVar(String varName, Value v, boolean anonymous) {
+		namedIntermediateJoins.add(varName);
+		return new Var(varName, null, anonymous, false);
+	}
+
 	public Var createAnonVar(String varName) {
-		Var var = new Var(varName);
-		var.setAnonymous(true);
-		return var;
+		return createAnonVar(varName, null, true);
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIterationTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIterationTest.java
@@ -110,6 +110,7 @@ public class PathIterationTest {
 		assertEquals(subClass, result.getBinding("subClass").getValue());
 		assertTrue(result.hasBinding("superClass"), "path zlp evaluation should binding for superClass var");
 		assertEquals(superClass, result.getBinding("superClass").getValue());
+		assertEquals(2, result.size());
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #4646 

Briefly describe the changes proposed in this PR:

The PathIteration adds variables to the binding set that are not known ahead of time and not needed after the pathiteration logic is done. These should be stripped out and not propegated.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

