### PR TITLE
GH-4784 interrupt threads using connections when forcefully closing

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DefaultEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DefaultEvaluationStrategy.java
@@ -716,9 +716,18 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 
 			@Override
 			public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(BindingSet bs) {
-				return new DescribeIteration(child.evaluate(bs), DefaultEvaluationStrategy.this,
-						node.getBindingNames(),
-						bs);
+				CloseableIteration<BindingSet, QueryEvaluationException> evaluate = null;
+
+				try {
+					evaluate = child.evaluate(bs);
+					return new DescribeIteration(evaluate, DefaultEvaluationStrategy.this, node.getBindingNames(), bs);
+				} catch (Throwable t) {
+					if (evaluate != null) {
+						evaluate.close();
+					}
+					throw t;
+				}
+
 			}
 		};
 	}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/DescribeIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/DescribeIteration.java
@@ -230,11 +230,11 @@ public class DescribeIteration extends LookAheadIteration<BindingSet, QueryEvalu
 				if (currentDescribeExprIter != null)
 					currentDescribeExprIter.close();
 			} finally {
+				if (sourceIter instanceof CloseableIteration) {
+					((CloseableIteration<?, QueryEvaluationException>) sourceIter).close();
+				}
+			}
 
-			}
-			if (sourceIter instanceof CloseableIteration) {
-				((CloseableIteration<?, QueryEvaluationException>) sourceIter).close();
-			}
 		}
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/DescribeIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/DescribeIteration.java
@@ -220,4 +220,21 @@ public class DescribeIteration extends LookAheadIteration<BindingSet, QueryEvalu
 		return strategy.evaluate(pattern, parentBindings);
 	}
 
+	@Override
+	protected void handleClose() throws QueryEvaluationException {
+		try {
+			super.handleClose();
+
+		} finally {
+			try {
+				if (currentDescribeExprIter != null)
+					currentDescribeExprIter.close();
+			} finally {
+
+			}
+			if (sourceIter instanceof CloseableIteration) {
+				((CloseableIteration<?, QueryEvaluationException>) sourceIter).close();
+			}
+		}
+	}
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -349,11 +349,19 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 			Resource... contexts) throws RepositoryException {
 		Objects.requireNonNull(contexts,
 				"contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");
-
+		CloseableIteration<? extends Statement, SailException> statements = null;
 		try {
-			return createRepositoryResult(sailConnection.getStatements(subj, pred, obj, includeInferred, contexts));
-		} catch (SailException e) {
-			throw new RepositoryException("Unable to get statements from Sail", e);
+			statements = sailConnection.getStatements(subj, pred, obj, includeInferred, contexts);
+			return createRepositoryResult(statements);
+		} catch (Throwable t) {
+			if (statements != null) {
+				statements.close();
+			}
+			if (t instanceof SailException) {
+				throw new RepositoryException("Unable to get statements from Sail", t);
+			} else {
+				throw t;
+			}
 		}
 	}
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -229,13 +229,15 @@ public abstract class AbstractSail implements Sail {
 
 					if (con instanceof AbstractSailConnection) {
 						AbstractSailConnection sailCon = (AbstractSailConnection) con;
-						if (sailCon.getOwner() != Thread.currentThread()) {
-							sailCon.getOwner().interrupt();
-							sailCon.getOwner().join(1000);
-							if (sailCon.getOwner().isAlive()) {
+						Thread owner = sailCon.getOwner();
+						if (owner != Thread.currentThread()) {
+							owner.interrupt();
+							// wait up to 1 second for the owner thread to die
+							owner.join(1000);
+							if (owner.isAlive()) {
 								logger.error(
 										"Closing active connection due to shut down and interrupted the owning thread of the connection {} but thread is still alive after 1000 ms!",
-										sailCon.getOwner());
+										owner);
 							}
 						}
 					}

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -222,6 +222,36 @@ public abstract class AbstractSail implements Sail {
 				activeConnectionsCopy = new IdentityHashMap<>(activeConnections);
 			}
 
+			// Interrupt any threads that are still using a connection, in case they are waiting for a lock
+			for (Map.Entry<SailConnection, Throwable> entry : activeConnectionsCopy.entrySet()) {
+				try {
+					SailConnection con = entry.getKey();
+
+					if (con instanceof AbstractSailConnection) {
+						AbstractSailConnection sailCon = (AbstractSailConnection) con;
+						if (sailCon.getOwner() != Thread.currentThread()) {
+							sailCon.getOwner().interrupt();
+							sailCon.getOwner().join(1000);
+							if (sailCon.getOwner().isAlive()) {
+								logger.error(
+										"Closing active connection due to shut down and interrupted the owning thread of the connection {} but thread is still alive after 1000 ms!",
+										sailCon.getOwner());
+							}
+						}
+					}
+
+				} catch (Throwable e) {
+					if (e instanceof InterruptedException) {
+						throw new SailException(e);
+					} else if (e instanceof AssertionError) {
+						// ignore assertions errors
+					} else if (e instanceof Error) {
+						throw (Error) e;
+					}
+					// ignore all other exceptions
+				}
+			}
+
 			// Forcefully close any connections that are still open
 			for (Map.Entry<SailConnection, Throwable> entry : activeConnectionsCopy.entrySet()) {
 				SailConnection con = entry.getKey();

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.sail.helpers;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -19,6 +20,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -98,15 +100,7 @@ public abstract class AbstractSailConnection implements SailConnection {
 	private boolean isOpen = true;
 	private static final VarHandle IS_OPEN;
 
-	static {
-		try {
-			IS_OPEN = MethodHandles.lookup()
-					.in(AbstractSailConnection.class)
-					.findVarHandle(AbstractSailConnection.class, "isOpen", boolean.class);
-		} catch (ReflectiveOperationException e) {
-			throw new Error(e);
-		}
-	}
+	private Thread owner;
 
 	/**
 	 * Lock used to prevent concurrent calls to update methods like addStatement, clear, commit, etc. within a
@@ -161,6 +155,7 @@ public abstract class AbstractSailConnection implements SailConnection {
 		} else {
 			activeIterationsDebug = Collections.emptyMap();
 		}
+		owner = Thread.currentThread();
 	}
 
 	/*---------*
@@ -252,6 +247,8 @@ public abstract class AbstractSailConnection implements SailConnection {
 
 	@Override
 	public final void close() throws SailException {
+		Thread deadlockPreventionThread = startDeadlockPreventionThread();
+
 		// obtain an exclusive lock so that any further operations on this
 		// connection (including those from any concurrent threads) are blocked.
 		if (!IS_OPEN.compareAndSet(this, true, false)) {
@@ -268,7 +265,7 @@ public abstract class AbstractSailConnection implements SailConnection {
 				if (sumDone == sumBlocking) {
 					break;
 				} else {
-					Thread.onSpinWait();
+					LockSupport.parkNanos(Duration.ofMillis(10).toNanos());
 				}
 			}
 
@@ -297,11 +294,54 @@ public abstract class AbstractSailConnection implements SailConnection {
 				sailBase.connectionClosed(this);
 			}
 		} finally {
-			if (useConnectionLock) {
-				connectionLock.writeLock().unlock();
+			try {
+				if (deadlockPreventionThread != null) {
+					deadlockPreventionThread.interrupt();
+				}
+			} finally {
+				if (useConnectionLock) {
+					connectionLock.writeLock().unlock();
+				}
 			}
+
 		}
 
+	}
+
+	/**
+	 * If the current thread is not the owner, starts a thread to handle potential deadlocks by interrupting the owner.
+	 *
+	 * @return The started deadlock prevention thread or null if the current thread is the owner.
+	 */
+	private Thread startDeadlockPreventionThread() {
+		Thread deadlockPreventionThread = null;
+
+		if (Thread.currentThread() != owner) {
+			if (logger.isInfoEnabled()) {
+				logger.info(
+						"Closing connection from a different thread than the one that opened it. Connections should not be shared between threads. Opened by "
+								+ owner + " closed by " + Thread.currentThread(),
+						new Throwable("Throwable used for stacktrace"));
+			}
+			deadlockPreventionThread = new Thread(() -> {
+				try {
+					Thread.sleep(sailBase.connectionTimeOut / 2);
+
+					owner.interrupt();
+					owner.join(1000);
+					if (owner.isAlive()) {
+						logger.error("Interrupted thread {} but thread is still alive after 1000 ms!", owner);
+					}
+
+				} catch (InterruptedException ignored) {
+				}
+
+			});
+			deadlockPreventionThread.setDaemon(true);
+			deadlockPreventionThread.start();
+
+		}
+		return deadlockPreventionThread;
 	}
 
 	@Override
@@ -877,6 +917,16 @@ public abstract class AbstractSailConnection implements SailConnection {
 	}
 
 	/**
+	 * This is for internal use only. It returns the thread that opened this connection.
+	 *
+	 * @return the thread that opened this connection.
+	 */
+	@InternalUseOnly
+	public Thread getOwner() {
+		return owner;
+	}
+
+	/**
 	 * Registers an iteration as active by wrapping it in a {@link SailBaseIteration} object and adding it to the list
 	 * of active iterations.
 	 */
@@ -959,41 +1009,51 @@ public abstract class AbstractSailConnection implements SailConnection {
 	}
 
 	private void forceCloseActiveOperations() throws SailException {
-		for (int i = 0; i < 10 && isActiveOperation() && !debugEnabled; i++) {
-			System.gc();
-			try {
-				Thread.sleep(1);
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
+		Thread deadlockPreventionThread = startDeadlockPreventionThread();
+		try {
+			for (int i = 0; i < 10 && isActiveOperation() && !debugEnabled; i++) {
+				System.gc();
+				try {
+					Thread.sleep(1);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new SailException(e);
+				}
 			}
-		}
 
-		if (debugEnabled) {
+			if (debugEnabled) {
 
-			var activeIterationsCopy = new IdentityHashMap<>(activeIterationsDebug);
-			activeIterationsDebug.clear();
+				var activeIterationsCopy = new IdentityHashMap<>(activeIterationsDebug);
+				activeIterationsDebug.clear();
 
-			if (!activeIterationsCopy.isEmpty()) {
-				for (var entry : activeIterationsCopy.entrySet()) {
-					try {
-						logger.warn("Unclosed iteration", entry.getValue());
-						entry.getKey().close();
-					} catch (Exception e) {
-						if (e instanceof InterruptedException) {
-							Thread.currentThread().interrupt();
+				if (!activeIterationsCopy.isEmpty()) {
+					for (var entry : activeIterationsCopy.entrySet()) {
+						try {
+							logger.warn("Unclosed iteration", entry.getValue());
+							entry.getKey().close();
+						} catch (Exception e) {
+							if (e instanceof InterruptedException) {
+								Thread.currentThread().interrupt();
+								throw new SailException(e);
+							}
+							logger.warn("Exception occurred while closing unclosed iterations.", e);
 						}
-						logger.warn("Exception occurred while closing unclosed iterations.", e);
 					}
+
+					var entry = activeIterationsCopy.entrySet().stream().findAny().orElseThrow();
+
+					throw new SailException(
+							"Connection closed before all iterations were closed: " + entry.getKey().toString(),
+							entry.getValue());
 				}
 
-				var entry = activeIterationsCopy.entrySet().stream().findAny().orElseThrow();
-
-				throw new SailException(
-						"Connection closed before all iterations were closed: " + entry.getKey().toString(),
-						entry.getValue());
 			}
-
+		} finally {
+			if (deadlockPreventionThread != null) {
+				deadlockPreventionThread.interrupt();
+			}
 		}
+
 	}
 
 	/**
@@ -1136,6 +1196,16 @@ public abstract class AbstractSailConnection implements SailConnection {
 				javaLock.unlock();
 				isActive = false;
 			}
+		}
+	}
+
+	static {
+		try {
+			IS_OPEN = MethodHandles.lookup()
+					.in(AbstractSailConnection.class)
+					.findVarHandle(AbstractSailConnection.class, "isOpen", boolean.class);
+		} catch (ReflectiveOperationException e) {
+			throw new Error(e);
 		}
 	}
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailWrapper.java
@@ -150,4 +150,5 @@ public class SailWrapper implements StackableSail, FederatedServiceResolverClien
 		verifyBaseSailSet();
 		return baseSail.getCollectionFactory();
 	}
+
 }

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/DirectTypeHierarchyInferencerTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/DirectTypeHierarchyInferencerTest.java
@@ -13,14 +13,11 @@ package org.eclipse.rdf4j.sail.inferencer.fc;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.io.StringReader;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.repository.util.RDFLoader;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
@@ -574,7 +574,7 @@ class LmdbSailStore implements SailStore {
 													if (!running.get()) {
 														logger.warn(
 																"LmdbSailStore was closed while active transaction was waiting for the next operation. Forcing a rollback!");
-														opQueue.add(ROLLBACK_TRANSACTION);
+														rollback();
 													} else if (Thread.interrupted()) {
 														throw new InterruptedException();
 													} else {

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.sail.lmdb;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +19,8 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -235,13 +234,21 @@ class LmdbSailStore implements SailStore {
 						}
 					} finally {
 						if (tripleStore != null) {
-							running.set(false);
-							tripleStoreExecutor.shutdown();
-							while (!tripleStoreExecutor.isTerminated()) {
-								tripleStoreExecutor.shutdownNow();
-								LockSupport.parkNanos(Duration.ofMillis(100).toNanos());
+							try {
+								running.set(false);
+								tripleStoreExecutor.shutdown();
+								try {
+									while (!tripleStoreExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+										logger.warn("Waiting for triple store executor to terminate");
+									}
+								} catch (InterruptedException e) {
+									Thread.currentThread().interrupt();
+									throw new SailException(e);
+								}
+							} finally {
+								tripleStore.close();
 							}
-							tripleStore.close();
+
 						}
 					}
 				}
@@ -564,17 +571,28 @@ class LmdbSailStore implements SailStore {
 														op.execute();
 													}
 												} else {
-													if (Thread.interrupted()) {
+													if (!running.get()) {
+														logger.warn(
+																"LmdbSailStore was closed while active transaction was waiting for the next operation. Forcing a rollback!");
+														opQueue.add(ROLLBACK_TRANSACTION);
+													} else if (Thread.interrupted()) {
 														throw new InterruptedException();
+													} else {
+														Thread.yield();
 													}
-													Thread.yield();
 												}
 											}
 
 											// keep thread running for at least 2ms to lock-free wait for the next
 											// transaction
-											long start = System.currentTimeMillis();
+											long start = 0;
 											while (running.get() && !nextTransactionAsync) {
+												if (start == 0) {
+													// System.currentTimeMillis() is expensive, so only call it when we
+													// are sure we need to wait
+													start = System.currentTimeMillis();
+												}
+
 												if (System.currentTimeMillis() - start > 2) {
 													synchronized (storeTxnStarted) {
 														if (!nextTransactionAsync) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -359,9 +359,14 @@ public class ShaclSail extends ShaclSailBaseConfiguration {
 
 			logger.info("Shapes will be persisted in: " + path);
 
-			shapesRepo = new SailRepository(new MemoryStore(new File(path)));
+			MemoryStore sail = new MemoryStore(new File(path));
+			sail.setConnectionTimeOut(1000);
+			shapesRepo = new SailRepository(sail);
+
 		} else {
-			shapesRepo = new SailRepository(new MemoryStore());
+			MemoryStore sail = new MemoryStore();
+			sail.setConnectionTimeOut(1000);
+			shapesRepo = new SailRepository(sail);
 		}
 
 		shapesRepo.init();

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ContextWithShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ContextWithShape.java
@@ -10,17 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.ast;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.DynamicModel;
 import org.eclipse.rdf4j.model.impl.DynamicModelFactory;
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclParsingException.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclParsingException.java
@@ -12,7 +12,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
-import org.eclipse.rdf4j.model.Resource;
 
 /**
  * An exception indicating that something went wrong when parsing the SHACL statements, but without a specific shape

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractConstraintComponent.java
@@ -11,8 +11,6 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 
-import java.util.Objects;
-
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
@@ -12,7 +12,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DisjointConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DisjointConstraintComponent.java
@@ -12,7 +12,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.IRI;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/LanguageInConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/LanguageInConstraintComponent.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/AlternativePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/AlternativePath.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.shacl.ast.paths;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
@@ -14,7 +14,6 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/BackwardChainingShapeSource.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/BackwardChainingShapeSource.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.wrapper.shape;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -22,13 +20,9 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Statements;
 import org.eclipse.rdf4j.model.vocabulary.DASH;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.SailConnection;
-import org.eclipse.rdf4j.sail.shacl.ast.ShaclParsingException;
-import org.eclipse.rdf4j.sail.shacl.ast.ShaclShapeParsingException;
 
 public class BackwardChainingShapeSource implements ShapeSource {
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/Rdf4jShaclShapeGraphShapeSource.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/Rdf4jShaclShapeGraphShapeSource.java
@@ -15,7 +15,6 @@ import static org.eclipse.rdf4j.model.util.Values.iri;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclPropertiesCastingTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclPropertiesCastingTest.java
@@ -18,7 +18,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.stream.Stream;
 
-import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.sail.shacl.wrapper.shape.ShapeSource;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailConcurrencyTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailConcurrencyTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sail;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -323,15 +324,15 @@ public abstract class SailConcurrencyTest {
 			}
 		}
 
-		CountDownLatch countDownLatch = new CountDownLatch(1);
-		Thread thread = new Thread(() -> {
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		Thread thread1 = new Thread(() -> {
 			SailConnection connection = store.getConnection();
-			countDownLatch.countDown();
+			countDownLatch1.countDown();
 			connection.begin(IsolationLevels.NONE);
 			connection.addStatement(RDF.FIRST, RDF.TYPE, RDF.PROPERTY);
 		});
-		thread.setName("Thread 1");
-		thread.start();
+		thread1.setName("Thread 1");
+		thread1.start();
 
 		CountDownLatch countDownLatch2 = new CountDownLatch(1);
 		Thread thread2 = new Thread(() -> {
@@ -344,12 +345,65 @@ public abstract class SailConcurrencyTest {
 		thread2.setName("Thread 2");
 		thread2.start();
 
-		countDownLatch.await();
+		countDownLatch1.await();
 		countDownLatch2.await();
 
-		Thread.sleep(1000);
+		while (thread1.isAlive() && thread2.isAlive()) {
+			Thread.yield();
+		}
 
 		store.shutDown();
+
+	}
+
+	@Test
+	public void testConcurrentConnectionsShutdownReadCommitted() throws InterruptedException {
+		if (store instanceof AbstractSail) {
+			((AbstractSail) store).setConnectionTimeOut(200);
+		} else if (store instanceof SailWrapper) {
+			Sail baseSail = ((SailWrapper) store).getBaseSail();
+			if (baseSail instanceof AbstractSail) {
+				((AbstractSail) baseSail).setConnectionTimeOut(200);
+			}
+		}
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		Thread thread1 = new Thread(() -> {
+			SailConnection connection = store.getConnection();
+			countDownLatch1.countDown();
+			connection.begin(IsolationLevels.READ_COMMITTED);
+			connection.addStatement(RDF.FIRST, RDF.TYPE, RDF.PROPERTY);
+		});
+		thread1.setName("Thread 1");
+		thread1.start();
+
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+		Thread thread2 = new Thread(() -> {
+			SailConnection connection = store.getConnection();
+			countDownLatch2.countDown();
+			connection.begin(IsolationLevels.READ_COMMITTED);
+			connection.addStatement(RDF.REST, RDF.TYPE, RDF.PROPERTY);
+
+		});
+		thread2.setName("Thread 2");
+		thread2.start();
+
+		countDownLatch1.await();
+		countDownLatch2.await();
+
+		while (thread1.isAlive() && thread2.isAlive()) {
+			Thread.yield();
+		}
+		store.shutDown();
+
+		store.init();
+
+		try (SailConnection connection = store.getConnection()) {
+			connection.begin();
+			long size = connection.size();
+			assertEquals(0, size);
+			connection.commit();
+		}
 
 	}
 
@@ -368,15 +422,15 @@ public abstract class SailConcurrencyTest {
 		AtomicReference<SailConnection> connection1 = new AtomicReference<>();
 		AtomicReference<SailConnection> connection2 = new AtomicReference<>();
 
-		CountDownLatch countDownLatch = new CountDownLatch(1);
-		Thread thread = new Thread(() -> {
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		Thread thread1 = new Thread(() -> {
 			connection1.set(store.getConnection());
-			countDownLatch.countDown();
+			countDownLatch1.countDown();
 			connection1.get().begin(IsolationLevels.NONE);
 			connection1.get().clear();
 		});
-		thread.setName("Thread 1");
-		thread.start();
+		thread1.setName("Thread 1");
+		thread1.start();
 
 		CountDownLatch countDownLatch2 = new CountDownLatch(1);
 		Thread thread2 = new Thread(() -> {
@@ -389,16 +443,12 @@ public abstract class SailConcurrencyTest {
 		thread2.setName("Thread 2");
 		thread2.start();
 
-		countDownLatch.await();
+		countDownLatch1.await();
 		countDownLatch2.await();
 
-		Thread.sleep(1000);
-
-		Thread thread3 = new Thread(() -> {
-
-		});
-		thread3.setName("Thread 3");
-		thread3.start();
+		while (thread1.isAlive() && thread2.isAlive()) {
+			Thread.yield();
+		}
 
 		try {
 			if (thread2.isAlive()) {
@@ -409,6 +459,77 @@ public abstract class SailConcurrencyTest {
 				connection2.get().close();
 			}
 		} catch (SailException ignored) {
+		}
+
+		try (SailConnection connection = store.getConnection()) {
+			connection.begin();
+			long size = connection.size();
+			connection.commit();
+			assertThat(size).isLessThanOrEqualTo(1);
+		}
+
+		store.shutDown();
+	}
+
+	@Test
+	public void testConcurrentConnectionsShutdownAndCloseRollback() throws InterruptedException {
+		if (store instanceof AbstractSail) {
+			((AbstractSail) store).setConnectionTimeOut(200);
+		}
+
+		try (SailConnection connection = store.getConnection()) {
+			connection.begin();
+			connection.addStatement(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+			connection.commit();
+		}
+
+		AtomicReference<SailConnection> connection1 = new AtomicReference<>();
+		AtomicReference<SailConnection> connection2 = new AtomicReference<>();
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		Thread thread1 = new Thread(() -> {
+			connection1.set(store.getConnection());
+			countDownLatch1.countDown();
+			connection1.get().begin(IsolationLevels.READ_UNCOMMITTED);
+			connection1.get().clear();
+		});
+		thread1.setName("Thread 1");
+		thread1.start();
+
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+		Thread thread2 = new Thread(() -> {
+			connection2.set(store.getConnection());
+			countDownLatch2.countDown();
+			connection2.get().begin(IsolationLevels.READ_UNCOMMITTED);
+			connection2.get().clear();
+
+		});
+		thread2.setName("Thread 2");
+		thread2.start();
+
+		countDownLatch1.await();
+		countDownLatch2.await();
+
+		while (thread1.isAlive() && thread2.isAlive()) {
+			Thread.yield();
+		}
+
+		try {
+			if (thread2.isAlive()) {
+				connection2.get().close();
+				connection1.get().close();
+			} else {
+				connection1.get().close();
+				connection2.get().close();
+			}
+		} catch (SailException ignored) {
+		}
+
+		try (SailConnection connection = store.getConnection()) {
+			connection.begin();
+			long size = connection.size();
+			connection.commit();
+			assertThat(size).isEqualTo(1);
 		}
 
 		store.shutDown();

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailConcurrencyTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailConcurrencyTest.java
@@ -17,15 +17,20 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.helpers.AbstractSail;
+import org.eclipse.rdf4j.sail.helpers.SailWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -305,6 +310,108 @@ public abstract class SailConcurrencyTest {
 		} else {
 			logger.info("Test succeeded");
 		}
+	}
+
+	@Test
+	public void testConcurrentConnectionsShutdown() throws InterruptedException {
+		if (store instanceof AbstractSail) {
+			((AbstractSail) store).setConnectionTimeOut(200);
+		} else if (store instanceof SailWrapper) {
+			Sail baseSail = ((SailWrapper) store).getBaseSail();
+			if (baseSail instanceof AbstractSail) {
+				((AbstractSail) baseSail).setConnectionTimeOut(200);
+			}
+		}
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		Thread thread = new Thread(() -> {
+			SailConnection connection = store.getConnection();
+			countDownLatch.countDown();
+			connection.begin(IsolationLevels.NONE);
+			connection.addStatement(RDF.FIRST, RDF.TYPE, RDF.PROPERTY);
+		});
+		thread.setName("Thread 1");
+		thread.start();
+
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+		Thread thread2 = new Thread(() -> {
+			SailConnection connection = store.getConnection();
+			countDownLatch2.countDown();
+			connection.begin(IsolationLevels.NONE);
+			connection.addStatement(RDF.REST, RDF.TYPE, RDF.PROPERTY);
+
+		});
+		thread2.setName("Thread 2");
+		thread2.start();
+
+		countDownLatch.await();
+		countDownLatch2.await();
+
+		Thread.sleep(1000);
+
+		store.shutDown();
+
+	}
+
+	@Test
+	public void testConcurrentConnectionsShutdownAndClose() throws InterruptedException {
+		if (store instanceof AbstractSail) {
+			((AbstractSail) store).setConnectionTimeOut(200);
+		}
+
+		try (SailConnection connection = store.getConnection()) {
+			connection.begin();
+			connection.addStatement(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+			connection.commit();
+		}
+
+		AtomicReference<SailConnection> connection1 = new AtomicReference<>();
+		AtomicReference<SailConnection> connection2 = new AtomicReference<>();
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		Thread thread = new Thread(() -> {
+			connection1.set(store.getConnection());
+			countDownLatch.countDown();
+			connection1.get().begin(IsolationLevels.NONE);
+			connection1.get().clear();
+		});
+		thread.setName("Thread 1");
+		thread.start();
+
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+		Thread thread2 = new Thread(() -> {
+			connection2.set(store.getConnection());
+			countDownLatch2.countDown();
+			connection2.get().begin(IsolationLevels.NONE);
+			connection2.get().clear();
+
+		});
+		thread2.setName("Thread 2");
+		thread2.start();
+
+		countDownLatch.await();
+		countDownLatch2.await();
+
+		Thread.sleep(1000);
+
+		Thread thread3 = new Thread(() -> {
+
+		});
+		thread3.setName("Thread 3");
+		thread3.start();
+
+		try {
+			if (thread2.isAlive()) {
+				connection2.get().close();
+				connection1.get().close();
+			} else {
+				connection1.get().close();
+				connection2.get().close();
+			}
+		} catch (SailException ignored) {
+		}
+
+		store.shutDown();
 	}
 
 	protected synchronized void fail(String message, Throwable t) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -872,10 +872,19 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 			throw new FedXRuntimeException(
 					"Expected a FedXDescribeOperator Node. Found " + operator.getClass() + " instead.");
 		}
-		CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluate(operator.getArg(), bindings);
-		// Note: we need to evaluate the DESCRIBE over the entire federation
-		return new FederatedDescribeIteration(iter, this, operator.getBindingNames(), bindings,
-				((FederatedDescribeOperator) operator).getQueryInfo());
+		CloseableIteration<BindingSet, QueryEvaluationException> iter = null;
+		try {
+			iter = evaluate(operator.getArg(), bindings);
+			// Note: we need to evaluate the DESCRIBE over the entire federation
+			return new FederatedDescribeIteration(iter, this, operator.getBindingNames(), bindings,
+					((FederatedDescribeOperator) operator).getQueryInfo());
+		} catch (Throwable t) {
+			if (iter != null) {
+				iter.close();
+			}
+			throw t;
+		}
+
 	}
 
 	protected CloseableIteration<BindingSet, QueryEvaluationException> evaluateAtStatementSources(Object preparedQuery,


### PR DESCRIPTION
GitHub issue resolved: #4784 #4790 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

This is mainly an issue with the MemoryStore, but has been detected when using the ShaclSail since it uses memory stores for tracking the changes in a transaction.

When one connection holds the MemorySailStore `txnLockManager` then another thread can get stuck waiting for the same lock if both threads are forcefully closed. Two issues are causing this, the first is that the `txnLockManager` can't be forcefully unlocked by another thread, the second is that the `txnLockManager` is being locked without support for interruptions.

The fix is to track the owner thread of the connection and interrupt that thread. Since connections shouldn't be shared between threads we can assume that the thread that created the connection is the owner.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

