### PR TITLE
GH-4802: Fix setting isolation level in SailRepositoryConnection

### DIFF
--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -167,6 +167,7 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 
 	@Override
 	public void begin(IsolationLevel level) throws RepositoryException {
+		super.begin(level);
 		try {
 			// always call receiveTransactionSettings(...) before calling begin();
 			sailConnection.setTransactionSettings(new TransactionSetting[0]);

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -20,6 +21,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.query.BooleanQuery;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.Query;
@@ -146,6 +148,13 @@ public class SailRepositoryConnectionTest {
 		query.evaluate();
 		// check that the TupleExpr implementation created by the underlying sail was passed to the evaluation
 		verify(sailConnection).evaluate(eq(expr), any(), any(), anyBoolean());
+	}
+
+	@Test
+	public void testIsolationLevelIsSet() throws Exception {
+		IsolationLevels isolationLevel = IsolationLevels.SERIALIZABLE;
+		subject.begin(isolationLevel);
+		assertThat(subject.getIsolationLevel()).isEqualTo(isolationLevel);
 	}
 
 }


### PR DESCRIPTION
GitHub issue resolved: #4802 
Briefly describe the changes proposed in this PR:

Calling super method of `AbstractRepositoryConnection` sets the isolation level for the `SailRepositoryConnection`.

I am not sure if this is solved correct. I am pretty new to the RDF4J world.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

