### PR TITLE
GH-4815 retrieve the variable names from BindingSetAssignment nodes when making the list of names to include in the ArrayBindingSet

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ArrayBindingBasedQueryEvaluationContext.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ArrayBindingBasedQueryEvaluationContext.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MutableBindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.ExtensionElem;
 import org.eclipse.rdf4j.query.algebra.Group;
 import org.eclipse.rdf4j.query.algebra.MultiProjection;
@@ -308,6 +309,19 @@ public final class ArrayBindingBasedQueryEvaluationContext implements QueryEvalu
 			}
 
 			@Override
+			public void meet(BindingSetAssignment node) throws QueryEvaluationException {
+				Set<String> bindingNames = node.getBindingNames();
+
+				Set<String> collect = bindingNames.stream()
+						.map(varName -> varNames.computeIfAbsent(varName, k -> k))
+						.collect(Collectors.toSet());
+
+				node.setBindingNames(collect);
+
+				super.meet(node);
+			}
+
+			@Override
 			public void meet(Group node) throws QueryEvaluationException {
 				List<String> collect = node.getGroupBindingNames()
 						.stream()
@@ -316,6 +330,7 @@ public final class ArrayBindingBasedQueryEvaluationContext implements QueryEvalu
 				node.setGroupBindingNames(collect);
 				super.meet(node);
 			}
+
 		};
 		node.visit(queryModelVisitorBase);
 		return varNames.keySet().toArray(new String[0]);

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ValuesTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ValuesTest.java
@@ -33,6 +33,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.junit.Test;
@@ -41,7 +42,6 @@ import org.junit.Test;
  * Tests on SPARQL VALUES clauses.
  *
  * @author Jeen Broekstra
- *
  */
 public class ValuesTest extends AbstractComplianceTest {
 
@@ -204,4 +204,21 @@ public class ValuesTest extends AbstractComplianceTest {
 		assertEquals("single result expected", 1, result.size());
 		assertEquals("http://subj1", result.get(0).getValue("s").stringValue());
 	}
+
+	@Test
+	public void testMultipleValuesClauses() {
+		Update update = conn.prepareUpdate("PREFIX ex: <http://example.org/>\n" +
+				"\n" +
+				"INSERT DATA { ex:sub ex:somePred \"value\" . };\n" +
+				"\n" +
+				"INSERT { ?s ?newPred ?newObj }\n" +
+				"WHERE {\n" +
+				"  # If one combines these into a single VALUES clause then it also works\n" +
+				"  VALUES ?newPred { ex:somePred2 }\n" +
+				"  VALUES ?newObj { \"value2\" }\n" +
+				"  ?s ex:somePred [] .\n" +
+				"}");
+		update.execute();
+	}
+
 }


### PR DESCRIPTION
GitHub issue resolved: #4815 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

