### PR TITLE
GH-4817 LMDB: Make close method of LmdbRecordIterator thread-safe.

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -54,7 +54,7 @@ class LmdbRecordIterator implements RecordIterator {
 
 	private final int dbi;
 
-	private boolean closed = false;
+	private volatile boolean closed = false;
 
 	private final MDBVal keyData;
 
@@ -71,6 +71,8 @@ class LmdbRecordIterator implements RecordIterator {
 	private boolean fetchNext = false;
 
 	private final StampedLock txnLock;
+
+	private final Thread ownerThread = Thread.currentThread();
 
 	LmdbRecordIterator(Pool pool, TripleIndex index, boolean rangeSearch, long subj, long pred, long obj,
 			long context, boolean explicit, Txn txnRef) throws IOException {
@@ -140,7 +142,7 @@ class LmdbRecordIterator implements RecordIterator {
 						lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
 					}
 					if (lastResult != 0) {
-						close();
+						closeInternal(false);
 						return null;
 					}
 				}
@@ -177,30 +179,45 @@ class LmdbRecordIterator implements RecordIterator {
 					return quad;
 				}
 			}
-			close();
+			closeInternal(false);
 			return null;
 		} finally {
 			txnLock.unlockRead(stamp);
 		}
 	}
 
-	@Override
-	public void close() throws IOException {
+	private void closeInternal(boolean maybeCalledAsync) {
 		if (!closed) {
+			long stamp;
+			if (maybeCalledAsync && ownerThread != Thread.currentThread()) {
+				stamp = txnLock.writeLock();
+			} else {
+				stamp = 0;
+			}
 			try {
-				mdb_cursor_close(cursor);
-				pool.free(keyData);
-				pool.free(valueData);
-				if (minKeyBuf != null) {
-					pool.free(minKeyBuf);
-				}
-				if (maxKey != null) {
-					pool.free(maxKeyBuf);
-					pool.free(maxKey);
+				if (!closed) {
+					mdb_cursor_close(cursor);
+					pool.free(keyData);
+					pool.free(valueData);
+					if (minKeyBuf != null) {
+						pool.free(minKeyBuf);
+					}
+					if (maxKey != null) {
+						pool.free(maxKeyBuf);
+						pool.free(maxKey);
+					}
 				}
 			} finally {
 				closed = true;
+				if (stamp != 0) {
+					txnLock.unlockWrite(stamp);
+				}
 			}
 		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		closeInternal(true);
 	}
 }


### PR DESCRIPTION
Ensures that a lock is used if close() is called asynchronously from another thread than next().

GitHub issue resolved: #4817 

Briefly describe the changes proposed in this PR:

Ensures that close method does not interfere next if called asynchronously from another thread. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

