### PR TITLE
GH-4826: Fix StackOverflow in ContextAwareConnection

### DIFF
--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/ContextAwareConnection.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/ContextAwareConnection.java
@@ -327,7 +327,8 @@ public class ContextAwareConnection extends RepositoryConnectionWrapper {
 			throws RepositoryException, E {
 		final IRI insertContext = getInsertContext();
 		if (isNilContext(contexts)) {
-			super.add(new ConvertingIteration<Statement, Statement, E>(statementIter) {
+			super.add((Iteration<? extends Statement, E>) new ConvertingIteration<Statement, Statement, E>(
+					statementIter) {
 
 				@Override
 				protected Statement convert(Statement st) {


### PR DESCRIPTION
GitHub issue resolved: #4826 

Briefly describe the changes proposed in this PR:

Cast `ConvertingIteration` to `Iteration` so calling `super.add(...)` does not end in a StackOverflowError.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

