### PR TITLE
GH-4811 process also optional TEs when handling BIND

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
@@ -103,6 +103,7 @@ public class GraphPattern {
 	 */
 	void clearRequiredTEs() {
 		requiredTEs.clear();
+		optionalTEs.clear();
 	}
 
 	public void addRequiredSP(Var subjVar, Var predVar, Var objVar) {
@@ -173,6 +174,18 @@ public class GraphPattern {
 	public TupleExpr buildTupleExpr() {
 		TupleExpr result = buildJoinFromRequiredTEs();
 
+		result = buildOptionalTE(result);
+
+		for (ValueExpr constraint : constraints) {
+			result = new Filter(result, constraint);
+		}
+		return result;
+	}
+
+	/**
+	 * Build optionals to the supplied TE
+	 */
+	public TupleExpr buildOptionalTE(TupleExpr result) {
 		for (Map.Entry<TupleExpr, List<ValueExpr>> entry : optionalTEs) {
 			List<ValueExpr> constraints = entry.getValue();
 			if (constraints != null && !constraints.isEmpty()) {
@@ -186,11 +199,6 @@ public class GraphPattern {
 				result = new LeftJoin(result, entry.getKey());
 			}
 		}
-
-		for (ValueExpr constraint : constraints) {
-			result = new Filter(result, constraint);
-		}
-
 		return result;
 	}
 

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -2378,6 +2378,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		// get a tupleExpr that represents the basic graph pattern, sofar.
 		TupleExpr arg = graphPattern.buildJoinFromRequiredTEs();
+		// apply optionals, if any
+		arg = graphPattern.buildOptionalTE(arg);
 
 		// check if alias is not previously used in the BGP
 		if (arg.getBindingNames().contains(alias)) {

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilderTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilderTest.java
@@ -266,6 +266,41 @@ public class TupleExprBuilderTest {
 
 	}
 
+	@Test
+	public void testOtionalBindCoalesce() throws Exception {
+		StringBuilder qb = new StringBuilder();
+		qb.append("SELECT ?result \n");
+		qb.append("WHERE { \n");
+		qb.append("OPTIONAL {\n" +
+				"        OPTIONAL {\n" +
+				"            BIND(\"value\" AS ?foo)\n" +
+				"        }\n" +
+				"        BIND(COALESCE(?foo, \"no value\") AS ?result)\n" +
+				"    }");
+		qb.append(" } ");
+
+		ASTQueryContainer qc = SyntaxTreeBuilder.parseQuery(qb.toString());
+		TupleExpr result = builder.visit(qc, null);
+		String expected = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"result\"\n" +
+				"   LeftJoin\n" +
+				"      SingletonSet\n" +
+				"      Extension\n" +
+				"         LeftJoin\n" +
+				"            SingletonSet\n" +
+				"            Extension\n" +
+				"               SingletonSet\n" +
+				"               ExtensionElem (foo)\n" +
+				"                  ValueConstant (value=\"value\")\n" +
+				"         ExtensionElem (result)\n" +
+				"            Coalesce\n" +
+				"               Var (name=foo)\n" +
+				"               ValueConstant (value=\"no value\")\n";
+		assertEquals(expected.replace("\r\n", "\n"), result.toString().replace("\r\n", "\n"));
+//		System.out.println(result);
+	}
+
 	private class ServiceNodeFinder extends AbstractASTVisitor {
 
 		private final List<String> graphPatterns = new ArrayList<>();


### PR DESCRIPTION
GitHub issue resolved: #4811 

Briefly describe the changes proposed in this PR:

Process also optional TEs when handling BIND, Added a test case.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

