### PR TITLE
GH-4831 Elasticsearch store created by unit test uses max 1gb heap

### DIFF
--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -193,7 +193,7 @@
 					<httpPort>9200</httpPort>
 					<environmentVariables>
 						<ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
-						<ES_JAVA_OPTS>${java.sec.mgr}</ES_JAVA_OPTS>
+						<ES_JAVA_OPTS>${java.sec.mgr} -Xmx1g</ES_JAVA_OPTS>
 					</environmentVariables>
 					<instanceCount>1</instanceCount>
 					<instanceSettings>


### PR DESCRIPTION
GitHub issue resolved: #4831 
Briefly describe the changes proposed in this PR:

Just limit the heap size of the java process for the elastic search tests to 1gb.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

