### PR TITLE
GH-4833: Copy triple structures to avoid infinite loops

### DIFF
--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalProcessor.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalProcessor.java
@@ -10,13 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.jsonld;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -127,7 +121,16 @@ public class JSONLDHierarchicalProcessor {
 								if (graph.containsKey(objectsPredId) && !currentNode.get(ID).equals(objectsPredId)
 										&& !currentTreeNode.hasPassedThrough(objectsPredId)) {
 									children.add(objectsPredId);
-									objectsPredSubjPairs.set(i, (Map<String, Object>) graph.get(objectsPredId));
+									Map<String, Object> tuples = (Map<String, Object>) graph.get(objectsPredId);
+									Map<String, Object> copiedTuples = tuples.entrySet().stream().map(tuple -> {
+										Map.Entry<String, Object> entry = new AbstractMap.SimpleEntry<>(tuple);
+										if (tuple.getValue() instanceof List) {
+											List<Object> copy = new ArrayList<>((Collection<?>) tuple.getValue());
+											entry.setValue(copy);
+										}
+										return entry;
+									}).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+									objectsPredSubjPairs.set(i, copiedTuples);
 									frontier.add(new TreeNode(objectsPredSubjPairs.get(i), currentTreeNode));
 								}
 							}

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
@@ -299,6 +299,35 @@ public class JSONLDHierarchicalWriterTest {
 		verifyOutput();
 	}
 
+	/**
+	 *
+	 * @throws IOException
+	 * @see <a href="https://github.com/eclipse-rdf4j/rdf4j/issues/4833s">GH-4833</a>
+	 */
+	@Test
+	public void testMultipleLoops() throws IOException {
+		addStatement(vf.createIRI("sch:node1"), vf.createIRI("sch:pred1"), vf.createIRI("sch:node2"));
+
+		addStatement(vf.createIRI("sch:node2"), vf.createIRI("sch:pred2"), vf.createIRI("sch:node3"));
+		addStatement(vf.createIRI("sch:node2"), vf.createIRI("sch:pred2"), vf.createIRI("sch:node4"));
+		addStatement(vf.createIRI("sch:node2"), vf.createIRI("sch:pred2"), vf.createIRI("sch:node5"));
+
+		addStatement(vf.createIRI("sch:node2"), vf.createIRI("sch:pred3"), vf.createIRI("sch:node1"));
+
+		addStatement(vf.createIRI("sch:node3"), vf.createIRI("sch:pred4"), vf.createIRI("sch:node2"));
+		addStatement(vf.createIRI("sch:node3"), vf.createIRI("sch:pred5"), vf.createIRI("sch:node6"));
+
+		addStatement(vf.createIRI("sch:node4"), vf.createIRI("sch:pred4"), vf.createIRI("sch:node2"));
+
+		addStatement(vf.createIRI("sch:node5"), vf.createIRI("sch:pred4"), vf.createIRI("sch:node2"));
+		addStatement(vf.createIRI("sch:node5"), vf.createIRI("sch:pred5"), vf.createIRI("sch:node6"));
+
+		addStatement(vf.createIRI("sch:node6"), vf.createIRI("sch:pred6"), vf.createIRI("sch:node3"));
+
+		verifyOutput();
+
+	}
+
 	private void addStatement(Resource subject, IRI predicate, Value object, Resource context) {
 		model.add(vf.createStatement(subject, predicate, object, context));
 	}

--- a/core/rio/jsonld/src/test/resources/serialized/testMultipleLoops.json
+++ b/core/rio/jsonld/src/test/resources/serialized/testMultipleLoops.json
@@ -1,0 +1,43 @@
+[ {
+  "@id" : "sch:node2",
+  "sch:pred2" : [ {
+    "@id" : "sch:node3",
+    "sch:pred4" : [ {
+      "@id" : "sch:node2"
+    } ],
+    "sch:pred5" : [ {
+      "@id" : "sch:node6",
+      "sch:pred6" : [ {
+        "@id" : "sch:node3"
+      } ]
+    } ]
+  }, {
+    "@id" : "sch:node4",
+    "sch:pred4" : [ {
+      "@id" : "sch:node2"
+    } ]
+  }, {
+    "@id" : "sch:node5",
+    "sch:pred4" : [ {
+      "@id" : "sch:node2"
+    } ],
+    "sch:pred5" : [ {
+      "@id" : "sch:node6",
+      "sch:pred6" : [ {
+        "@id" : "sch:node3",
+        "sch:pred4" : [ {
+          "@id" : "sch:node2"
+        } ],
+        "sch:pred5" : [ {
+          "@id" : "sch:node6"
+        } ]
+      } ]
+    } ]
+  } ],
+  "sch:pred3" : [ {
+    "@id" : "sch:node1",
+    "sch:pred1" : [ {
+      "@id" : "sch:node2"
+    } ]
+  } ]
+} ]


### PR DESCRIPTION
The current implementation of the algorithm for the hierachical JSON-LD output changes references of the triples stored in `List`s and keeps adding these references to the output. This can leed to infinite loops when traversing the result. Making copies of the contained lists avoids this.


GitHub issue resolved: #4833 


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

