### PR TITLE
GH-4847 ArrayBindingSetIterator should not advance on hasNext, also a…

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSet.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSet.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -346,12 +347,16 @@ public class ArrayBindingSet extends AbstractBindingSet implements MutableBindin
 				}
 			}
 
-			String name = bindingNames[index];
-			Value value = values[index++];
-			if (value != null) {
-				return new SimpleBinding(name, value);
-			} else {
-				return null;
+			try {
+				String name = bindingNames[index];
+				Value value = values[index++];
+				if (value != null) {
+					return new SimpleBinding(name, value);
+				} else {
+					return null;
+				}
+			} catch (ArrayIndexOutOfBoundsException e) {
+				throw new NoSuchElementException();
 			}
 		}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSet.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSet.java
@@ -331,8 +331,9 @@ public class ArrayBindingSet extends AbstractBindingSet implements MutableBindin
 
 		@Override
 		public boolean hasNext() {
-			for (int at = index; at < values.length; at++) {
-				if (whichBindingsHaveBeenSet[at] && values[at] != null) {
+			// If the current index is at at a set value then this wont advance again.
+			for (; index < values.length; index++) {
+				if (whichBindingsHaveBeenSet[index] && values[index] != null) {
 					return true;
 				}
 			}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSetTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSetTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
@@ -10,13 +10,19 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,4 +83,82 @@ public class ArrayBindingSetTest {
 		assertEquals(bs1.hashCode(), bs2.hashCode());
 	}
 
+	@Test
+	public void testEmptyIterator() {
+
+		ArrayBindingSet bs = new ArrayBindingSet("foo");
+		Iterator<Binding> iterator = bs.iterator();
+		assertNotNull(iterator);
+		assertFalse(iterator.hasNext());
+	}
+
+	@Test
+	public void testOneElementIterator() {
+		ArrayBindingSet bs = new ArrayBindingSet("foo");
+		bs.setBinding("foo", RDF.FIRST);
+		Iterator<Binding> iterator = bs.iterator();
+		assertNotNull(iterator);
+		assertTrue(iterator.hasNext());
+		assertTrue(iterator.hasNext());
+		assertTrue(iterator.hasNext());
+		assertNotNull(iterator.next());
+		assertFalse(iterator.hasNext());
+		try {
+			iterator.next();
+			fail("There are no more elements");
+		} catch (NoSuchElementException e) {
+			assertNotNull(e);
+		}
+	}
+
+	@Test
+	public void testThreeElementIterator() {
+		ArrayBindingSet bs = new ArrayBindingSet("first", "alt", "bag");
+		bs.setBinding("first", RDF.FIRST);
+		bs.setBinding("alt", RDF.ALT);
+		bs.setBinding("bag", RDF.BAG);
+		Iterator<Binding> iterator = bs.iterator();
+		assertNotNull(iterator);
+		assertTrue(iterator.hasNext());
+		Binding first = iterator.next();
+		assertNotNull(first);
+		assertTrue(iterator.hasNext());
+		Binding alt = iterator.next();
+		assertNotNull(alt);
+		assertEquals("alt", alt.getName());
+		assertTrue(iterator.hasNext());
+		Binding bag = iterator.next();
+		assertNotNull(bag);
+		assertEquals("bag", bag.getName());
+		assertFalse(iterator.hasNext());
+		try {
+			iterator.next();
+			fail("There are no more elements");
+		} catch (NoSuchElementException e) {
+			assertNotNull(e);
+		}
+	}
+
+	@Test
+	public void testThreeWithTwoElementsSetIterator() {
+		ArrayBindingSet bs = new ArrayBindingSet("first", "alt", "bag");
+		bs.setBinding("first", RDF.FIRST);
+		bs.setBinding("bag", RDF.BAG);
+		Iterator<Binding> iterator = bs.iterator();
+		assertNotNull(iterator);
+		assertTrue(iterator.hasNext());
+		Binding first = iterator.next();
+		assertNotNull(first);
+		assertTrue(iterator.hasNext());
+		Binding bag = iterator.next();
+		assertNotNull(bag);
+		assertEquals("bag", bag.getName());
+		assertFalse(iterator.hasNext());
+		try {
+			iterator.next();
+			fail("There are no more elements");
+		} catch (NoSuchElementException e) {
+			assertNotNull(e);
+		}
+	}
 }


### PR DESCRIPTION
…void LinkedHashSet althoughether


GitHub issue resolved: #4847 

Briefly describe the changes proposed in this PR:

Fix the iterator logic to not advance when it should not.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

