### PR TITLE
GH-4544 Openrewrite migration to junit5. 

### DIFF
--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
@@ -23,17 +23,17 @@ import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 @ClusterScope(numDataNodes = 1)
 public class ElasticsearchSailGeoSPARQLTest extends ESIntegTestCase {
 
 	AbstractLuceneSailGeoSPARQLTest delegateTest;
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -64,7 +64,7 @@ public class ElasticsearchSailGeoSPARQLTest extends ESIntegTestCase {
 		return List.of(ReindexPlugin.class);
 	}
 
-	@After
+	@AfterEach
 	@Override
 	public void tearDown() throws Exception {
 		try {
@@ -75,30 +75,32 @@ public class ElasticsearchSailGeoSPARQLTest extends ESIntegTestCase {
 	}
 
 	@Test
-	public void testTriplesStored() {
+	void testTriplesStored() {
 		delegateTest.testTriplesStored();
 	}
 
 	@Test
-	public void testDistanceQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+	void testDistanceQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testDistanceQuery();
 	}
 
 	@Test
-	public void testComplexDistanceQuery()
+	void testComplexDistanceQuery()
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testComplexDistanceQuery();
 	}
 
+	// JTS is required
 	@Test
-	@Ignore // JTS is required
-	public void testIntersectionQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+	@Disabled
+	void testIntersectionQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testIntersectionQuery();
 	}
 
+	// JTS is required
 	@Test
-	@Ignore // JTS is required
-	public void testComplexIntersectionQuery()
+	@Disabled
+	void testComplexIntersectionQuery()
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testComplexIntersectionQuery();
 	}

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
@@ -23,16 +23,16 @@ import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @ClusterScope(numDataNodes = 1)
 public class ElasticsearchSailIndexedPropertiesTest extends ESIntegTestCase {
 
 	AbstractLuceneSailIndexedPropertiesTest delegateTest;
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -63,7 +63,7 @@ public class ElasticsearchSailIndexedPropertiesTest extends ESIntegTestCase {
 		return List.of(ReindexPlugin.class);
 	}
 
-	@After
+	@AfterEach
 	@Override
 	public void tearDown() throws Exception {
 		try {
@@ -74,12 +74,12 @@ public class ElasticsearchSailIndexedPropertiesTest extends ESIntegTestCase {
 	}
 
 	@Test
-	public void testTriplesStored() {
+	void testTriplesStored() {
 		delegateTest.testTriplesStored();
 	}
 
 	@Test
-	public void testRegularQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+	void testRegularQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testRegularQuery();
 	}
 

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
@@ -23,16 +23,16 @@ import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @ClusterScope(numDataNodes = 1)
 public class ElasticsearchSailTest extends ESIntegTestCase {
 
 	AbstractLuceneSailTest delegateTest;
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -63,7 +63,7 @@ public class ElasticsearchSailTest extends ESIntegTestCase {
 		return List.of(ReindexPlugin.class);
 	}
 
-	@After
+	@AfterEach
 	@Override
 	public void tearDown() throws Exception {
 		try {
@@ -74,96 +74,96 @@ public class ElasticsearchSailTest extends ESIntegTestCase {
 	}
 
 	@Test
-	public void testTriplesStored() {
+	void testTriplesStored() {
 		delegateTest.testTriplesStored();
 	}
 
 	@Test
-	public void testRegularQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+	void testRegularQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testRegularQuery();
 	}
 
 	@Test
-	public void testComplexQueryOne() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
+	void testComplexQueryOne() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testComplexQueryOne();
 	}
 
 	@Test
-	public void testComplexQueryTwo() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
+	void testComplexQueryTwo() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testComplexQueryTwo();
 	}
 
 	@Test
-	public void testMultipleLuceneQueries()
+	void testMultipleLuceneQueries()
 			throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testMultipleLuceneQueries();
 	}
 
 	@Test
-	public void testPredicateLuceneQueries()
+	void testPredicateLuceneQueries()
 			throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testPredicateLuceneQueries();
 	}
 
 	@Test
-	public void testSnippetQueries() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
+	void testSnippetQueries() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testSnippetQueries();
 	}
 
 	@Test
-	public void testSnippetLimitedToPredicate()
+	void testSnippetLimitedToPredicate()
 			throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testSnippetLimitedToPredicate();
 	}
 
 	@Test
-	public void testGraphQuery() throws QueryEvaluationException, MalformedQueryException, RepositoryException {
+	void testGraphQuery() throws QueryEvaluationException, MalformedQueryException, RepositoryException {
 		delegateTest.testGraphQuery();
 	}
 
 	@Test
-	public void testQueryWithSpecifiedSubject()
+	void testQueryWithSpecifiedSubject()
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testQueryWithSpecifiedSubject();
 	}
 
 	@Test
-	public void testUnionQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+	void testUnionQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		delegateTest.testUnionQuery();
 	}
 
 	@Test
-	public void testContextHandling() {
+	void testContextHandling() {
 		delegateTest.testContextHandling();
 	}
 
 	@Test
-	public void testConcurrentReadingAndWriting() {
+	void testConcurrentReadingAndWriting() {
 		delegateTest.testConcurrentReadingAndWriting();
 	}
 
 	@Test
-	public void testNullContextHandling() {
+	void testNullContextHandling() {
 		delegateTest.testNullContextHandling();
 	}
 
 	@Test
-	public void testFuzzyQuery() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
+	void testFuzzyQuery() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testFuzzyQuery();
 	}
 
 	@Test
-	public void testReindexing() {
+	void testReindexing() {
 		delegateTest.testReindexing();
 	}
 
 	@Test
-	public void testPropertyVar() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
+	void testPropertyVar() throws MalformedQueryException, RepositoryException, QueryEvaluationException {
 		delegateTest.testPropertyVar();
 	}
 
 	@Test
-	public void testMultithreadedAdd() throws InterruptedException {
+	void testMultithreadedAdd() throws InterruptedException {
 		delegateTest.testMultithreadedAdd();
 	}
 

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
@@ -14,8 +14,8 @@ import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * @author jeen
@@ -24,7 +24,7 @@ public class HTTPRepositoryOptimisticIsolationTest extends OptimisticIsolationTe
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 
@@ -46,7 +46,7 @@ public class HTTPRepositoryOptimisticIsolationTest extends OptimisticIsolationTe
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 		server.stop();

--- a/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrIndexTest.java
+++ b/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrIndexTest.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.solr;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,11 +45,11 @@ import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.lucene.SearchDocument;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +95,7 @@ public class SolrIndexTest {
 
 	private static String toRestoreSolrHome = null;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		toRestoreSolrHome = System.getProperty("solr.solr.home");
 		PropertiesReader reader = new PropertiesReader("maven-config.properties");
@@ -104,13 +104,13 @@ public class SolrIndexTest {
 		System.setProperty("solr.solr.home", testSolrHome);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownClass() {
 		System.setProperty("solr.solr.home", toRestoreSolrHome == null ? "" : toRestoreSolrHome);
 		toRestoreSolrHome = null;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		index = new SolrIndex();
 		Properties sailProperties = new Properties();
@@ -119,7 +119,7 @@ public class SolrIndexTest {
 		client = index.getClient();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		index.shutDown();
 
@@ -129,7 +129,7 @@ public class SolrIndexTest {
 	}
 
 	@Test
-	public void testAddStatement() throws IOException, SolrServerException {
+	void testAddStatement() throws IOException, SolrServerException {
 		// add a statement to an index
 		index.begin();
 		index.addStatement(statement11);
@@ -221,7 +221,7 @@ public class SolrIndexTest {
 	}
 
 	@Test
-	public void testAddMultiple() throws Exception {
+	void testAddMultiple() throws Exception {
 		// add a statement to an index
 		HashSet<Statement> added = new HashSet<>();
 		HashSet<Statement> removed = new HashSet<>();
@@ -287,7 +287,7 @@ public class SolrIndexTest {
 	 * @throws Exception
 	 */
 	@Test
-	public void testContexts() throws Exception {
+	void testContexts() throws Exception {
 		// add a sail
 		MemoryStore memoryStore = new MemoryStore();
 		// enable lock tracking
@@ -338,7 +338,7 @@ public class SolrIndexTest {
 	 * @throws Exception
 	 */
 	@Test
-	public void testContextsRemoveContext2() throws Exception {
+	void testContextsRemoveContext2() throws Exception {
 		// add a sail
 		MemoryStore memoryStore = new MemoryStore();
 		// enable lock tracking
@@ -384,29 +384,29 @@ public class SolrIndexTest {
 	}
 
 	@Test
-	public void testRejectedDatatypes() {
+	void testRejectedDatatypes() {
 		Literal literal1 = fac.createLiteral("hi there");
 		Literal literal2 = fac.createLiteral("hi there, too", XSD.STRING);
 		Literal literal3 = fac.createLiteral("1.0");
 		Literal literal4 = fac.createLiteral("1.0", XSD.FLOAT);
 
-		assertEquals("Is the first literal accepted?", true, index.accept(literal1));
-		assertEquals("Is the second literal accepted?", true, index.accept(literal2));
-		assertEquals("Is the third literal accepted?", true, index.accept(literal3));
-		assertEquals("Is the fourth literal accepted?", false, index.accept(literal4));
+		assertEquals(true, index.accept(literal1), "Is the first literal accepted?");
+		assertEquals(true, index.accept(literal2), "Is the second literal accepted?");
+		assertEquals(true, index.accept(literal3), "Is the third literal accepted?");
+		assertEquals(false, index.accept(literal4), "Is the fourth literal accepted?");
 	}
 
 	@Test
-	public void testRejectedCoreDatatypes() {
+	void testRejectedCoreDatatypes() {
 		Literal literal1 = fac.createLiteral("hi there");
 		Literal literal2 = fac.createLiteral("hi there, too", CoreDatatype.XSD.STRING);
 		Literal literal3 = fac.createLiteral("1.0");
 		Literal literal4 = fac.createLiteral("1.0", CoreDatatype.XSD.FLOAT);
 
-		assertEquals("Is the first literal accepted?", true, index.accept(literal1));
-		assertEquals("Is the second literal accepted?", true, index.accept(literal2));
-		assertEquals("Is the third literal accepted?", true, index.accept(literal3));
-		assertEquals("Is the fourth literal accepted?", false, index.accept(literal4));
+		assertEquals(true, index.accept(literal1), "Is the first literal accepted?");
+		assertEquals(true, index.accept(literal2), "Is the second literal accepted?");
+		assertEquals(true, index.accept(literal3), "Is the third literal accepted?");
+		assertEquals(false, index.accept(literal4), "Is the fourth literal accepted?");
 	}
 
 	private void assertStatement(Statement statement) throws Exception {
@@ -431,7 +431,7 @@ public class SolrIndexTest {
 	 */
 	private void assertStatement(Statement statement, SearchDocument document) {
 		List<String> fields = document.getProperty(SearchFields.getPropertyField(statement.getPredicate()));
-		assertNotNull("field " + statement.getPredicate() + " not found in document " + document, fields);
+		assertNotNull(fields, "field " + statement.getPredicate() + " not found in document " + document);
 		for (String f : fields) {
 			if (((Literal) statement.getObject()).getLabel().equals(f)) {
 				return;

--- a/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrSailGeoSPARQLTest.java
+++ b/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrSailGeoSPARQLTest.java
@@ -20,17 +20,17 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.solr.SolrIndexTest.PropertiesReader;
 import org.eclipse.testsuite.rdf4j.sail.lucene.AbstractLuceneSailGeoSPARQLTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class SolrSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLTest {
 
 	private static final String DATA_DIR = "target/test-data";
 	private static String toRestoreSolrHome = null;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		toRestoreSolrHome = System.getProperty("solr.solr.home");
 		PropertiesReader reader = new PropertiesReader("maven-config.properties");
@@ -38,7 +38,7 @@ public class SolrSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLTest {
 		System.setProperty("solr.solr.home", testSolrHome);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownClass() {
 		System.setProperty("solr.solr.home", toRestoreSolrHome == null ? "" : toRestoreSolrHome);
 		toRestoreSolrHome = null;
@@ -61,14 +61,14 @@ public class SolrSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLTest {
 	}
 
 	@Test
-	@Ignore // JTS is required
+	@Disabled // JTS is required
 	@Override
 	public void testIntersectionQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		super.testIntersectionQuery();
 	}
 
 	@Test
-	@Ignore // JTS is required
+	@Disabled // JTS is required
 	@Override
 	public void testComplexIntersectionQuery()
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {

--- a/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrSailIndexedPropertiesTest.java
+++ b/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrSailIndexedPropertiesTest.java
@@ -18,8 +18,8 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.solr.SolrIndexTest.PropertiesReader;
 import org.eclipse.testsuite.rdf4j.sail.lucene.AbstractLuceneSailIndexedPropertiesTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class SolrSailIndexedPropertiesTest extends AbstractLuceneSailIndexedPropertiesTest {
 
@@ -27,7 +27,7 @@ public class SolrSailIndexedPropertiesTest extends AbstractLuceneSailIndexedProp
 
 	private static String toRestoreSolrHome = null;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		toRestoreSolrHome = System.getProperty("solr.solr.home");
 		PropertiesReader reader = new PropertiesReader("maven-config.properties");
@@ -35,7 +35,7 @@ public class SolrSailIndexedPropertiesTest extends AbstractLuceneSailIndexedProp
 		System.setProperty("solr.solr.home", testSolrHome);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownClass() {
 		System.setProperty("solr.solr.home", toRestoreSolrHome == null ? "" : toRestoreSolrHome);
 		toRestoreSolrHome = null;

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,11 +69,10 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,8 +99,7 @@ public class SPARQLServiceEvaluationTest {
 
 	private List<HTTPRepository> remoteRepositories;
 
-	@Rule
-	public TestName name = new TestName();
+	public String name;
 
 	public SPARQLServiceEvaluationTest() {
 
@@ -109,8 +108,12 @@ public class SPARQLServiceEvaluationTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
-	public void setUp() throws Exception {
+	@BeforeEach
+	public void setUp(TestInfo testInfo) throws Exception {
+		Optional<Method> testMethod = testInfo.getTestMethod();
+		if (testMethod.isPresent()) {
+			this.name = testMethod.get().getName();
+		}
 		// set up the server: the maximal number of endpoints must be known
 		List<String> repositoryIds = new ArrayList<>(MAX_ENDPOINTS);
 		for (int i = 1; i <= MAX_ENDPOINTS; i++) {
@@ -211,7 +214,7 @@ public class SPARQLServiceEvaluationTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			localRepository.shutDown();
@@ -226,7 +229,7 @@ public class SPARQLServiceEvaluationTest {
 	 * @see <a href="https://github.com/eclipse/rdf4j/issues/646">#646</a>
 	 */
 	@Test
-	public void testValuesBindClauseHandling() {
+	void testValuesBindClauseHandling() {
 		String query = "select * { service <" + getRepositoryUrl(1) + "> { Bind(1 as ?val) . VALUES ?x {1 2} . } }";
 
 		try (RepositoryConnection conn = localRepository.getConnection()) {
@@ -255,7 +258,7 @@ public class SPARQLServiceEvaluationTest {
 	 * @see <a href="https://github.com/eclipse/rdf4j/issues/703">#703</a>
 	 */
 	@Test
-	public void testVariableNameHandling() throws Exception {
+	void testVariableNameHandling() throws Exception {
 		String query = "select * { service <" + getRepositoryUrl(1) + "> { ?s ?p ?o . Bind(str(?o) as ?val) .  } }";
 
 		// add some data to the remote endpoint (we don't care about the exact contents)
@@ -279,7 +282,7 @@ public class SPARQLServiceEvaluationTest {
 	}
 
 	@Test
-	public void testSimpleServiceQuery() throws RepositoryException {
+	void testSimpleServiceQuery() throws RepositoryException {
 		// test setup
 		String EX_NS = "http://example.org/";
 		ValueFactory f = localRepository.getValueFactory();
@@ -338,74 +341,74 @@ public class SPARQLServiceEvaluationTest {
 	}
 
 	@Test
-	public void test1() throws Exception {
+	void test1() throws Exception {
 		prepareTest("/testcases-service/data01.ttl", List.of("/testcases-service/data01endpoint.ttl"));
 		execute("/testcases-service/service01.rq", "/testcases-service/service01.srx", false);
 	}
 
 	@Test
-	public void test2() throws Exception {
+	void test2() throws Exception {
 		prepareTest(null,
 				Arrays.asList("/testcases-service/data02endpoint1.ttl", "/testcases-service/data02endpoint2.ttl"));
 		execute("/testcases-service/service02.rq", "/testcases-service/service02.srx", false);
 	}
 
 	@Test
-	public void test3() throws Exception {
+	void test3() throws Exception {
 		prepareTest(null,
 				Arrays.asList("/testcases-service/data03endpoint1.ttl", "/testcases-service/data03endpoint2.ttl"));
 		execute("/testcases-service/service03.rq", "/testcases-service/service03.srx", false);
 	}
 
 	@Test
-	public void test4() throws Exception {
+	void test4() throws Exception {
 		prepareTest("/testcases-service/data04.ttl", List.of("/testcases-service/data04endpoint.ttl"));
 		execute("/testcases-service/service04.rq", "/testcases-service/service04.srx", false);
 	}
 
 	@Test
-	public void test5() throws Exception {
+	void test5() throws Exception {
 		prepareTest("/testcases-service/data05.ttl",
 				Arrays.asList("/testcases-service/data05endpoint1.ttl", "/testcases-service/data05endpoint2.ttl"));
 		execute("/testcases-service/service05.rq", "/testcases-service/service05.srx", false);
 	}
 
 	@Test
-	public void test6() throws Exception {
+	void test6() throws Exception {
 		prepareTest(null, List.of("/testcases-service/data06endpoint1.ttl"));
 		execute("/testcases-service/service06.rq", "/testcases-service/service06.srx", false);
 	}
 
 	@Test
-	public void test7() throws Exception {
+	void test7() throws Exception {
 		// clears the repository and adds new data + execute
 		prepareTest("/testcases-service/data07.ttl", Collections.<String>emptyList());
 		execute("/testcases-service/service07.rq", "/testcases-service/service07.srx", false);
 	}
 
 	@Test
-	public void test8() throws Exception {
+	void test8() throws Exception {
 		/* test where the SERVICE expression is to be evaluated as ASK request */
 		prepareTest("/testcases-service/data08.ttl", List.of("/testcases-service/data08endpoint.ttl"));
 		execute("/testcases-service/service08.rq", "/testcases-service/service08.srx", false);
 	}
 
 	@Test
-	public void test9() throws Exception {
+	void test9() throws Exception {
 		/* test where the service endpoint is bound at runtime through BIND */
 		prepareTest(null, List.of("/testcases-service/data09endpoint.ttl"));
 		execute("/testcases-service/service09.rq", "/testcases-service/service09.srx", false);
 	}
 
 	@Test
-	public void test10() throws Exception {
+	void test10() throws Exception {
 		/* test how we deal with blank node */
 		prepareTest("/testcases-service/data10.ttl", List.of("/testcases-service/data10endpoint.ttl"));
 		execute("/testcases-service/service10.rq", "/testcases-service/service10.srx", false);
 	}
 
 	@Test
-	public void test11() throws Exception {
+	void test11() throws Exception {
 		/* test vectored join with more intermediate results */
 		// clears the repository and adds new data + execute
 		prepareTest("/testcases-service/data11.ttl", List.of("/testcases-service/data11endpoint.ttl"));
@@ -431,28 +434,28 @@ public class SPARQLServiceEvaluationTest {
 	// }
 
 	@Test
-	public void test13() throws Exception {
+	void test13() throws Exception {
 		/* test for bug SES-899: cross product is required */
 		prepareTest(null, List.of("/testcases-service/data13.ttl"));
 		execute("/testcases-service/service13.rq", "/testcases-service/service13.srx", false);
 	}
 
 	@Test
-	public void testEmptyServiceBlock() throws Exception {
+	void testEmptyServiceBlock() throws Exception {
 		/* test for bug SES-900: nullpointer for empty service block */
 		prepareTest(null, List.of("/testcases-service/data13.ttl"));
 		execute("/testcases-service/service14.rq", "/testcases-service/service14.srx", false);
 	}
 
 	@Test
-	public void testNotProjectedCount() throws Exception {
+	void testNotProjectedCount() throws Exception {
 		/* test projection of subqueries - SES-1000 */
 		prepareTest(null, List.of("/testcases-service/data17endpoint1.ttl"));
 		execute("/testcases-service/service17.rq", "/testcases-service/service17.srx", false);
 	}
 
 	@Test
-	public void testNonAsciiCharHandling() throws Exception {
+	void testNonAsciiCharHandling() throws Exception {
 		/* SES-1056 */
 		prepareTest(null, List.of("/testcases-service/data18endpoint1.rdf"));
 		execute("/testcases-service/service18.rq", "/testcases-service/service18.srx", false);
@@ -622,7 +625,7 @@ public class SPARQLServiceEvaluationTest {
 
 			StringBuilder message = new StringBuilder(128);
 			message.append("\n============ ");
-			message.append(name.getMethodName());
+			message.append(name);
 			message.append(" =======================\n");
 
 			if (!missingBindings.isEmpty()) {
@@ -634,7 +637,7 @@ public class SPARQLServiceEvaluationTest {
 				}
 
 				message.append("=============");
-				StringUtil.appendN('=', name.getMethodName().length(), message);
+				StringUtil.appendN('=', name.length(), message);
 				message.append("========================\n");
 			}
 
@@ -646,7 +649,7 @@ public class SPARQLServiceEvaluationTest {
 				}
 
 				message.append("=============");
-				StringUtil.appendN('=', name.getMethodName().length(), message);
+				StringUtil.appendN('=', name.length(), message);
 				message.append("========================\n");
 			}
 
@@ -708,7 +711,7 @@ public class SPARQLServiceEvaluationTest {
 			 */
 			StringBuilder message = new StringBuilder(128);
 			message.append("\n============ ");
-			message.append(name.getMethodName());
+			message.append(name);
 			message.append(" =======================\n");
 			message.append("Expected result: \n");
 			for (Statement st : expectedResult) {
@@ -716,7 +719,7 @@ public class SPARQLServiceEvaluationTest {
 				message.append("\n");
 			}
 			message.append("=============");
-			StringUtil.appendN('=', name.getMethodName().length(), message);
+			StringUtil.appendN('=', name.length(), message);
 			message.append("========================\n");
 
 			message.append("Query result: \n");
@@ -725,7 +728,7 @@ public class SPARQLServiceEvaluationTest {
 				message.append("\n");
 			}
 			message.append("=============");
-			StringUtil.appendN('=', name.getMethodName().length(), message);
+			StringUtil.appendN('=', name.length(), message);
 			message.append("========================\n");
 
 			logger.error(message.toString());

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomAggregateFunctionEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomAggregateFunctionEvaluationTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.query.parser.sparql.function;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringReader;

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.datatypes;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
@@ -260,15 +260,15 @@ public class XMLDatatypeUtilTest {
 	public void testCompareDateTimeStamp() {
 		int sameOffset = XMLDatatypeUtil.compare("2019-12-06T00:00:00Z", "2019-12-06T00:00:00+00:00",
 				XSD.DATETIMESTAMP);
-		assertTrue("Not the same", sameOffset == 0);
+		assertTrue(sameOffset == 0, "Not the same");
 
 		int offset1 = XMLDatatypeUtil.compare("2019-12-06T14:00:00+02:00", "2019-12-06T13:00:00+02:00",
 				XSD.DATETIMESTAMP);
-		assertTrue("Wrong order", offset1 > 0);
+		assertTrue(offset1 > 0, "Wrong order");
 
 		int offset2 = XMLDatatypeUtil.compare("2019-12-06T12:00:00+02:00", "2019-12-06T13:00:00-04:00",
 				XSD.DATETIMESTAMP);
-		assertTrue("Wrong order", offset2 < 0);
+		assertTrue(offset2 < 0, "Wrong order");
 	}
 
 	@Test

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/ContextStatementTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/ContextStatementTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelBuilderTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelBuilderTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelCollectorTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelCollectorTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -41,12 +41,12 @@ public class ModelCollectorTest {
 	@Test
 	public void testCollector() {
 		Model m = stmts.stream().collect(ModelCollector.toModel());
-		assertEquals("Number of statements does not match", m.size(), nrStmts);
+		assertEquals(m.size(), nrStmts, "Number of statements does not match");
 	}
 
 	@Test
 	public void testCollectorParallel() {
 		Model m = stmts.parallelStream().collect(ModelCollector.toModel());
-		assertEquals("Number of statements does not match", m.size(), nrStmts);
+		assertEquals(m.size(), nrStmts, "Number of statements does not match");
 	}
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelsTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.model.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Optional;
@@ -81,7 +81,7 @@ public class ModelsTest {
 		// add same statement again
 		model2.add(foo, RDF.TYPE, bar);
 
-		assertTrue("Duplicate statement should not be considered", Models.isomorphic(model1, model2));
+		assertTrue(Models.isomorphic(model1, model2), "Duplicate statement should not be considered");
 
 		// two identical statements with bnodes added.
 		model1.add(foo, RDF.TYPE, VF.createBNode());
@@ -461,22 +461,22 @@ public class ModelsTest {
 		Model referenceRDFStarModel = RDFStarTestHelper.createRDFStarModel();
 
 		Model rdfStarModel1 = Models.convertReificationToRDFStar(VF, reificationModel);
-		assertTrue("RDF reification conversion to RDF-star with explicit VF, model-to-model",
-				Models.isomorphic(rdfStarModel1, referenceRDFStarModel));
+		assertTrue(Models.isomorphic(rdfStarModel1, referenceRDFStarModel),
+				"RDF reification conversion to RDF-star with explicit VF, model-to-model");
 
 		Model rdfStarModel2 = Models.convertReificationToRDFStar(reificationModel);
-		assertTrue("RDF reification conversion to RDF-star with implicit VF, model-to-model",
-				Models.isomorphic(rdfStarModel2, referenceRDFStarModel));
+		assertTrue(Models.isomorphic(rdfStarModel2, referenceRDFStarModel),
+				"RDF reification conversion to RDF-star with implicit VF, model-to-model");
 
 		Model rdfStarModel3 = new TreeModel();
 		Models.convertReificationToRDFStar(VF, reificationModel, (Consumer<Statement>) rdfStarModel3::add);
-		assertTrue("RDF reification conversion to RDF-star with explicit VF, model-to-consumer",
-				Models.isomorphic(rdfStarModel3, referenceRDFStarModel));
+		assertTrue(Models.isomorphic(rdfStarModel3, referenceRDFStarModel),
+				"RDF reification conversion to RDF-star with explicit VF, model-to-consumer");
 
 		Model rdfStarModel4 = new TreeModel();
 		Models.convertReificationToRDFStar(reificationModel, rdfStarModel4::add);
-		assertTrue("RDF reification conversion to RDF-star with implicit VF, model-to-consumer",
-				Models.isomorphic(rdfStarModel4, referenceRDFStarModel));
+		assertTrue(Models.isomorphic(rdfStarModel4, referenceRDFStarModel),
+				"RDF reification conversion to RDF-star with implicit VF, model-to-consumer");
 	}
 
 	@Test
@@ -486,22 +486,22 @@ public class ModelsTest {
 		Model incompleteReificationModel = RDFStarTestHelper.createIncompleteRDFReificationModel();
 
 		Model rdfStarModel1 = Models.convertReificationToRDFStar(VF, incompleteReificationModel);
-		assertTrue("Incomplete RDF reification conversion to RDF-star with explicit VF, model-to-model",
-				Models.isomorphic(rdfStarModel1, incompleteReificationModel));
+		assertTrue(Models.isomorphic(rdfStarModel1, incompleteReificationModel),
+				"Incomplete RDF reification conversion to RDF-star with explicit VF, model-to-model");
 
 		Model rdfStarModel2 = Models.convertReificationToRDFStar(incompleteReificationModel);
-		assertTrue("Incomplete RDF reification conversion to RDF-star with implicit VF, model-to-model",
-				Models.isomorphic(rdfStarModel2, incompleteReificationModel));
+		assertTrue(Models.isomorphic(rdfStarModel2, incompleteReificationModel),
+				"Incomplete RDF reification conversion to RDF-star with implicit VF, model-to-model");
 
 		Model rdfStarModel3 = new TreeModel();
 		Models.convertReificationToRDFStar(VF, incompleteReificationModel, (Consumer<Statement>) rdfStarModel3::add);
-		assertTrue("Incomplete RDF reification conversion to RDF-star with explicit VF, model-to-consumer",
-				Models.isomorphic(rdfStarModel3, incompleteReificationModel));
+		assertTrue(Models.isomorphic(rdfStarModel3, incompleteReificationModel),
+				"Incomplete RDF reification conversion to RDF-star with explicit VF, model-to-consumer");
 
 		Model rdfStarModel4 = new TreeModel();
 		Models.convertReificationToRDFStar(incompleteReificationModel, rdfStarModel4::add);
-		assertTrue("Incomplete RDF reification conversion to RDF-star with implicit VF, model-to-consumer",
-				Models.isomorphic(rdfStarModel4, incompleteReificationModel));
+		assertTrue(Models.isomorphic(rdfStarModel4, incompleteReificationModel),
+				"Incomplete RDF reification conversion to RDF-star with implicit VF, model-to-consumer");
 	}
 
 	@Test
@@ -510,22 +510,22 @@ public class ModelsTest {
 		Model referenceModel = RDFStarTestHelper.createRDFReificationModel();
 
 		Model reificationModel1 = Models.convertRDFStarToReification(VF, rdfStarModel);
-		assertTrue("RDF-star conversion to reification with explicit VF, model-to-model",
-				Models.isomorphic(reificationModel1, referenceModel));
+		assertTrue(Models.isomorphic(reificationModel1, referenceModel),
+				"RDF-star conversion to reification with explicit VF, model-to-model");
 
 		Model reificationModel2 = Models.convertRDFStarToReification(rdfStarModel);
-		assertTrue("RDF-star conversion to reification with implicit VF, model-to-model",
-				Models.isomorphic(reificationModel2, referenceModel));
+		assertTrue(Models.isomorphic(reificationModel2, referenceModel),
+				"RDF-star conversion to reification with implicit VF, model-to-model");
 
 		Model reificationModel3 = new TreeModel();
 		Models.convertRDFStarToReification(VF, rdfStarModel, (Consumer<Statement>) reificationModel3::add);
-		assertTrue("RDF-star conversion to reification with explicit VF, model-to-consumer",
-				Models.isomorphic(reificationModel3, referenceModel));
+		assertTrue(Models.isomorphic(reificationModel3, referenceModel),
+				"RDF-star conversion to reification with explicit VF, model-to-consumer");
 
 		Model reificationModel4 = new TreeModel();
 		Models.convertRDFStarToReification(rdfStarModel, reificationModel4::add);
-		assertTrue("RDF-star conversion to reification with explicit VF, model-to-consumer",
-				Models.isomorphic(reificationModel4, referenceModel));
+		assertTrue(Models.isomorphic(reificationModel4, referenceModel),
+				"RDF-star conversion to reification with explicit VF, model-to-consumer");
 	}
 
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/NamespacesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/NamespacesTest.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -269,7 +269,7 @@ public class NamespacesTest {
 		Map<String, String> testMap = Namespaces.wrap(testSet);
 
 		String put1 = testMap.put(testPrefix1, testName1);
-		assertNull("Should have returned null from put on an empty backing set", put1);
+		assertNull(put1, "Should have returned null from put on an empty backing set");
 		assertEquals(1, testSet.size());
 		assertTrue(testSet.contains(new SimpleNamespace(testPrefix1, testName1)));
 		assertTrue(testMap.containsKey(testPrefix1));
@@ -293,7 +293,7 @@ public class NamespacesTest {
 		assertFalse(testMap.containsValue(testName2));
 
 		String put3 = testMap.put(testPrefix1, testName1);
-		assertNull("Should have returned null from put on an empty backing set", put3);
+		assertNull(put3, "Should have returned null from put on an empty backing set");
 		assertEquals(1, testSet.size());
 		assertTrue(testSet.contains(new SimpleNamespace(testPrefix1, testName1)));
 		assertTrue(testMap.containsKey(testPrefix1));

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFCollectionsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFCollectionsTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.atLeastOnce;

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFContainersTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFContainersTest.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.atLeastOnce;

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
@@ -12,10 +12,10 @@ package org.eclipse.rdf4j.model.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
@@ -92,19 +92,19 @@ public class StatementsTest {
 
 		Model convertedModel1 = new LinkedHashModel();
 		rdfStarModel.forEach((s) -> Statements.convertRDFStarToReification(s, convertedModel1::add));
-		assertTrue("RDF-star conversion to reification with implicit VF",
-				Models.isomorphic(reifiedModel, convertedModel1));
+		assertTrue(Models.isomorphic(reifiedModel, convertedModel1),
+				"RDF-star conversion to reification with implicit VF");
 
 		Model convertedModel2 = new LinkedHashModel();
 		rdfStarModel.forEach((s) -> Statements.convertRDFStarToReification(vf, s, convertedModel2::add));
-		assertTrue("RDF-star conversion to reification with explicit VF",
-				Models.isomorphic(reifiedModel, convertedModel2));
+		assertTrue(Models.isomorphic(reifiedModel, convertedModel2),
+				"RDF-star conversion to reification with explicit VF");
 
 		Model convertedModel3 = new LinkedHashModel();
 		rdfStarModel.forEach((s) -> Statements.convertRDFStarToReification(vf, (t) -> vf.createBNode(t.stringValue()),
 				s, convertedModel3::add));
-		assertTrue("RDF-star conversion to reification with explicit VF and custom BNode mapping",
-				Models.isomorphic(reifiedModel, convertedModel3));
+		assertTrue(Models.isomorphic(reifiedModel, convertedModel3),
+				"RDF-star conversion to reification with explicit VF and custom BNode mapping");
 	}
 
 	@Test
@@ -113,8 +113,8 @@ public class StatementsTest {
 				vf.createLiteral("data"));
 		Triple t2 = vf.createTriple(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
 				vf.createLiteral("data"));
-		assertEquals("Identical triples must produce the same blank node",
-				Statements.TRIPLE_BNODE_MAPPER.apply(t1), Statements.TRIPLE_BNODE_MAPPER.apply(t2));
+		assertEquals(Statements.TRIPLE_BNODE_MAPPER.apply(t1), Statements.TRIPLE_BNODE_MAPPER.apply(t2),
+				"Identical triples must produce the same blank node");
 	}
 
 	@Test

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,35 +48,35 @@ public class URIUtilTest {
 	@Test
 	public void testIsValidURIReference() {
 		assertTrue(URIUtil.isValidURIReference("http://example.org/foo/bar/"));
-		assertTrue("whitespace should be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo/bar with a lot of space/"));
-		assertTrue("unwise chars should be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo/bar/unwise{<characters>}"));
-		assertTrue("query params in single quotes should be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo/bar?query='blah'"));
-		assertTrue("query params in double quotes should be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo/bar?query=\"blah\"&foo=bar"));
-		assertTrue("short simple urns should be allowed", URIUtil.isValidURIReference("urn:p1"));
-		assertTrue("Escaped special char should be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo\\u00ea/bar/"));
-		assertTrue("fragment identifier should be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo/bar#fragment1"));
-		assertTrue("Unescaped special char should be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo®/bar/"));
-		assertFalse("control char should not be allowed",
-				URIUtil.isValidURIReference("http://example.org/foo\u0001/bar/"));
-		assertFalse("relative uri should fail", URIUtil.isValidURIReference("foo/bar/"));
-		assertFalse("single column is not a valid uri", URIUtil.isValidURIReference(":"));
-		assertTrue("reserved char is allowed in non-conflicting spot",
-				URIUtil.isValidURIReference("http://foo.com/b!ar/"));
-		assertFalse("reserved char should not be allowed in conflicting spot",
-				URIUtil.isValidURIReference("http;://foo.com/bar/"));
+		assertTrue(URIUtil.isValidURIReference("http://example.org/foo/bar with a lot of space/"),
+				"whitespace should be allowed");
+		assertTrue(URIUtil.isValidURIReference("http://example.org/foo/bar/unwise{<characters>}"),
+				"unwise chars should be allowed");
+		assertTrue(URIUtil.isValidURIReference("http://example.org/foo/bar?query='blah'"),
+				"query params in single quotes should be allowed");
+		assertTrue(URIUtil.isValidURIReference("http://example.org/foo/bar?query=\"blah\"&foo=bar"),
+				"query params in double quotes should be allowed");
+		assertTrue(URIUtil.isValidURIReference("urn:p1"), "short simple urns should be allowed");
+		assertTrue(URIUtil.isValidURIReference("http://example.org/foo\\u00ea/bar/"),
+				"Escaped special char should be allowed");
+		assertTrue(URIUtil.isValidURIReference("http://example.org/foo/bar#fragment1"),
+				"fragment identifier should be allowed");
+		assertTrue(URIUtil.isValidURIReference("http://example.org/foo®/bar/"),
+				"Unescaped special char should be allowed");
+		assertFalse(URIUtil.isValidURIReference("http://example.org/foo\u0001/bar/"),
+				"control char should not be allowed");
+		assertFalse(URIUtil.isValidURIReference("foo/bar/"), "relative uri should fail");
+		assertFalse(URIUtil.isValidURIReference(":"), "single column is not a valid uri");
+		assertTrue(URIUtil.isValidURIReference("http://foo.com/b!ar/"),
+				"reserved char is allowed in non-conflicting spot");
+		assertFalse(URIUtil.isValidURIReference("http;://foo.com/bar/"),
+				"reserved char should not be allowed in conflicting spot");
 	}
 
 	@Test
 	public void controlCharacterInURI() {
-		assertFalse("URI containing Unicode control char should be invalid",
-				URIUtil.isValidURIReference("http://example.org/foo\u001F/bar/"));
+		assertFalse(URIUtil.isValidURIReference("http://example.org/foo\u001F/bar/"),
+				"URI containing Unicode control char should be invalid");
 	}
 
 	@Test

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
@@ -17,8 +17,8 @@ import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.model.util.Values.namespace;
 import static org.eclipse.rdf4j.model.util.Values.triple;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/VocabulariesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/VocabulariesTest.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/config/TestProxyRepositoryFactory.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/config/TestProxyRepositoryFactory.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.repository.sail.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreIT.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreTransactionsIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreTransactionsIT.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreWalIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreWalIT.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -54,7 +54,7 @@ public class ElasticsearchStoreWalIT extends AbstractElasticsearchStoreIT {
 
 			long size = connection.size();
 			System.out.println(size);
-			assertEquals("Since transaction failed there should be no statements in the store", 0, size);
+			assertEquals(0, size, "Since transaction failed there should be no statements in the store");
 
 		}
 
@@ -119,7 +119,7 @@ public class ElasticsearchStoreWalIT extends AbstractElasticsearchStoreIT {
 
 			long size = connection.size();
 			System.out.println(size);
-			assertEquals("Since transaction failed there should be no statements in the store", count, size);
+			assertEquals(count, size, "Since transaction failed there should be no statements in the store");
 
 		}
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/InferenceIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/InferenceIT.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sail.elasticsearchstore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/InferredContextTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/InferredContextTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.inferencer.fc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.BNode;
@@ -64,7 +64,7 @@ public class InferredContextTest {
 					RDF.TYPE, RDFS.RESOURCE, true)) {
 				while (statements.hasNext()) {
 					Statement next = statements.next();
-					assertEquals("Context should be equal", context, next.getContext());
+					assertEquals(context, next.getContext(), "Context should be equal");
 				}
 			}
 		}
@@ -75,8 +75,8 @@ public class InferredContextTest {
 	public void testDefaultBehaviour() {
 		SchemaCachingRDFSInferencer sail = new SchemaCachingRDFSInferencer(new MemoryStore());
 
-		assertFalse("Current default behaviour should be to add all statements to default context",
-				sail.isAddInferredStatementsToDefaultContext());
+		assertFalse(sail.isAddInferredStatementsToDefaultContext(),
+				"Current default behaviour should be to add all statements to default context");
 
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/DefaultIndexTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/DefaultIndexTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimisticIsolationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class LmdbOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -30,7 +30,7 @@ public class LmdbOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -72,9 +72,9 @@ public class LmdbSailStoreTest {
 			conn.remove((IRI) null, null, null, CTX_1);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
-			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertFalse(conn.hasStatement(S1, false, CTX_1), "Statement 1 still not removed");
+			assertTrue(conn.hasStatement(S2, false, CTX_2), "Statement 2 incorrectly removed");
 		}
 	}
 
@@ -84,9 +84,9 @@ public class LmdbSailStoreTest {
 			conn.remove((IRI) null, null, null, (Resource) null);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertFalse("Statement 0 still not removed", conn.hasStatement(S0, false));
-			assertTrue("Statement 1 incorrectly removed", conn.hasStatement(S1, false, CTX_1));
-			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+			assertFalse(conn.hasStatement(S0, false), "Statement 0 still not removed");
+			assertTrue(conn.hasStatement(S1, false, CTX_1), "Statement 1 incorrectly removed");
+			assertTrue(conn.hasStatement(S2, false, CTX_2), "Statement 2 incorrectly removed");
 		}
 	}
 
@@ -96,9 +96,9 @@ public class LmdbSailStoreTest {
 			conn.remove((IRI) null, null, null, CTX_INV);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertTrue("Statement 1 incorrectly removed", conn.hasStatement(S1, false, CTX_1));
-			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertTrue(conn.hasStatement(S1, false, CTX_1), "Statement 1 incorrectly removed");
+			assertTrue(conn.hasStatement(S2, false, CTX_2), "Statement 2 incorrectly removed");
 		}
 	}
 
@@ -108,9 +108,9 @@ public class LmdbSailStoreTest {
 			conn.remove((IRI) null, null, null, CTX_1, CTX_2);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
-			assertFalse("Statement 2 still not removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertFalse(conn.hasStatement(S1, false, CTX_1), "Statement 1 still not removed");
+			assertFalse(conn.hasStatement(S2, false, CTX_2), "Statement 2 still not removed");
 		}
 	}
 
@@ -120,9 +120,9 @@ public class LmdbSailStoreTest {
 			conn.clear(CTX_1, CTX_2);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
-			assertFalse("Statement 2 still not removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertFalse(conn.hasStatement(S1, false, CTX_1), "Statement 1 still not removed");
+			assertFalse(conn.hasStatement(S2, false, CTX_2), "Statement 2 still not removed");
 		}
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConsistencyIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConsistencyIT.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.List;

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreDirLockTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreDirLockTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreErrorHandlingTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreErrorHandlingTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreTmpDatadirTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreTmpDatadirTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -25,10 +25,10 @@ public class LmdbStoreTmpDatadirTest {
 		LmdbStore store = new LmdbStore(dataDir);
 
 		store.init();
-		assertTrue("Data dir not set correctly", dataDir.equals(store.getDataDir()));
+		assertTrue(dataDir.equals(store.getDataDir()), "Data dir not set correctly");
 
 		store.shutDown();
-		assertTrue("Data dir does not exist anymore", dataDir.exists());
+		assertTrue(dataDir.exists(), "Data dir does not exist anymore");
 	}
 
 	@Test
@@ -36,10 +36,10 @@ public class LmdbStoreTmpDatadirTest {
 		LmdbStore store = new LmdbStore();
 		store.init();
 		File dataDir = store.getDataDir();
-		assertTrue("Temp data dir not created", dataDir != null && dataDir.exists());
+		assertTrue(dataDir != null && dataDir.exists(), "Temp data dir not created");
 
 		store.shutDown();
-		assertFalse("Temp data dir still exists", dataDir.exists());
+		assertFalse(dataDir.exists(), "Temp data dir still exists");
 	}
 
 	@Test
@@ -52,7 +52,7 @@ public class LmdbStoreTmpDatadirTest {
 		store.init();
 		File dataDir2 = store.getDataDir();
 		store.shutDown();
-		assertFalse("Temp data dirs are the same", dataDir1.equals(dataDir2));
+		assertFalse(dataDir1.equals(dataDir2), "Temp data dirs are the same");
 	}
 
 	@Test
@@ -67,7 +67,7 @@ public class LmdbStoreTmpDatadirTest {
 		File tmpDataDir = store.getDataDir();
 		store.shutDown();
 
-		assertFalse("Temp data dir still exists", tmpDataDir.exists());
-		assertTrue("Data dir does not exist anymore", dataDir.exists());
+		assertFalse(tmpDataDir.exists(), "Temp data dir still exists");
+		assertTrue(dataDir.exists(), "Data dir does not exist anymore");
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
@@ -30,7 +30,7 @@ import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
@@ -39,7 +39,8 @@ public class QueryBenchmarkTest {
 
 	private static SailRepository repository;
 
-	public static TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public static File tempDir;
 
 	private static final String query1;
 	private static final String query2;
@@ -63,8 +64,7 @@ public class QueryBenchmarkTest {
 
 	@BeforeAll
 	public static void beforeClass() throws IOException {
-		tempDir.create();
-		File file = tempDir.newFolder();
+		File file = newFolder(tempDir, "junit");
 
 		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
 		repository = new SailRepository(new LmdbStore(file, config));
@@ -195,6 +195,15 @@ public class QueryBenchmarkTest {
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			return connection.hasStatement(RDF.TYPE, RDF.TYPE, RDF.TYPE, true);
 		}
+	}
+
+	private static File newFolder(File root, String... subDirs) throws IOException {
+		String subFolder = String.join("/", subDirs);
+		File result = new File(root, subFolder);
+		if (!result.mkdirs()) {
+			throw new IOException("Couldn't create folders " + root);
+		}
+		return result;
 	}
 
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TestLmdbStoreUpgrade.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TestLmdbStoreUpgrade.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
@@ -47,21 +47,25 @@ public class TripleStoreTest {
 		tripleStore.commit();
 
 		try (Txn txn = tripleStore.getTxnManager().createReadTxn()) {
-			assertEquals("Store should have 1 inferred statement", 1,
-					count(tripleStore.getTriples(txn, 1, 2, 3, 1, false)));
+			assertEquals(1,
+					count(tripleStore.getTriples(txn, 1, 2, 3, 1, false)),
+					"Store should have 1 inferred statement");
 
-			assertEquals("Store should have 0 explicit statements", 0,
-					count(tripleStore.getTriples(txn, 1, 2, 3, 1, true)));
+			assertEquals(0,
+					count(tripleStore.getTriples(txn, 1, 2, 3, 1, true)),
+					"Store should have 0 explicit statements");
 
 			tripleStore.startTransaction();
 			tripleStore.storeTriple(1, 2, 3, 1, true);
 			tripleStore.commit();
 
-			assertEquals("Store should have 0 inferred statements", 0,
-					count(tripleStore.getTriples(txn, 1, 2, 3, 1, false)));
+			assertEquals(0,
+					count(tripleStore.getTriples(txn, 1, 2, 3, 1, false)),
+					"Store should have 0 inferred statements");
 
-			assertEquals("Store should have 1 explicit statements", 1,
-					count(tripleStore.getTriples(txn, 1, 2, 3, 1, true)));
+			assertEquals(1,
+					count(tripleStore.getTriples(txn, 1, 2, 3, 1, true)),
+					"Store should have 1 explicit statements");
 		}
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,7 +69,7 @@ public class ValueStoreTest {
 
 		ValueStoreRevision revAfter = valueStore.getRevision();
 
-		assertNotEquals("revisions must change after gc of IDs", revBefore, revAfter);
+		assertNotEquals(revBefore, revAfter, "revisions must change after gc of IDs");
 
 		Arrays.fill(values, null);
 		// GC would collect revision at some point in time
@@ -90,7 +90,7 @@ public class ValueStoreTest {
 		}
 		valueStore.commit();
 
-		assertEquals("IDs should have been reused", Collections.emptySet(), ids);
+		assertEquals(Collections.emptySet(), ids, "IDs should have been reused");
 	}
 
 	@Test
@@ -126,7 +126,7 @@ public class ValueStoreTest {
 		}
 		valueStore.commit();
 
-		assertEquals("IDs should have been reused", Collections.emptySet(), ids);
+		assertEquals(Collections.emptySet(), ids, "IDs should have been reused");
 	}
 
 	@AfterEach

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/VarintTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/VarintTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 
@@ -31,8 +31,8 @@ public class VarintTest {
 			bb.clear();
 			Varint.writeUnsigned(bb, values[i]);
 			bb.flip();
-			assertEquals("Encoding should use " + (i + 1) + " bytes", i + 1, bb.remaining());
-			assertEquals("Encoded and decoded value should be equal", values[i], Varint.readUnsigned(bb));
+			assertEquals(i + 1, bb.remaining(), "Encoding should use " + (i + 1) + " bytes");
+			assertEquals(values[i], Varint.readUnsigned(bb), "Encoded and decoded value should be equal");
 		}
 	}
 
@@ -47,7 +47,7 @@ public class VarintTest {
 			bb.flip();
 			long[] actual = new long[4];
 			Varint.readListUnsigned(bb, actual);
-			assertArrayEquals("Encoded and decoded value should be equal", expected, actual);
+			assertArrayEquals(expected, actual, "Encoded and decoded value should be equal");
 		}
 	}
 }

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/MultiParamTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/MultiParamTest.java
@@ -11,10 +11,11 @@
 package org.eclipse.rdf4j.sail.lucene;
 
 import static org.eclipse.rdf4j.model.util.Values.literal;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -30,11 +31,10 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.evaluation.TupleFunctionEvaluationMode;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class MultiParamTest {
 	private static final String NAMESPACE = "http://example.org/";
@@ -63,14 +63,14 @@ public class MultiParamTest {
 	private static final IRI p2 = iri("p2");
 	private static final IRI p3 = iri("p3");
 
-	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
+	@TempDir
+	public File tmpFolder;
 
 	LuceneSail luceneSail;
 	SailRepository repository;
 	SailRepositoryConnection conn;
 
-	@Before
+	@BeforeEach
 	public void setup() throws IOException {
 		MemoryStore memoryStore = new MemoryStore();
 		// sail with the ex:text1 filter
@@ -78,7 +78,7 @@ public class MultiParamTest {
 		luceneSail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
 		luceneSail.setEvaluationMode(TupleFunctionEvaluationMode.NATIVE);
 		luceneSail.setBaseSail(memoryStore);
-		luceneSail.setDataDir(tmpFolder.newFolder());
+		luceneSail.setDataDir(newFolder(tmpFolder, "junit"));
 		repository = new SailRepository(luceneSail);
 		repository.init();
 
@@ -117,7 +117,7 @@ public class MultiParamTest {
 		conn.commit();
 	}
 
-	@After
+	@AfterEach
 	public void complete() {
 		try {
 			conn.close();
@@ -127,7 +127,7 @@ public class MultiParamTest {
 	}
 
 	@Test
-	public void testPredicateSimple() {
+	void testPredicateSimple() {
 		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
 				PREFIXES,
 				"SELECT * {",
@@ -144,14 +144,14 @@ public class MultiParamTest {
 
 			while (result.hasNext()) {
 				Value next = result.next().getValue("subj");
-				assertTrue("unknown value: " + next, values.remove(next.toString()));
+				assertTrue(values.remove(next.toString()), "unknown value: " + next);
 			}
-			assertTrue("missing value" + values, values.isEmpty());
+			assertTrue(values.isEmpty(), "missing value" + values);
 		}
 	}
 
 	@Test
-	public void testPredicateMulti() {
+	void testPredicateMulti() {
 		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
 				PREFIXES,
 				"SELECT * {",
@@ -170,14 +170,14 @@ public class MultiParamTest {
 
 			while (result.hasNext()) {
 				Value next = result.next().getValue("subj");
-				assertTrue("unknown value: " + next, values.remove(next.toString()));
+				assertTrue(values.remove(next.toString()), "unknown value: " + next);
 			}
-			assertTrue("missing value" + values, values.isEmpty());
+			assertTrue(values.isEmpty(), "missing value" + values);
 		}
 	}
 
 	@Test
-	public void testMultiPredicate() {
+	void testMultiPredicate() {
 		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
 				PREFIXES,
 				"SELECT * {",
@@ -196,14 +196,14 @@ public class MultiParamTest {
 
 			while (result.hasNext()) {
 				Value next = result.next().getValue("subj");
-				assertTrue("unknown value: " + next, values.remove(next.toString()));
+				assertTrue(values.remove(next.toString()), "unknown value: " + next);
 			}
-			assertTrue("missing value" + values, values.isEmpty());
+			assertTrue(values.isEmpty(), "missing value" + values);
 		}
 	}
 
 	@Test
-	public void testMultiQuery() {
+	void testMultiQuery() {
 		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
 				PREFIXES,
 				"SELECT * {",
@@ -228,14 +228,14 @@ public class MultiParamTest {
 			while (result.hasNext()) {
 				BindingSet binding = result.next();
 				Value next = binding.getValue("subj");
-				assertTrue("unknown value: " + next, values.remove(next.toString()));
+				assertTrue(values.remove(next.toString()), "unknown value: " + next);
 			}
-			assertTrue("missing value" + values, values.isEmpty());
+			assertTrue(values.isEmpty(), "missing value" + values);
 		}
 	}
 
 	@Test
-	public void testMultiSnippetQuery() {
+	void testMultiSnippetQuery() {
 		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
 				PREFIXES,
 				"SELECT * {",
@@ -265,14 +265,14 @@ public class MultiParamTest {
 				Value snippet1 = bindings.getValue("sp1");
 				Value snippet2 = bindings.getValue("sp2");
 				String obj = next + ":" + snippet1 + ":" + snippet2;
-				assertTrue("unknown value: " + obj, values.remove(obj));
+				assertTrue(values.remove(obj), "unknown value: " + obj);
 			}
-			assertTrue("missing value" + values, values.isEmpty());
+			assertTrue(values.isEmpty(), "missing value" + values);
 		}
 	}
 
 	@Test
-	public void testMultiOrderQuery() {
+	void testMultiOrderQuery() {
 		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
 				PREFIXES,
 				"SELECT * {",
@@ -362,7 +362,7 @@ public class MultiParamTest {
 	}
 
 	@Test
-	public void testMultiOrderSnippetQuery() {
+	void testMultiOrderSnippetQuery() {
 		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
 				PREFIXES,
 				"SELECT * {",
@@ -463,5 +463,14 @@ public class MultiParamTest {
 				fail();
 			}
 		}
+	}
+
+	private static File newFolder(File root, String... subDirs) throws IOException {
+		String subFolder = String.join("/", subDirs);
+		File result = new File(root, subFolder);
+		if (!result.mkdirs()) {
+			throw new IOException("Couldn't create folders " + root);
+		}
+		return result;
 	}
 }

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryOptimisticIsolationTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.memory.config.MemoryStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class MemoryOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 		setRepositoryFactory(new SailRepositoryFactory() {
@@ -31,7 +31,7 @@ public class MemoryOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySparqlAggregatesTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySparqlAggregatesTest.java
@@ -13,17 +13,17 @@ package org.eclipse.rdf4j.sail.memory;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.testsuite.repository.SparqlAggregatesTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class MemorySparqlAggregatesTest extends SparqlAggregatesTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -12,8 +12,8 @@
 package org.eclipse.rdf4j.sail.memory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeOptimisticIsolationTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class NativeOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -30,7 +30,7 @@ public class NativeOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SparqlConstraintTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SparqlConstraintTest.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.rdf4j.sail.shacl;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.StringReader;

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ast/paths/SparqlPathStringTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ast/paths/SparqlPathStringTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.Values;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SparqlPathStringTest {
 
@@ -27,37 +27,37 @@ public class SparqlPathStringTest {
 	public static final IRI PREDICATE3 = Values.iri("http://example.com/predicate3");
 
 	@Test
-	public void simplePath() {
+	void simplePath() {
 		Path path = new SimplePath(PREDICATE);
 		assertEquals("<http://example.com/predicate>", path.toSparqlPathString());
 	}
 
 	@Test
-	public void inversePath() {
+	void inversePath() {
 		Path path = new InversePath(null, new SimplePath(PREDICATE));
 		assertEquals("^<http://example.com/predicate>", path.toSparqlPathString());
 	}
 
 	@Test
-	public void oneOrMorePath() {
+	void oneOrMorePath() {
 		Path path = new OneOrMorePath(null, new SimplePath(PREDICATE));
 		assertEquals("<http://example.com/predicate>+", path.toSparqlPathString());
 	}
 
 	@Test
-	public void zeroOrMore() {
+	void zeroOrMore() {
 		Path path = new ZeroOrMorePath(null, new SimplePath(PREDICATE));
 		assertEquals("<http://example.com/predicate>*", path.toSparqlPathString());
 	}
 
 	@Test
-	public void zeroOrOne() {
+	void zeroOrOne() {
 		Path path = new ZeroOrOnePath(null, new SimplePath(PREDICATE));
 		assertEquals("<http://example.com/predicate>?", path.toSparqlPathString());
 	}
 
 	@Test
-	public void sequencePath() {
+	void sequencePath() {
 		Path path = new SequencePath(null,
 				List.of(new SimplePath(PREDICATE1), new SimplePath(PREDICATE2), new SimplePath(PREDICATE3)));
 		assertEquals(
@@ -66,7 +66,7 @@ public class SparqlPathStringTest {
 	}
 
 	@Test
-	public void alternativePath() {
+	void alternativePath() {
 		Path path = new AlternativePath(null, null,
 				List.of(new SimplePath(PREDICATE1), new SimplePath(PREDICATE2), new SimplePath(PREDICATE3)));
 		assertEquals(
@@ -75,7 +75,7 @@ public class SparqlPathStringTest {
 	}
 
 	@Test
-	public void complexPath() {
+	void complexPath() {
 		Path path = new AlternativePath(null, null,
 				List.of(new SimplePath(PREDICATE1), new SimplePath(PREDICATE2), new SimplePath(PREDICATE3)));
 		path = new SequencePath(null,

--- a/testsuites/lucene/src/main/java/org/eclipse/testsuite/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/testsuite/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.testsuite.rdf4j.sail.lucene;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -39,9 +39,9 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractLuceneSailGeoSPARQLTest {
 
@@ -88,7 +88,7 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 
 	protected abstract void configure(LuceneSail sail);
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		// setup a LuceneSail
 		MemoryStore memoryStore = new MemoryStore();
@@ -121,7 +121,7 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws IOException, RepositoryException {
 		if (repository != null) {
 			repository.shutDown();
@@ -222,7 +222,7 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 	}
 
 	@Test
-	public void testComplexDistanceQueryMathExpr()
+	void testComplexDistanceQueryMathExpr()
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		try (RepositoryConnection connection = repository.getConnection()) {
 			String queryStr = "prefix geo:  <" + GEO.NAMESPACE + ">" + "prefix geof: <" + GEOF.NAMESPACE + ">"
@@ -305,7 +305,7 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 					IRI subj = (IRI) bindings.getValue("matchUri");
 
 					Literal location = expected.remove(subj);
-					assertNotNull("Expected subject: " + subj, location);
+					assertNotNull(location, "Expected subject: " + subj);
 					assertEquals(location.booleanValue(), ((Literal) bindings.getValue("intersects")).booleanValue());
 
 					assertNotNull(bindings.getValue("g"));

--- a/testsuites/lucene/src/main/java/org/eclipse/testsuite/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/testsuite/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
@@ -14,10 +14,10 @@ import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.MATCHES;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.PROPERTY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.QUERY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SCORE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -39,9 +39,9 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractLuceneSailIndexedPropertiesTest {
 
@@ -77,7 +77,7 @@ public abstract class AbstractLuceneSailIndexedPropertiesTest {
 
 	protected abstract void configure(LuceneSail sail);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// setup a LuceneSail
 		MemoryStore memoryStore = new MemoryStore();
@@ -118,7 +118,7 @@ public abstract class AbstractLuceneSailIndexedPropertiesTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws IOException, RepositoryException {
 		if (repository != null) {
 			repository.shutDown();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
@@ -28,8 +28,8 @@ import org.eclipse.rdf4j.testsuite.repository.optimistic.MonotonicTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.RemoveIsolationTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.SerializableTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.SnapshotTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -43,12 +43,12 @@ import org.junit.runners.Suite.SuiteClasses;
 		SerializableTest.class })
 public abstract class OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeadLockTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeadLockTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -22,20 +22,20 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeadLockTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -56,7 +56,7 @@ public class DeadLockTest {
 
 	private IRI REMBRANDT;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(DeadLockTest.class);
 		ValueFactory uf = repo.getValueFactory();
@@ -67,7 +67,7 @@ public class DeadLockTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			a.close();
@@ -81,7 +81,7 @@ public class DeadLockTest {
 	}
 
 	@Test
-	public void test() throws Exception {
+	void test() throws Exception {
 		final CountDownLatch start = new CountDownLatch(2);
 		final CountDownLatch end = new CountDownLatch(2);
 		final CountDownLatch commit = new CountDownLatch(1);

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeleteInsertTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeleteInsertTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
@@ -19,11 +19,11 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that a complex delete-insert SPARQL query gets correctly executed.
@@ -31,12 +31,12 @@ import org.junit.Test;
  */
 public class DeleteInsertTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -51,13 +51,13 @@ public class DeleteInsertTest {
 
 	private final ClassLoader cl = getClass().getClassLoader();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(DeleteInsertTest.class);
 		con = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			con.close();
@@ -67,7 +67,7 @@ public class DeleteInsertTest {
 	}
 
 	@Test
-	public void test() throws Exception {
+	void test() throws Exception {
 		String load = IOUtil.readString(cl.getResource("test/insert-data.ru"));
 		con.prepareUpdate(QueryLanguage.SPARQL, load, NS).execute();
 		con.begin(level);

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -31,11 +31,12 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.UnknownTransactionStateException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,12 +47,12 @@ import org.slf4j.LoggerFactory;
  */
 public class IsolationLevelTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -72,13 +73,13 @@ public class IsolationLevelTest {
 	 * Methods *
 	 *---------*/
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		store = OptimisticIsolationTest.getEmptyInitializedRepository(IsolationLevelTest.class);
 		failed = null;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		store.shutDown();
 	}
@@ -97,25 +98,25 @@ public class IsolationLevelTest {
 	}
 
 	@Test
-	public void testNone() {
+	void testNone() {
 		readPending(IsolationLevels.NONE);
 	}
 
 	@Test
-	public void testReadUncommitted() {
+	void testReadUncommitted() {
 		rollbackTriple(IsolationLevels.READ_UNCOMMITTED);
 		readPending(IsolationLevels.READ_UNCOMMITTED);
 	}
 
 	@Test
-	public void testReadCommitted() throws Exception {
+	void testReadCommitted() throws Exception {
 		readCommitted(IsolationLevels.READ_COMMITTED);
 		rollbackTriple(IsolationLevels.READ_COMMITTED);
 		readPending(IsolationLevels.READ_COMMITTED);
 	}
 
 	@Test
-	public void testSnapshotRead() throws Exception {
+	void testSnapshotRead() throws Exception {
 		if (isSupported(IsolationLevels.SNAPSHOT_READ)) {
 			snapshotRead(IsolationLevels.SNAPSHOT_READ);
 			readCommitted(IsolationLevels.SNAPSHOT_READ);
@@ -127,7 +128,7 @@ public class IsolationLevelTest {
 	}
 
 	@Test
-	public void testSnapshot() throws Exception {
+	void testSnapshot() throws Exception {
 		if (isSupported(IsolationLevels.SNAPSHOT)) {
 			snapshot(IsolationLevels.SNAPSHOT);
 			snapshotRead(IsolationLevels.SNAPSHOT);
@@ -141,7 +142,7 @@ public class IsolationLevelTest {
 	}
 
 	@Test
-	public void testSerializable() throws Exception {
+	void testSerializable() throws Exception {
 
 		if (isSupported(IsolationLevels.SERIALIZABLE)) {
 			serializable(IsolationLevels.SERIALIZABLE);
@@ -480,7 +481,7 @@ public class IsolationLevelTest {
 			}
 			Value obj = stmts.next().getObject();
 			if (stmts.hasNext()) {
-				org.junit.Assert.fail("multiple literals: " + obj + " and " + stmts.next());
+				Assertions.fail("multiple literals: " + obj + " and " + stmts.next());
 			}
 			return (Literal) obj;
 		}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/LinearTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/LinearTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,11 +31,11 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Various tests on linear execution of updates.
@@ -43,12 +43,12 @@ import org.junit.Test;
  */
 public class LinearTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -95,7 +95,7 @@ public class LinearTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(LinearTest.class);
 		lf = repo.getValueFactory();
@@ -119,7 +119,7 @@ public class LinearTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			a.close();
@@ -133,7 +133,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_independentPattern() {
+	void test_independentPattern() {
 		a.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		assertEquals(1, size(a, PICASSO, RDF.TYPE, PAINTER, false));
@@ -147,7 +147,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safePattern() {
+	void test_safePattern() {
 		a.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		assertEquals(1, size(a, null, RDF.TYPE, PAINTER, false));
@@ -158,7 +158,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_afterPattern() {
+	void test_afterPattern() {
 		a.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		assertEquals(1, size(a, null, RDF.TYPE, PAINTER, false));
@@ -170,7 +170,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_afterInsertDataPattern() {
+	void test_afterInsertDataPattern() {
 		a.begin(level);
 		a.prepareUpdate(QueryLanguage.SPARQL, "INSERT DATA { <picasso> a <Painter> }", NS).execute();
 		assertEquals(1, size(a, null, RDF.TYPE, PAINTER, false));
@@ -182,7 +182,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_changedPattern() {
+	void test_changedPattern() {
 		a.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.commit();
@@ -193,7 +193,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeQuery() {
+	void test_safeQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -214,7 +214,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeInsert() {
+	void test_safeInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -233,7 +233,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeOptionalQuery() {
+	void test_safeOptionalQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -257,7 +257,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeOptionalInsert() {
+	void test_safeOptionalInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -276,7 +276,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeFilterQuery() {
+	void test_safeFilterQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -298,7 +298,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeFilterInsert() {
+	void test_safeFilterInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -318,7 +318,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeRangeQuery() {
+	void test_safeRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);
@@ -346,7 +346,7 @@ public class LinearTest {
 	}
 
 	@Test
-	public void test_safeRangeInsert() {
+	void test_safeRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/ModificationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/ModificationTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
@@ -22,20 +22,20 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ModificationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -52,7 +52,7 @@ public class ModificationTest {
 
 	private IRI PICASSO;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(ModificationTest.class);
 		ValueFactory uf = repo.getValueFactory();
@@ -61,7 +61,7 @@ public class ModificationTest {
 		con = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			con.close();
@@ -71,7 +71,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testAdd() {
+	void testAdd() {
 		con.begin(level);
 		con.add(PICASSO, RDF.TYPE, PAINTER);
 		con.commit();
@@ -79,7 +79,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testAutoCommit() {
+	void testAutoCommit() {
 		con.add(PICASSO, RDF.TYPE, PAINTER);
 		con.close();
 		con = repo.getConnection();
@@ -87,7 +87,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testInsertData() {
+	void testInsertData() {
 		con.begin(level);
 		con.prepareUpdate(QueryLanguage.SPARQL, "INSERT DATA { <picasso> a <Painter> }", NS).execute();
 		con.commit();
@@ -95,7 +95,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testInsertDataAutoCommit() {
+	void testInsertDataAutoCommit() {
 		con.prepareUpdate(QueryLanguage.SPARQL, "INSERT DATA { <picasso> a <Painter> }", NS).execute();
 		con.close();
 		con = repo.getConnection();
@@ -103,7 +103,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testRemove() {
+	void testRemove() {
 		con.begin(level);
 		con.add(PICASSO, RDF.TYPE, PAINTER);
 		con.commit();
@@ -114,7 +114,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testAddIn() {
+	void testAddIn() {
 		con.begin(level);
 		con.add(PICASSO, RDF.TYPE, PAINTER, PICASSO);
 		con.commit();
@@ -122,7 +122,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testRemoveFrom() {
+	void testRemoveFrom() {
 		con.begin(level);
 		con.add(PICASSO, RDF.TYPE, PAINTER, PICASSO);
 		con.commit();
@@ -133,7 +133,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testMove() {
+	void testMove() {
 		con.begin(level);
 		con.add(PICASSO, RDF.TYPE, PAINTER, PICASSO);
 		con.commit();
@@ -146,7 +146,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testMoveOut() {
+	void testMoveOut() {
 		con.begin(level);
 		con.add(PICASSO, RDF.TYPE, PAINTER, PICASSO);
 		con.commit();
@@ -159,7 +159,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testCancel() {
+	void testCancel() {
 		con.begin(level);
 		con.add(PICASSO, RDF.TYPE, PAINTER, PICASSO);
 		con.remove(PICASSO, RDF.TYPE, PAINTER, PICASSO);
@@ -168,7 +168,7 @@ public class ModificationTest {
 	}
 
 	@Test
-	public void testRemoveDuplicate() {
+	void testRemoveDuplicate() {
 		con.add(PICASSO, RDF.TYPE, PAINTER, PICASSO, PAINTER);
 		assertTrue(con.hasStatement(PICASSO, RDF.TYPE, PAINTER, false, PAINTER));
 		assertTrue(con.hasStatement(PICASSO, RDF.TYPE, PAINTER, false, PICASSO));

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/MonotonicTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/MonotonicTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,20 +28,20 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MonotonicTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -88,7 +88,7 @@ public class MonotonicTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(MonotonicTest.class);
 		lf = repo.getValueFactory();
@@ -112,7 +112,7 @@ public class MonotonicTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			a.close();
@@ -126,7 +126,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_independentPattern() {
+	void test_independentPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -140,7 +140,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safePattern() {
+	void test_safePattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -151,7 +151,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_afterPattern() {
+	void test_afterPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -163,7 +163,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_afterInsertDataPattern() {
+	void test_afterInsertDataPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.prepareUpdate(QueryLanguage.SPARQL, "INSERT DATA { <picasso> a <Painter> }", NS).execute();
@@ -175,7 +175,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedPattern() {
+	void test_changedPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -187,7 +187,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeQuery() {
+	void test_safeQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -208,7 +208,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeInsert() {
+	void test_safeInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -227,7 +227,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeQuery() {
+	void test_mergeQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -249,7 +249,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeInsert() {
+	void test_mergeInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -269,7 +269,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedQuery() {
+	void test_changedQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -291,7 +291,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedInsert() {
+	void test_changedInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -311,7 +311,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeOptionalQuery() {
+	void test_safeOptionalQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -335,7 +335,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeOptionalInsert() {
+	void test_safeOptionalInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -354,7 +354,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeOptionalQuery() {
+	void test_mergeOptionalQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -379,7 +379,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeOptionalInsert() {
+	void test_mergeOptionalInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -399,7 +399,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedOptionalQuery() {
+	void test_changedOptionalQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -424,7 +424,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedOptionalInsert() {
+	void test_changedOptionalInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -444,7 +444,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeFilterQuery() {
+	void test_safeFilterQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -466,7 +466,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeFilterInsert() {
+	void test_safeFilterInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -486,7 +486,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeOptionalFilterQuery() {
+	void test_mergeOptionalFilterQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -513,7 +513,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeOptionalFilterInsert() {
+	void test_mergeOptionalFilterInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -536,7 +536,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedOptionalFilterQuery() {
+	void test_changedOptionalFilterQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -562,7 +562,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedOptionalFilterInsert() {
+	void test_changedOptionalFilterInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -585,7 +585,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeRangeQuery() {
+	void test_safeRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);
@@ -613,7 +613,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_safeRangeInsert() {
+	void test_safeRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);
@@ -640,7 +640,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeRangeQuery() {
+	void test_mergeRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -669,7 +669,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_mergeRangeInsert() {
+	void test_mergeRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -697,7 +697,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedRangeQuery() {
+	void test_changedRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -726,7 +726,7 @@ public class MonotonicTest {
 	}
 
 	@Test
-	public void test_changedRangeInsert() {
+	void test_changedRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/RemoveIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/RemoveIsolationTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 
@@ -23,11 +23,11 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test isolation behavior on removal operations
@@ -37,12 +37,12 @@ import org.junit.Test;
  */
 public class RemoveIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -55,14 +55,14 @@ public class RemoveIsolationTest {
 
 	private final IsolationLevel level = IsolationLevels.SNAPSHOT_READ;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(RemoveIsolationTest.class);
 		con = repo.getConnection();
 		f = con.getValueFactory();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			con.close();
@@ -72,7 +72,7 @@ public class RemoveIsolationTest {
 	}
 
 	@Test
-	public void testRemoveOptimisticIsolation() {
+	void testRemoveOptimisticIsolation() {
 		con.begin(level);
 
 		con.add(f.createIRI("http://example.org/people/alice"), f.createIRI("http://example.org/ontology/name"),
@@ -89,7 +89,7 @@ public class RemoveIsolationTest {
 	}
 
 	@Test
-	public void testRemoveIsolation() {
+	void testRemoveIsolation() {
 		con.begin(level);
 
 		con.add(f.createIRI("http://example.org/people/alice"), f.createIRI("http://example.org/ontology/name"),

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SerializableTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SerializableTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,11 +32,11 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on behavior of SERIALIZABLE transactions.
@@ -46,12 +46,12 @@ import org.junit.Test;
  */
 public class SerializableTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -98,7 +98,7 @@ public class SerializableTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(SerializableTest.class);
 		lf = repo.getValueFactory();
@@ -122,7 +122,7 @@ public class SerializableTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			a.close();
@@ -136,7 +136,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_independentPattern() {
+	void test_independentPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -150,7 +150,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safePattern() {
+	void test_safePattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -161,7 +161,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void testPrepare_safePattern() {
+	void testPrepare_safePattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -172,7 +172,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_afterPattern() {
+	void test_afterPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -184,7 +184,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_afterInsertDataPattern() {
+	void test_afterInsertDataPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.prepareUpdate(QueryLanguage.SPARQL, "INSERT DATA { <picasso> a <Painter> }", NS).execute();
@@ -196,7 +196,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictPattern() {
+	void test_conflictPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -215,7 +215,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void testPrepare_conflictPattern() {
+	void testPrepare_conflictPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -234,7 +234,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeQuery() {
+	void test_safeQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -256,7 +256,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeInsert() {
+	void test_safeInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -275,7 +275,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictQuery() {
+	void test_conflictQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -305,7 +305,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictInsert() {
+	void test_conflictInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -333,7 +333,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeOptionalQuery() {
+	void test_safeOptionalQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -357,7 +357,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeOptionalInsert() {
+	void test_safeOptionalInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -376,7 +376,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictOptionalQuery() {
+	void test_conflictOptionalQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -408,7 +408,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictOptionalInsert() {
+	void test_conflictOptionalInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -436,7 +436,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeFilterQuery() {
+	void test_safeFilterQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -466,7 +466,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeFilterInsert() {
+	void test_safeFilterInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -494,7 +494,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictOptionalFilterQuery() {
+	void test_conflictOptionalFilterQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -527,7 +527,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictOptionalFilterInsert() {
+	void test_conflictOptionalFilterInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -558,7 +558,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeRangeQuery() {
+	void test_safeRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);
@@ -594,7 +594,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_safeRangeInsert() {
+	void test_safeRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);
@@ -629,7 +629,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictRangeQuery() {
+	void test_conflictRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -665,7 +665,7 @@ public class SerializableTest {
 	}
 
 	@Test
-	public void test_conflictRangeInsert() {
+	void test_conflictRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SnapshotTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SnapshotTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,20 +31,20 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SnapshotTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -91,7 +91,7 @@ public class SnapshotTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(SnapshotTest.class);
 		lf = repo.getValueFactory();
@@ -115,7 +115,7 @@ public class SnapshotTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		try {
 			a.close();
@@ -129,7 +129,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_independentPattern() {
+	void test_independentPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -143,7 +143,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safePattern() {
+	void test_safePattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -154,7 +154,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_afterPattern() {
+	void test_afterPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -166,7 +166,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_afterInsertDataPattern() {
+	void test_afterInsertDataPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.prepareUpdate(QueryLanguage.SPARQL, "INSERT DATA { <picasso> a <Painter> }", NS).execute();
@@ -178,7 +178,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictPattern() {
+	void test_conflictPattern() {
 		a.begin(level);
 		b.begin(level);
 		a.add(PICASSO, RDF.TYPE, PAINTER);
@@ -196,7 +196,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeQuery() {
+	void test_safeQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -217,7 +217,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeInsert() {
+	void test_safeInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -236,7 +236,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeQuery() {
+	void test_mergeQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -258,7 +258,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeInsert() {
+	void test_mergeInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -278,7 +278,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictQuery() {
+	void test_conflictQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -307,7 +307,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictInsert() {
+	void test_conflictInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -334,7 +334,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeOptionalQuery() {
+	void test_safeOptionalQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -358,7 +358,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeOptionalInsert() {
+	void test_safeOptionalInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -377,7 +377,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeOptionalQuery() {
+	void test_mergeOptionalQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -402,7 +402,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeOptionalInsert() {
+	void test_mergeOptionalInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -422,7 +422,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictOptionalQuery() {
+	void test_conflictOptionalQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -454,7 +454,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictOptionalInsert() {
+	void test_conflictOptionalInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
@@ -481,7 +481,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeFilterQuery() {
+	void test_safeFilterQuery() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -503,7 +503,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeFilterInsert() {
+	void test_safeFilterInsert() {
 		b.add(REMBRANDT, RDF.TYPE, PAINTER);
 		b.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		b.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -523,7 +523,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeOptionalFilterQuery() {
+	void test_mergeOptionalFilterQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -549,7 +549,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeOptionalFilterInsert() {
+	void test_mergeOptionalFilterInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -572,7 +572,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictOptionalFilterQuery() {
+	void test_conflictOptionalFilterQuery() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -606,7 +606,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictOptionalFilterInsert() {
+	void test_conflictOptionalFilterInsert() {
 		a.add(PICASSO, RDF.TYPE, PAINTER);
 		a.add(PICASSO, PAINTS, GUERNICA);
 		a.add(PICASSO, PAINTS, JACQUELINE);
@@ -636,7 +636,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeRangeQuery() {
+	void test_safeRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);
@@ -664,7 +664,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_safeRangeInsert() {
+	void test_safeRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
 		a.add(REMBRANDT, PAINTS, DANAE);
@@ -691,7 +691,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeRangeQuery() {
+	void test_mergeRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -720,7 +720,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_mergeRangeInsert() {
+	void test_mergeRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -748,7 +748,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictRangeQuery() {
+	void test_conflictRangeQuery() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);
@@ -784,7 +784,7 @@ public class SnapshotTest {
 	}
 
 	@Test
-	public void test_conflictRangeInsert() {
+	void test_conflictRangeInsert() {
 		a.add(REMBRANDT, RDF.TYPE, PAINTER);
 		a.add(REMBRANDT, PAINTS, NIGHTWATCH);
 		a.add(REMBRANDT, PAINTS, ARTEMISIA);

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
Junit4 is still used in a few places, one for lucene or guavatestlibs that don't have an junit4 equivalent


GitHub issue resolved: #4544 

Briefly describe the changes proposed in this PR:
```sh
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run   \ -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:RELEASE   \
-Drewrite.activeRecipes=org.openrewrite.java.testing.junit5.JUnit4to5Migration
```
Then reverting any module with compiler issues and throwing away all pom changes.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

