### PR TITLE
GH-4854 remove SPI reference to deprecated & removed ForwardChainingRDFSInferencerFactory

### DIFF
--- a/core/sail/inferencer/src/main/resources/META-INF/services/org.eclipse.rdf4j.sail.config.SailFactory
+++ b/core/sail/inferencer/src/main/resources/META-INF/services/org.eclipse.rdf4j.sail.config.SailFactory
@@ -1,5 +1,4 @@
 org.eclipse.rdf4j.sail.inferencer.fc.config.SchemaCachingRDFSInferencerFactory
-org.eclipse.rdf4j.sail.inferencer.fc.config.ForwardChainingRDFSInferencerFactory
 org.eclipse.rdf4j.sail.inferencer.fc.config.DirectTypeHierarchyInferencerFactory
 org.eclipse.rdf4j.sail.inferencer.fc.config.CustomGraphQueryInferencerFactory
 org.eclipse.rdf4j.sail.inferencer.fc.config.DedupingInferencerFactory


### PR DESCRIPTION
GitHub issue resolved: #4854 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

