### PR TITLE
GH-4779 Maintain RDFa support

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
@@ -23,6 +23,8 @@ public class RDFaParserSettings {
 
 	/**
 	 * Boolean setting for parser to determine the RDFa version to use when processing the document.
+         * Note that although these settings are not used within RDF4J, they are in use by external plugins.
+         * @see <a href="https://github.com/eclipse-rdf4j/rdf4j/issues/4779">https://github.com/eclipse-rdf4j/rdf4j/issues/4779</a>
 	 * <p>
 	 * Defaults to {@link RDFaVersion#RDFA_1_0}.
 	 */

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
@@ -26,7 +26,6 @@ public class RDFaParserSettings {
 	 * <p>
 	 * Defaults to {@link RDFaVersion#RDFA_1_0}.
 	 */
-	@Deprecated(since = "4.3.0", forRemoval = true)
 	public static final RioSetting<RDFaVersion> RDFA_COMPATIBILITY = new RioSettingImpl<>(
 			"org.eclipse.rdf4j.rio.rdfa.version", "RDFa Version Compatibility", RDFaVersion.RDFA_1_0);
 

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
@@ -22,11 +22,13 @@ import org.eclipse.rdf4j.rio.RioSetting;
 public class RDFaParserSettings {
 
 	/**
-	 * Boolean setting for parser to determine the RDFa version to use when processing the document.
-         * Note that although these settings are not used within RDF4J, they are in use by external plugins.
-         * @see <a href="https://github.com/eclipse-rdf4j/rdf4j/issues/4779">https://github.com/eclipse-rdf4j/rdf4j/issues/4779</a>
-	 * <p>
-	 * Defaults to {@link RDFaVersion#RDFA_1_0}.
+	 * Boolean setting for parser to determine the RDFa version to use when processing the document. Note that although
+	 * these settings are not used within RDF4J, they are in use by external plugins.
+	 *
+	 * @see <a href=
+	 *      "https://github.com/eclipse-rdf4j/rdf4j/issues/4779">https://github.com/eclipse-rdf4j/rdf4j/issues/4779</a>
+	 *      <p>
+	 *      Defaults to {@link RDFaVersion#RDFA_1_0}.
 	 */
 	public static final RioSetting<RDFaVersion> RDFA_COMPATIBILITY = new RioSettingImpl<>(
 			"org.eclipse.rdf4j.rio.rdfa.version", "RDFa Version Compatibility", RDFaVersion.RDFA_1_0);

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaVersion.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaVersion.java
@@ -15,7 +15,6 @@ package org.eclipse.rdf4j.rio.helpers;
  *
  * @author Peter Ansell
  */
-@Deprecated(since = "4.3.0", forRemoval = true)
 public enum RDFaVersion {
 
 	/**

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaVersion.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaVersion.java
@@ -12,6 +12,8 @@ package org.eclipse.rdf4j.rio.helpers;
 
 /**
  * Enumeration for tracking versions of the RDFa specification to specify processing capabilities of RDFa modules.
+ * Note that although these settings are not used within RDF4J, they are in use by external plugins.
+ * @see <a href="https://github.com/eclipse-rdf4j/rdf4j/issues/4779">https://github.com/eclipse-rdf4j/rdf4j/issues/4779</a>
  *
  * @author Peter Ansell
  */

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaVersion.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaVersion.java
@@ -11,9 +11,11 @@
 package org.eclipse.rdf4j.rio.helpers;
 
 /**
- * Enumeration for tracking versions of the RDFa specification to specify processing capabilities of RDFa modules.
- * Note that although these settings are not used within RDF4J, they are in use by external plugins.
- * @see <a href="https://github.com/eclipse-rdf4j/rdf4j/issues/4779">https://github.com/eclipse-rdf4j/rdf4j/issues/4779</a>
+ * Enumeration for tracking versions of the RDFa specification to specify processing capabilities of RDFa modules. Note
+ * that although these settings are not used within RDF4J, they are in use by external plugins.
+ *
+ * @see <a href=
+ *      "https://github.com/eclipse-rdf4j/rdf4j/issues/4779">https://github.com/eclipse-rdf4j/rdf4j/issues/4779</a>
  *
  * @author Peter Ansell
  */


### PR DESCRIPTION
GitHub issue resolved: #4779 

Briefly describe the changes proposed in this PR:

This flag is not ready for deprecation as it is used by 3rd party plugins. It would be good to set up an alternative mechanism for providing this support before this is deprecated. See #4779 for details.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

