### PR TITLE
GH-4859 Add instead of remove QueryRoot for explaining optimized Sail queries

### DIFF
--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailQuery.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailQuery.java
@@ -43,12 +43,12 @@ public abstract class SailQuery extends AbstractParserQuery {
 
 		TupleExpr tupleExpr = getParsedQuery().getTupleExpr();
 
-		// That query has a root does not add to the explanation.
-		if (tupleExpr instanceof QueryRoot) {
-			tupleExpr = ((QueryRoot) tupleExpr).getArg();
+		if (!(tupleExpr instanceof QueryRoot)) {
+			// Add a dummy root node to the tuple expressions to allow optimizers to modify the actual root node
+			tupleExpr = new QueryRoot(tupleExpr);
 		}
-		SailConnection sailCon = getConnection().getSailConnection();
 
+		SailConnection sailCon = getConnection().getSailConnection();
 		return sailCon.explain(level, tupleExpr, getActiveDataset(), getBindings(), getIncludeInferred(), timeout);
 
 	}

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
@@ -10,8 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -24,7 +26,9 @@ import org.eclipse.rdf4j.query.BooleanQuery;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.Query;
 import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.explanation.Explanation;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,6 +150,23 @@ public class SailRepositoryConnectionTest {
 		query.evaluate();
 		// check that the TupleExpr implementation created by the underlying sail was passed to the evaluation
 		verify(sailConnection).evaluate(eq(expr), any(), any(), anyBoolean());
+	}
+
+	@Test
+	public void testExplainQuery() {
+		TupleExpr expr = mock(TupleExpr.class);
+		when(expr.clone()).thenReturn(expr);
+		Explanation explanation = mock(Explanation.class);
+
+		when(sailConnection.prepareQuery(any(), any(), any(), any())).thenReturn(Optional.of(expr));
+		when(sailConnection.explain(any(), any(TupleExpr.class), any(), any(), anyBoolean(), anyInt()))
+				.thenReturn(explanation);
+
+		TupleQuery query = subject.prepareTupleQuery("SELECT * WHERE { ?s ?p ?o }");
+		assertThat(query.explain(Explanation.Level.Unoptimized)).isEqualTo(explanation);
+
+		verify(sailConnection).explain(eq(Explanation.Level.Unoptimized), any(QueryRoot.class), any(), any(),
+				anyBoolean(), anyInt());
 	}
 
 }

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -919,15 +919,10 @@ public class QueryPlanRetrievalTest {
 	@Test
 	public void testWildcard() {
 
-		String expected = "Projection\n" +
-				"╠══ ProjectionElemList\n" +
-				"║     ProjectionElem \"a\"\n" +
-				"║     ProjectionElem \"b\"\n" +
-				"║     ProjectionElem \"c\"\n" +
-				"╚══ StatementPattern (resultSizeEstimate=12)\n" +
-				"      s: Var (name=a)\n" +
-				"      p: Var (name=b)\n" +
-				"      o: Var (name=c)\n";
+		String expected = "StatementPattern (resultSizeEstimate=12)\n" +
+				"   s: Var (name=a)\n" +
+				"   p: Var (name=b)\n" +
+				"   o: Var (name=c)\n";
 		SailRepository sailRepository = new SailRepository(new MemoryStore());
 		addData(sailRepository);
 


### PR DESCRIPTION
GitHub issue resolved: #4859

Briefly describe the changes proposed in this PR:

This change adds instead of removes `QueryRoot` in `SailQuery#explain` to support explanations of queries of which the root `TupleExpr` is replaced.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

