### PR TITLE
GH-4592 allow users to see variables used in compliance tests

### DIFF
--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL10QueryComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL10QueryComplianceTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -21,28 +20,26 @@ import org.junit.jupiter.api.TestFactory;
  * A test suite that runs the W3C Approved SPARQL 1.0 query tests.
  *
  * @author Jeen Broekstra
- *
  * @see <a href="https://www.w3.org/2009/sparql/docs/tests/">sparql docs test</a>
  */
 public abstract class SPARQL10QueryComplianceTest extends SPARQLQueryComplianceTest {
 
-	private final List<String> defaultIgnoredTests = new ArrayList<>();
-	{
-		// incompatible with SPARQL 1.1 - syntax for decimals was modified
-		defaultIgnoredTests.add("Basic - Term 6");
-		// incompatible with SPARQL 1.1 - syntax for decimals was modified
-		defaultIgnoredTests.add("Basic - Term 7");
-		// Test is incorrect: assumes timezoned date is comparable with non-timezoned
-		defaultIgnoredTests.add("date-2");
-		// Incompatible with SPARQL 1.1 - string-typed literals and plain literals are
-		// identical
-		defaultIgnoredTests.add("Strings: Distinct");
-		// Incompatible with SPARQL 1.1 - string-typed literals and plain literals are
-		// identical
-		defaultIgnoredTests.add("All: Distinct");
-		// Incompatible with SPARQL 1.1 - string-typed literals and plain literals are
-		// identical
-		defaultIgnoredTests.add("SELECT REDUCED ?x with strings");
+	private static final String[] defaultIgnoredTests = {
+			// incompatible with SPARQL 1.1 - syntax for decimals was modified
+			"Basic - Term 6",
+			// incompatible with SPARQL 1.1 - syntax for decimals was modified
+			"Basic - Term 7",
+			// Test is incorrect: assumes timezoned date is comparable with non-timezoned
+			"date-2",
+			// Incompatible with SPARQL 1.1 - string-typed literals and plain literals are
+			// identical
+			"Strings: Distinct",
+			// Incompatible with SPARQL 1.1 - string-typed literals and plain literals are
+			// identical
+			"All: Distinct",
+			// Incompatible with SPARQL 1.1 - string-typed literals and plain literals are
+			// identical
+			"SELECT REDUCED ?x with strings"
 	};
 
 	public SPARQL10QueryComplianceTest() {

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11QueryComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11QueryComplianceTest.java
@@ -20,15 +20,15 @@ import org.junit.jupiter.api.TestFactory;
  * A test suite that runs the W3C Approved SPARQL 1.1 query tests.
  *
  * @author Jeen Broekstra
- *
  * @see <a href="https://www.w3.org/2009/sparql/docs/tests/">sparql docs tests</a>
  */
 public abstract class SPARQL11QueryComplianceTest extends SPARQLQueryComplianceTest {
 
 	public SPARQL11QueryComplianceTest() {
 		super(List.of("service"));
-		for (String ig : defaultIgnoredTests)
+		for (String ig : defaultIgnoredTests) {
 			addIgnoredTest(ig);
+		}
 	}
 
 	private static final String[] defaultIgnoredTests = {

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11SyntaxComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11SyntaxComplianceTest.java
@@ -17,7 +17,6 @@ import org.eclipse.rdf4j.query.parser.ParsedOperation;
  * A test suite that runs the W3C Approved SPARQL 1.1 Syntax tests.
  *
  * @author Jeen Broekstra
- *
  * @see <a href="https://www.w3.org/2009/sparql/docs/tests/">sparql docs tests</a>
  */
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11UpdateComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11UpdateComplianceTest.java
@@ -383,8 +383,9 @@ public abstract class SPARQL11UpdateComplianceTest extends SPARQLComplianceTest 
 						DynamicSPARQL11UpdateComplianceTest ds11ut = new DynamicSPARQL11UpdateComplianceTest(
 								displayName, testURI.stringValue(), testName, requestFile.stringValue(),
 								defaultGraphURI, inputNamedGraphs, resultDefaultGraphURI, resultNamedGraphs);
-						if (!shouldIgnoredTest(testName))
+						if (!shouldIgnoredTest(testName)) {
 							tests.add(DynamicTest.dynamicTest(displayName, ds11ut::test));
+						}
 					}
 				}
 			}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL12QueryComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL12QueryComplianceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.TestFactory;
  * A test suite that runs the SPARQL 1.2 community group's query tests.
  *
  * @author Jeen Broekstra
- *
  * @see <a href="https://github.com/w3c/sparql-12/">sparql 1.2</a>
  */
 public abstract class SPARQL12QueryComplianceTest extends SPARQLQueryComplianceTest {
@@ -31,8 +30,9 @@ public abstract class SPARQL12QueryComplianceTest extends SPARQLQueryComplianceT
 
 	public SPARQL12QueryComplianceTest() {
 		super(excludedSubdirs);
-		for (String ig : defaultIgnoredTests)
+		for (String ig : defaultIgnoredTests) {
 			addIgnoredTest(ig);
+		}
 	}
 
 	@TestFactory

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLComplianceTest.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
  * Base functionality for SPARQL compliance test suites using a W3C-style Manifest.
  *
  * @author Jeen Broekstra
- *
  */
 public abstract class SPARQLComplianceTest {
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
@@ -233,8 +233,9 @@ public abstract class SPARQLSyntaxComplianceTest extends SPARQLComplianceTest {
 						DynamicSPARQLSyntaxComplianceTest ds11ut = new DynamicSPARQLSyntaxComplianceTest(displayName,
 								testURI.stringValue(), testName, action.stringValue(),
 								positiveTest);
-						if (!shouldIgnoredTest(testName))
+						if (!shouldIgnoredTest(testName)) {
 							tests.add(DynamicTest.dynamicTest(displayName, ds11ut::test));
+						}
 					}
 				}
 


### PR DESCRIPTION
GitHub issue resolved: #4592 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - allow users to see variables used in compliance tests

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

