### PR TITLE
GH-4899 Introduce MapDB3 backed queue to the MapDb3CollectionFactory

### DIFF
--- a/core/collection-factory/mapdb3/src/main/java/org/eclipse/rdf4j/collection/factory/mapdb/MapDb3CollectionFactory.java
+++ b/core/collection-factory/mapdb3/src/main/java/org/eclipse/rdf4j/collection/factory/mapdb/MapDb3CollectionFactory.java
@@ -184,9 +184,9 @@ public class MapDb3CollectionFactory implements CollectionFactory {
 		if (iterationCacheSyncThreshold > 0) {
 			init();
 			Serializer<T> serializer = createAnySerializer();
-			MemoryTillSizeXSet<T> set = new MemoryTillSizeXSet<T>(colectionId++, delegate.createSet(), serializer,
+			MemoryTillSizeXSet<T> set = new MemoryTillSizeXSet<>(colectionId++, delegate.createSet(), serializer,
 					DEFAULT_SWITCH_TO_DISK_BASED_SET_AT_SIZE);
-			return new CommitingSet<T>(set, iterationCacheSyncThreshold, db);
+			return new CommitingSet<>(set, iterationCacheSyncThreshold, db);
 		} else {
 			return delegate.createSet();
 		}
@@ -199,7 +199,7 @@ public class MapDb3CollectionFactory implements CollectionFactory {
 			Serializer<Value> serializer = createValueSerializer();
 			Set<Value> set = new MemoryTillSizeXSet<>(colectionId++, delegate.createValueSet(), serializer,
 					DEFAULT_SWITCH_TO_DISK_BASED_SET_AT_SIZE);
-			return new CommitingSet<Value>(set, iterationCacheSyncThreshold, db);
+			return new CommitingSet<>(set, iterationCacheSyncThreshold, db);
 		} else {
 			return delegate.createValueSet();
 		}

--- a/core/collection-factory/mapdb3/src/test/java/org/eclipse/rdf4j/collection/factory/mapdb/MapDb3CollectionFactoryTest.java
+++ b/core/collection-factory/mapdb3/src/test/java/org/eclipse/rdf4j/collection/factory/mapdb/MapDb3CollectionFactoryTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.collection.factory.mapdb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+import org.junit.jupiter.api.Test;
+
+public class MapDb3CollectionFactoryTest {
+
+	@Test
+	void queuOfferAnd() {
+		try (MapDb3CollectionFactory mapDb3CollectionFactory = new MapDb3CollectionFactory(1)) {
+			Queue<String> q = mapDb3CollectionFactory.createQueue();
+			int size = 1024;
+			for (int i = 0; i < size; i++) {
+				assertTrue(q.offer(Integer.toString(i)));
+			}
+			assertEquals(size, q.size());
+			for (int i = 0; i < size; i++) {
+				String p = q.peek();
+				assertEquals(p, Integer.toString(i));
+				String p2 = q.peek();
+				assertEquals(p2, Integer.toString(i));
+				String s = q.poll();
+				assertEquals(s, Integer.toString(i));
+			}
+			assertEquals(0, q.size());
+		}
+	}
+
+	@Test
+	void iterator() {
+		try (MapDb3CollectionFactory mapDb3CollectionFactory = new MapDb3CollectionFactory(1)) {
+			Queue<String> q = mapDb3CollectionFactory.createQueue();
+			int size = 1024;
+			for (int i = 0; i < size; i++) {
+				assertTrue(q.offer(Integer.toString(i)));
+			}
+			assertEquals(size, q.size());
+			Iterator<String> iter = q.iterator();
+			for (int i = 0; i < size; i++) {
+				assertTrue(iter.hasNext());
+				assertEquals(iter.next(), Integer.toString(i));
+			}
+			assertFalse(iter.hasNext());
+			assertEquals(size, q.size());
+			try {
+				iter.next();
+				fail();
+			} catch (NoSuchElementException e) {
+				assertNotNull(e);
+			}
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.collection.factory.api.CollectionFactory;
+import org.eclipse.rdf4j.collection.factory.impl.DefaultCollectionFactory;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
@@ -27,7 +28,7 @@ public class StrictEvaluationStrategyFactory extends AbstractEvaluationStrategyF
 		implements FederatedServiceResolverClient {
 
 	private FederatedServiceResolver serviceResolver;
-	protected Supplier<CollectionFactory> collectionFactorySupplier;
+	protected Supplier<CollectionFactory> collectionFactorySupplier = DefaultCollectionFactory::new;
 
 	public StrictEvaluationStrategyFactory() {
 	}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 
+import org.eclipse.rdf4j.collection.factory.api.CollectionFactory;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
 import org.eclipse.rdf4j.model.Value;
@@ -68,6 +69,8 @@ public class PathIteration extends LookAheadIteration<BindingSet> {
 
 	private final Set<String> namedIntermediateJoins = new HashSet<>();
 
+	private final CollectionFactory collectionFactory;
+
 	public PathIteration(EvaluationStrategy strategy, Scope scope, Var startVar,
 			TupleExpr pathExpression, Var endVar, Var contextVar, long minLength, BindingSet bindings)
 			throws QueryEvaluationException {
@@ -85,9 +88,10 @@ public class PathIteration extends LookAheadIteration<BindingSet> {
 		this.currentLength = minLength;
 		this.bindings = bindings;
 
-		this.reportedValues = strategy.makeSet();
-		this.unreportedValues = strategy.makeSet();
-		this.valueQueue = strategy.makeQueue();
+		collectionFactory = strategy.getCollectionFactory().get();
+		this.reportedValues = collectionFactory.createSet();
+		this.unreportedValues = collectionFactory.createSet();
+		this.valueQueue = collectionFactory.createQueue();
 
 		createIteration();
 	}
@@ -218,7 +222,7 @@ public class PathIteration extends LookAheadIteration<BindingSet> {
 		if (currentIter != null) {
 			currentIter.close();
 		}
-
+		collectionFactory.close();
 	}
 
 	/**


### PR DESCRIPTION
GitHub issue resolved: #4899 

Briefly describe the changes proposed in this PR:

Introduce a new MapDb3 backed queue implementation to the MapDb3CollectionFactory. This spills to disk onze the queue reaches size 128. The queue is backed by a map and a small class which keeps a pointer to the tail and head. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [X] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

