### PR TITLE
GH-4913 downgrade to java 17 for main/develop status checks to allow some older elasticsearch tests to pass

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [11, 21]
+        jdk: [11, 17]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main-status.yml
+++ b/.github/workflows/main-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [11, 21]
+        jdk: [11, 17]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
GitHub issue resolved: #4913 <!-- add a Github issue number here, e.g #123. -->

GH-4913 downgrade to java 17 for main/develop status checks to allow some older elasticsearch tests to pass

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

