### PR TITLE
GH-4915 Fixed setting parent in ValueExprTripleRef#replaceChildNode

### DIFF
--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ValueExprTripleRef.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ValueExprTripleRef.java
@@ -20,13 +20,9 @@ public class ValueExprTripleRef extends AbstractQueryModelNode implements ValueE
 
 	public ValueExprTripleRef(String extName, Var s, Var p, Var o) {
 		this.exprVarName = extName;
-		subjectVar = s;
-		predicateVar = p;
-		objectVar = o;
-
-		subjectVar.setParentNode(this);
-		predicateVar.setParentNode(this);
-		objectVar.setParentNode(this);
+		setSubjectVar(s);
+		setPredicateVar(p);
+		setObjectVar(o);
 	}
 
 	public String getExtVarName() {
@@ -43,6 +39,21 @@ public class ValueExprTripleRef extends AbstractQueryModelNode implements ValueE
 
 	public Var getObjectVar() {
 		return objectVar;
+	}
+
+	private void setSubjectVar(Var s) {
+		subjectVar = s;
+		subjectVar.setParentNode(this);
+	}
+
+	private void setPredicateVar(Var p) {
+		predicateVar = p;
+		predicateVar.setParentNode(this);
+	}
+
+	private void setObjectVar(Var o) {
+		objectVar = o;
+		objectVar.setParentNode(this);
 	}
 
 	@Override
@@ -84,17 +95,16 @@ public class ValueExprTripleRef extends AbstractQueryModelNode implements ValueE
 	@Override
 	public <X extends Exception> void visit(QueryModelVisitor<X> visitor) throws X {
 		visitor.meetOther(this);
-		// visitChildren(visitor);
 	}
 
 	@Override
 	public void replaceChildNode(QueryModelNode current, QueryModelNode replacement) {
 		if (subjectVar == current) {
-			subjectVar = (Var) replacement;
+			setSubjectVar((Var) replacement);
 		} else if (predicateVar == current) {
-			predicateVar = (Var) replacement;
+			setPredicateVar((Var) replacement);
 		} else if (objectVar == current) {
-			objectVar = (Var) replacement;
+			setObjectVar((Var) replacement);
 		} else {
 			super.replaceChildNode(current, replacement);
 		}


### PR DESCRIPTION
GitHub issue resolved: #4915 

Briefly describe the changes proposed in this PR:

`ValueExprTripleRef#replaceChildNode` now sets itself as parent on the replacement.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

