### PR TITLE
GH-4923 Spaces inserted by PropertyPathBuilder cause problems with AllegroGraph

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/InversePath.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/InversePath.java
@@ -22,7 +22,8 @@ public class InversePath implements PropertyPath {
 		this.path = path;
 	}
 
+	@Override
 	public String getQueryString() {
-		return "^ " + path.getQueryString();
+		return "^" + path.getQueryString();
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/InversePredicatePath.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/InversePredicatePath.java
@@ -33,6 +33,6 @@ public class InversePredicatePath implements PredicatePathOrInversePredicatePath
 
 	@Override
 	public String getQueryString() {
-		return "^ " + predicate.getQueryString();
+		return "^" + predicate.getQueryString();
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/NegatedPropertySet.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/NegatedPropertySet.java
@@ -30,12 +30,12 @@ public class NegatedPropertySet implements PropertyPath {
 	@Override
 	public String getQueryString() {
 		if (properties.length == 1) {
-			return "! " + properties[0].getQueryString();
+			return "!" + properties[0].getQueryString();
 		} else {
 			return Arrays
 					.stream(properties)
 					.map(QueryElement::getQueryString)
-					.collect(Collectors.joining(" | ", "! ( ", " )"));
+					.collect(Collectors.joining(" | ", "!( ", " )"));
 		}
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/OneOrMorePath.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/OneOrMorePath.java
@@ -24,6 +24,6 @@ public class OneOrMorePath implements PropertyPath {
 
 	@Override
 	public String getQueryString() {
-		return path.getQueryString() + " +";
+		return path.getQueryString() + "+";
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/ZeroOrMorePath.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/ZeroOrMorePath.java
@@ -24,6 +24,6 @@ public class ZeroOrMorePath implements PropertyPath {
 
 	@Override
 	public String getQueryString() {
-		return path.getQueryString() + " *";
+		return path.getQueryString() + "*";
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/ZeroOrOnePath.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/ZeroOrOnePath.java
@@ -24,6 +24,6 @@ public class ZeroOrOnePath implements PropertyPath {
 
 	@Override
 	public String getQueryString() {
-		return path.getQueryString() + " ?";
+		return path.getQueryString() + "?";
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/PropertyPathTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/PropertyPathTest.java
@@ -122,7 +122,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.inv()
 				.build();
-		assertEquals("^ ( <" + RDFS.COMMENT + "> )", p.getQueryString());
+		assertEquals("^( <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -131,7 +131,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.oneOrMore()
 				.build();
-		assertEquals("<" + RDFS.COMMENT + "> +", p.getQueryString());
+		assertEquals("<" + RDFS.COMMENT + ">+", p.getQueryString());
 	}
 
 	@Test
@@ -140,7 +140,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.zeroOrMore()
 				.build();
-		assertEquals("<" + RDFS.COMMENT + "> *", p.getQueryString());
+		assertEquals("<" + RDFS.COMMENT + ">*", p.getQueryString());
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.zeroOrOne()
 				.build();
-		assertEquals("<" + RDFS.COMMENT + "> ?", p.getQueryString());
+		assertEquals("<" + RDFS.COMMENT + ">?", p.getQueryString());
 	}
 
 	@Test
@@ -159,7 +159,7 @@ public class PropertyPathTest {
 				.negProp()
 				.pred(iri(RDFS.COMMENT))
 				.build();
-		assertEquals("! <" + RDFS.COMMENT + ">", p.getQueryString());
+		assertEquals("!<" + RDFS.COMMENT + ">", p.getQueryString());
 	}
 
 	@Test
@@ -169,7 +169,7 @@ public class PropertyPathTest {
 				.negProp()
 				.invPred(iri(RDFS.COMMENT))
 				.build();
-		assertEquals("! ^ <" + RDFS.COMMENT + ">", p.getQueryString());
+		assertEquals("!^<" + RDFS.COMMENT + ">", p.getQueryString());
 	}
 
 	@Test
@@ -180,7 +180,7 @@ public class PropertyPathTest {
 				.invPred(iri(RDFS.COMMENT))
 				.invPred(iri(RDFS.LABEL))
 				.build();
-		assertEquals("! ( ^ <" + RDFS.COMMENT + "> | ^ <" + RDFS.LABEL + "> )", p.getQueryString());
+		assertEquals("!( ^<" + RDFS.COMMENT + "> | ^<" + RDFS.LABEL + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -193,7 +193,7 @@ public class PropertyPathTest {
 				.invPred(iri(RDFS.SUBPROPERTYOF))
 				.pred(iri(RDFS.COMMENT))
 				.build();
-		assertEquals("! ( ^ <" + RDFS.SUBCLASSOF + "> | <" + RDFS.LABEL + "> | ^ <" + RDFS.SUBPROPERTYOF
+		assertEquals("!( ^<" + RDFS.SUBCLASSOF + "> | <" + RDFS.LABEL + "> | ^<" + RDFS.SUBPROPERTYOF
 				+ "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #4923

Briefly describe the changes proposed in this PR:

- Removed spaces after prefix operators and before postfix operators

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

