### PR TITLE
GH-3654 reverted removal of generalized rdf

### DIFF
--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -14,6 +14,9 @@ import static org.eclipse.rdf4j.model.util.Values.bnode;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYTYPE;
 
+import java.util.Arrays;
+import java.util.Set;
+
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
@@ -112,7 +115,8 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()
 						.get(typeLit.getLabel())
 						.orElseThrow(() -> new RepositoryConfigException(
-								"Unsupported repository type: " + typeLit.getLabel()));
+								"Unsupported repository type: '" + typeLit.getLabel() + "' supported types are: "
+										+ Arrays.toString(RepositoryRegistry.getInstance().getKeys().toArray())));
 
 				RepositoryImplConfig implConfig = factory.getConfig();
 				implConfig.parse(model, resource);

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDSettings.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDSettings.java
@@ -113,6 +113,21 @@ public class JSONLDSettings {
 			"org.eclipse.rdf4j.rio.jsonld.hierarchical_view", "Hierarchical representation of the JSON", Boolean.FALSE);
 
 	/**
+	 * If set to true, the JSON-LD processor may emit blank nodes for triple predicates, otherwise they will be omitted.
+	 * <p>
+	 * Note: the use of blank node identifiers to label properties is obsolete, and may be removed in a future version
+	 * of JSON-LD,
+	 * <p>
+	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.jsonld.produce_generalized_rdf}.
+	 *
+	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
+	 */
+	public static final RioSetting<Boolean> PRODUCE_GENERALIZED_RDF = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.jsonld.produce_generalized_rdf", "Produce generalized RDF", Boolean.FALSE);
+
+	/**
 	 * Private default constructor.
 	 */
 	private JSONLDSettings() {

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -156,6 +156,7 @@ public class JSONLDWriter extends AbstractRDFWriter implements CharSink {
 			opts.setCompactArrays(writerConfig.get(JSONLDSettings.COMPACT_ARRAYS));
 			opts.setUseRdfType(writerConfig.get(JSONLDSettings.USE_RDF_TYPE));
 			opts.setUseNativeTypes(writerConfig.get(JSONLDSettings.USE_NATIVE_TYPES));
+			opts.setProduceGeneralizedRdf(writerConfig.get(JSONLDSettings.PRODUCE_GENERALIZED_RDF));
 			opts.setUriValidation(false);
 			opts.setExceptionOnWarning(writerConfig.get(JSONLDSettings.EXCEPTION_ON_WARNING));
 
@@ -393,6 +394,7 @@ public class JSONLDWriter extends AbstractRDFWriter implements CharSink {
 		result.add(JSONLDSettings.JSONLD_MODE);
 		result.add(JSONLDSettings.USE_RDF_TYPE);
 		result.add(JSONLDSettings.USE_NATIVE_TYPES);
+		result.add(JSONLDSettings.PRODUCE_GENERALIZED_RDF);
 		result.add(JSONLDSettings.EXCEPTION_ON_WARNING);
 
 		return result;

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriter.java
@@ -14,6 +14,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -126,14 +127,6 @@ public class NDJSONLDWriter extends AbstractRDFWriter {
 
 	@Override
 	public Collection<RioSetting<?>> getSupportedSettings() {
-		Collection<RioSetting<?>> result = new HashSet<>(Arrays.asList(
-				BasicWriterSettings.BASE_DIRECTIVE,
-				JSONLDSettings.COMPACT_ARRAYS,
-				JSONLDSettings.HIERARCHICAL_VIEW,
-				JSONLDSettings.JSONLD_MODE,
-				JSONLDSettings.USE_RDF_TYPE,
-				JSONLDSettings.USE_NATIVE_TYPES
-		));
-		return result;
+		return new JSONLDWriter(new StringWriter()).getSupportedSettings();
 	}
 }

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
@@ -121,6 +121,7 @@ public class JSONLDWriterBackgroundTest extends RDFWriterTest {
 				BasicWriterSettings.PRETTY_PRINT,
 				JSONLDSettings.COMPACT_ARRAYS,
 				JSONLDSettings.JSONLD_MODE,
+				JSONLDSettings.PRODUCE_GENERALIZED_RDF,
 				JSONLDSettings.USE_RDF_TYPE,
 				JSONLDSettings.USE_NATIVE_TYPES,
 				JSONLDSettings.EXCEPTION_ON_WARNING

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
@@ -245,6 +245,7 @@ public class JSONLDWriterTest extends RDFWriterTest {
 				BasicWriterSettings.PRETTY_PRINT,
 				JSONLDSettings.COMPACT_ARRAYS,
 				JSONLDSettings.JSONLD_MODE,
+				JSONLDSettings.PRODUCE_GENERALIZED_RDF,
 				JSONLDSettings.USE_RDF_TYPE,
 				JSONLDSettings.USE_NATIVE_TYPES,
 				JSONLDSettings.EXCEPTION_ON_WARNING

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterTest.java
@@ -52,11 +52,13 @@ public class NDJSONLDWriterTest extends RDFWriterTest {
 	protected RioSetting<?>[] getExpectedSupportedSettings() {
 		return new RioSetting[] {
 				BasicWriterSettings.BASE_DIRECTIVE,
+				BasicWriterSettings.PRETTY_PRINT,
 				JSONLDSettings.COMPACT_ARRAYS,
-				JSONLDSettings.HIERARCHICAL_VIEW,
 				JSONLDSettings.JSONLD_MODE,
+				JSONLDSettings.PRODUCE_GENERALIZED_RDF,
 				JSONLDSettings.USE_RDF_TYPE,
-				JSONLDSettings.USE_NATIVE_TYPES
+				JSONLDSettings.USE_NATIVE_TYPES,
+				JSONLDSettings.EXCEPTION_ON_WARNING
 		};
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #3654 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

