### PR TITLE
GH-4401 bug fix for configuration handling with new vocab

### DIFF
--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
@@ -276,9 +276,9 @@ public class LocalRepositoryManager extends RepositoryManager {
 					throw new RepositoryConfigException("Wrong repository ID in configuration: " + configFile);
 				}
 				var config = RepositoryConfigUtil.getRepositoryConfig(model, repositoryID);
-				if (Configurations.hasLegacyConfiguration(model) && !Configurations.useLegacyConfig()) {
-					logger.warn("configuration for {} uses legacy vocabulary, converting.", id);
-					addRepositoryConfig(config);
+				if (Configurations.hasLegacyConfiguration(model) && !Configurations.useLegacyConfig()
+						&& config != null) {
+					migrateToNewConfigVocabulary(config);
 				}
 				return config;
 			} catch (IOException e) {
@@ -286,6 +286,19 @@ public class LocalRepositoryManager extends RepositoryManager {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Migrate a repository configuration from the legacy vocabulary to the new vocabulary in
+	 * {@link org.eclipse.rdf4j.model.vocabulary.CONFIG}.
+	 * <p>
+	 * Override this method to provide custom migration logic.
+	 *
+	 * @param config
+	 */
+	protected void migrateToNewConfigVocabulary(RepositoryConfig config) {
+		logger.warn("Configuration for {} uses legacy vocabulary, converting.", config.getID());
+		addRepositoryConfig(config);
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #4401 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

