### PR TITLE
GH-4950 LMDB: extensible ID scheme

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -602,9 +602,18 @@ class TripleStore implements Closeable {
 									it.remove();
 									continue;
 								}
-								if (component != 2 && (id & 1) == 1) {
-									// id is a literal and can only appear in object position
-									continue;
+								if (component != 2) {
+									// optimization: ensure that literals are only tested if they appear in object
+									// position
+									switch (ValueIds.getIdType(id)) {
+									case ValueIds.T_URI:
+									case ValueIds.T_BNODE:
+									case ValueIds.T_TRIPLE:
+										// fall through
+									default:
+										// id is a literal, do not test it
+										continue;
+									}
 								}
 
 								long subj = c == 0 ? id : -1, pred = c == 1 ? id : -1,

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueIds.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueIds.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+/**
+ * Constants and functions for working with ids encoded into long values.
+ */
+public class ValueIds {
+	/**
+	 * Pointer to an arbitrary value in the value store. This is not used as RDF value.
+	 */
+	public static final int T_PTR = 0;
+
+	/** Reference to a URI */
+	public static final int T_URI = 1;
+	/** Reference to a literal */
+	public static final int T_LITERAL = 2;
+	/** Reference to a blank node */
+	public static final int T_BNODE = 3;
+	/** Reference to a triple */
+	public static final int T_TRIPLE = 4;
+
+	// inlined values
+	public static final int T_INTEGER = 16;
+	public static final int T_DECIMAL = 17;
+	public static final int T_FLOAT = 18;
+	public static final int T_DATETIME = 19;
+	public static final int T_DATETIMESTAMP = 20;
+	public static final int T_DATE = 21;
+	public static final int T_BOOLEAN = 22;
+	public static final int T_SHORTSTRING = 23;
+	public static final int T_POSITIVE_INTEGER = 24;
+	public static final int T_NEGATIVE_INTEGER = 25;
+	public static final int T_NON_NEGATIVE_INTEGER = 26;
+	public static final int T_NON_POSITIVE_INTEGER = 27;
+	public static final int T_LONG = 28;
+	public static final int T_INT = 29;
+	public static final int T_SHORT = 30;
+	public static final int T_BYTE = 31;
+	public static final int T_UNSIGNEDLONG = 32;
+	public static final int T_UNSIGNEDINT = 33;
+	public static final int T_UNSIGNEDSHORT = 34;
+	public static final int T_UNSIGNEDBYTE = 35;
+
+	/**
+	 * Returns the type section of the given id.
+	 *
+	 * @param id The id of which the type should be extracted.
+	 * @return The id's type.
+	 */
+	public static int getIdType(long id) {
+		return (int) ((id >> 1) & 0x7F);
+	}
+
+	/**
+	 * Returns the value section of the given id.
+	 *
+	 * @param id The id of which the value should be extracted.
+	 * @return The id's value.
+	 */
+	public static long getValue(long id) {
+		return id >> 8;
+	}
+
+	/**
+	 * Combines an id type and a value into a single long id.
+	 *
+	 * @param idType The id's type.
+	 * @param value  The id's value.
+	 * @return A composite id.
+	 */
+	public static long createId(int idType, long value) {
+		return value << 8 | idType << 1;
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreTest.java
@@ -152,22 +152,23 @@ public class ValueStoreTest {
 
 		valueStore.startTransaction();
 		List<Long> datatypeIds = new LinkedList<>();
-		for (int i = 1; i < types.length; i++) {
+		for (int i = 0; i < types.length; i++) {
 			datatypeIds.add(valueStore.storeValue(types[i]));
 		}
 		valueStore.commit();
 
 		valueStore.startTransaction();
 		valueStore.gcIds(Collections.singleton(values[0].getInternalID()), new HashSet<>());
-		valueStore.gcIds(datatypeIds, new HashSet<>());
+		valueStore.gcIds(datatypeIds.subList(1, datatypeIds.size() - 1), new HashSet<>());
 		valueStore.commit();
 
 		// close and recreate store
 		valueStore.close();
 		valueStore = createValueStore();
 
+		// the first value is directly GCed
 		assertNull(valueStore.getValue(values[0].getInternalID()));
-		// the first datatype is not directly garbage collected and must not be
+		// the first datatype is not directly GCed and must not be
 		// removed from the store if the related literal is removed
 		assertNotNull(valueStore.getValue(datatypeIds.remove(0)));
 


### PR DESCRIPTION
Implement an extensible ID scheme for the LmdbStore that also allows to embed values into IDs.

GitHub issue resolved: #4950 

Briefly describe the changes proposed in this PR:

Reworks the ID encoding of the LmdbStore to support RDF-star and embedding of values.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

