### PR TITLE
GH-4962: invalidation support for FedX source selection cache + factory

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.federated;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.federated.cache.SourceSelectionCache;
+import org.eclipse.rdf4j.federated.cache.SourceSelectionCacheFactory;
 import org.eclipse.rdf4j.federated.cache.SourceSelectionMemoryCache;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.TaskWrapper;
@@ -56,6 +57,8 @@ public class FedXConfig {
 	private boolean includeInferredDefault = true;
 
 	private String sourceSelectionCacheSpec = null;
+
+	private SourceSelectionCacheFactory sourceSelectionCacheFactory = null;
 
 	private TaskWrapper taskWrapper = null;
 
@@ -252,6 +255,18 @@ public class FedXConfig {
 	}
 
 	/**
+	 * The {@link SourceSelectionCacheFactory} to be used. If not set explicitly, the default in memory implementation
+	 * is used with the configued {@link #getSourceSelectionCacheSpec()}.
+	 *
+	 * @param factory the {@link SourceSelectionCacheFactory}
+	 * @return the current config
+	 */
+	public FedXConfig withSourceSelectionCacheFactory(SourceSelectionCacheFactory factory) {
+		this.sourceSelectionCacheFactory = factory;
+		return this;
+	}
+
+	/**
 	 * Sets a {@link TaskWrapper} which may be used for wrapping any background {@link Runnable}s. If no such wrapper is
 	 * explicitly configured, the unmodified task is returned. See {@link TaskWrapper} for more information.
 	 *
@@ -398,10 +413,22 @@ public class FedXConfig {
 	 * Returns the configured {@link CacheBuilderSpec} (if any) for the {@link SourceSelectionMemoryCache}. If not
 	 * defined, the {@link SourceSelectionMemoryCache#DEFAULT_CACHE_SPEC} is used.
 	 *
+	 * If {@link #getSourceSelectionCacheFactory()} is configured, this setting is ignored.
+	 *
 	 * @return the {@link CacheBuilderSpec} or <code>null</code>
 	 */
 	public String getSourceSelectionCacheSpec() {
 		return this.sourceSelectionCacheSpec;
+	}
+
+	/**
+	 * Returns the {@link SourceSelectionCacheFactory} (if any). If not defined, the {@link SourceSelectionCache} is
+	 * instantiated using the default implementation and respects {@link #getSourceSelectionCacheSpec()}.
+	 *
+	 * @return {@link SourceSelectionCacheFactory}
+	 */
+	public SourceSelectionCacheFactory getSourceSelectionCacheFactory() {
+		return this.sourceSelectionCacheFactory;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationContext.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationContext.java
@@ -97,12 +97,17 @@ public class FederationContext {
 	}
 
 	/**
-	 * Create the {@link SourceSelectionCache}
+	 * Create the {@link SourceSelectionCache}.
 	 *
 	 * @return the {@link SourceSelectionCache}
 	 * @see FedXConfig#getSourceSelectionCacheSpec()
+	 * @see FedXConfig#getSourceSelectionCacheFactory()
 	 */
 	private SourceSelectionCache createSourceSelectionCache() {
+		var factory = getConfig().getSourceSelectionCacheFactory();
+		if (factory != null) {
+			return factory.create();
+		}
 		String cacheSpec = getConfig().getSourceSelectionCacheSpec();
 		return new SourceSelectionMemoryCache(cacheSpec);
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionCache.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionCache.java
@@ -66,4 +66,10 @@ public interface SourceSelectionCache {
 	 * @param hasStatements
 	 */
 	void updateInformation(SubQuery subQuery, Endpoint endpoint, boolean hasStatements);
+
+	/**
+	 * Invalidate the underlying cache
+	 */
+	void invalidate();
+
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionCacheFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionCacheFactory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.cache;
+
+/**
+ * A factory for {@link SourceSelectionCache}.
+ *
+ * @author Andreas Schwarte
+ */
+public interface SourceSelectionCacheFactory {
+
+	/**
+	 * Create the {@link SourceSelectionCache}
+	 *
+	 * @return
+	 */
+	SourceSelectionCache create();
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCache.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCache.java
@@ -83,6 +83,11 @@ public class SourceSelectionMemoryCache implements SourceSelectionCache {
 		updateInferredInformation(subQuery, endpoint, hasStatements);
 	}
 
+	@Override
+	public void invalidate() {
+		cache.invalidateAll(); // invalidate the entire cache
+	}
+
 	private void updateCacheEntry(SubQuery subQuery, Endpoint endpoint, boolean hasStatements) {
 		Entry entry;
 		try {

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCacheTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCacheTest.java
@@ -148,6 +148,19 @@ public class SourceSelectionMemoryCacheTest extends SPARQLBaseTest {
 		// source selection is cached, only from fetching data
 		Assertions.assertEquals(1, requestsForEndpoint(endpoints.get(0)));
 		Assertions.assertEquals(0, requestsForEndpoint(endpoints.get(1)));
+
+		// invalidate source selection cache
+		federationContext().getSourceSelectionCache().invalidate();
+
+		// re-run requests
+		monitoring().resetMonitoringInformation();
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+			Assertions.assertEquals(2, Iterations.asList(tqr).size());
+		}
+
+		// source selection is non longer cached,
+		Assertions.assertEquals(2, requestsForEndpoint(endpoints.get(0)));
+		Assertions.assertEquals(1, requestsForEndpoint(endpoints.get(1)));
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #4962

Briefly describe the changes proposed in this PR:

* provide a means for externally invalidating the FedX source selection cache (e.g. upon writes)
* provide a means for configuring a custom source selection cache implementation


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

