### PR TITLE
GH-5000: Tone down WARN log output for frequent, non-critical events

### DIFF
--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverter.java
@@ -28,6 +28,7 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.spring.dao.support.BindingSetMapper;
@@ -56,8 +57,10 @@ public class TupleQueryResultConverter {
 		try {
 			consumer.accept(tupleQueryResult);
 		} catch (Exception e) {
-			logger.debug("Caught execption while processing TupleQueryResult", e);
-			throw mapException("Error processing TupleQueryResult", e);
+			logger.debug("Caught execption while processing TupleQueryResult: {}", e.getMessage());
+			RDF4JException mapped = mapException("Error processing TupleQueryResult", e);
+			logger.debug("Re-throwing as {} ", mapped.getClass().getSimpleName());
+			throw mapped;
 		} finally {
 			tupleQueryResult.close();
 			tupleQueryResult = null;
@@ -71,8 +74,10 @@ public class TupleQueryResultConverter {
 		try {
 			return function.apply(tupleQueryResult);
 		} catch (Exception e) {
-			logger.warn("Caught execption while processing TupleQueryResult", e);
-			throw mapException("Error processing TupleQueryResult", e);
+			logger.debug("Caught execption while processing TupleQueryResult: {}", e.getMessage());
+			RDF4JException mapped = mapException("Error processing TupleQueryResult", e);
+			logger.debug("Re-throwing as {} ", mapped.getClass().getSimpleName());
+			throw mapped;
 		} finally {
 			tupleQueryResult.close();
 			tupleQueryResult = null;


### PR DESCRIPTION
GitHub issue resolved: #5000

Briefly describe the changes proposed in this PR: 

Reduces loglevel for two very frequent, not-so-serious situations

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [~] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

