### PR TITLE
GH-5009: Fix position of OPTIONAL in RelationMapBuilder

### DIFF
--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
@@ -146,12 +146,15 @@ public class RelationMapBuilder {
 
 	private TupleQueryEvaluationBuilder makeTupleQueryBuilder() {
 		return rdf4JTemplate
-				.tupleQuery(
-						Queries.SELECT(getProjection())
-								.where(getWhereClause())
-								.distinct()
-								.getQueryString())
+				.tupleQuery(makeQueryString())
 				.withBindings(bindingsBuilder.build());
+	}
+
+	String makeQueryString() {
+		return Queries.SELECT(getProjection())
+				.where(getWhereClause())
+				.distinct()
+				.getQueryString();
 	}
 
 	private Projectable[] getProjection() {
@@ -168,14 +171,14 @@ public class RelationMapBuilder {
 
 	private GraphPattern[] getWhereClause() {
 		TriplePattern tp = _relSubject.has(predicate, _relObject);
+		GraphPattern[] ret = new GraphPattern[constraints.length + 1];
 		if (this.isRelationOptional) {
-			GraphPattern[] ret = new GraphPattern[constraints.length + 1];
-			ret[0] = tp.optional();
-			System.arraycopy(constraints, 0, ret, 1, constraints.length);
-			return ret;
+			ret[constraints.length] = tp.optional();
 		} else {
-			return new GraphPattern[] { tp.and(constraints) };
+			ret[constraints.length] = tp;
 		}
+		System.arraycopy(constraints, 0, ret, 0, constraints.length);
+		return ret;
 	}
 
 	public RelationMapBuilder withBinding(Variable key, Value value) {

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilderTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilderTests.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.spring.dao.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.rdf4j.model.vocabulary.SKOS;
+import org.eclipse.rdf4j.spring.RDF4JSpringTestBase;
+import org.eclipse.rdf4j.spring.dao.support.RelationMapBuilder;
+import org.eclipse.rdf4j.spring.domain.model.EX;
+import org.eclipse.rdf4j.spring.support.RDF4JTemplate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class RelationMapBuilderTests extends RDF4JSpringTestBase {
+
+	@Autowired
+	RDF4JTemplate rdf4JTemplate;
+
+	@Test
+	public void testRelationOnly() {
+		RelationMapBuilder rmb = new RelationMapBuilder(this.rdf4JTemplate, SKOS.BROADER);
+		assertEquals(normalize(
+				"SELECT DISTINCT ( ?rel_subject AS ?rel_key ) ( ?rel_object AS ?rel_value )\n"
+						+ "WHERE { ?rel_subject <http://www.w3.org/2004/02/skos/core#broader> ?rel_object . }"),
+				normalize(rmb.makeQueryString()));
+	}
+
+	@Test
+	public void testRelationWithConstraints() {
+		RelationMapBuilder rmb = new RelationMapBuilder(this.rdf4JTemplate, EX.creatorOf)
+				.constraints(RelationMapBuilder._relSubject.isA(
+						EX.Artist));
+		assertEquals(normalize("SELECT DISTINCT ( ?rel_subject AS ?rel_key ) ( ?rel_object AS ?rel_value )\n"
+				+ "WHERE { ?rel_subject a <http://example.org/Artist> .\n"
+				+ "?rel_subject <http://example.org/creatorOf> ?rel_object . }"), normalize(rmb.makeQueryString()));
+	}
+
+	@Test
+	public void testOptionalRelationWithPattern() {
+		RelationMapBuilder rmb = new RelationMapBuilder(this.rdf4JTemplate, EX.creatorOf)
+				.constraints(RelationMapBuilder._relSubject.isA(
+						EX.Artist))
+				.relationIsOptional();
+		assertEquals(normalize(
+				"SELECT DISTINCT ( ?rel_subject AS ?rel_key ) ( ?rel_object AS ?rel_value )\n"
+						+ "WHERE { ?rel_subject a <http://example.org/Artist> .\n"
+						+ "OPTIONAL { ?rel_subject <http://example.org/creatorOf> ?rel_object . } }\n"),
+				normalize(rmb.makeQueryString()));
+	}
+
+	private String normalize(String s) {
+		return s.replaceAll("\n", " ").replaceAll("\\s+", " ").trim();
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #5009 

Briefly describe the changes proposed in this PR:

Generating the query was simplified such that any constraints specified are put first, then the relation triple is added, which may be optional, depending on builder configuration

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

