### PR TITLE
GH-5024 Fix 'nuclear' delete bug in RDF4JTemplate.delete(IRI, List)

### DIFF
--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/RDF4JTemplate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/RDF4JTemplate.java
@@ -315,7 +315,9 @@ public class RDF4JTemplate {
 			Variable p2 = SparqlBuilder.var("p2_" + i);
 			Variable s2 = SparqlBuilder.var("s2_" + i);
 			q.delete(target.has(p1, o1), s2.has(p2, target))
-					.where(toIri(start).has(p, target).optional(), target.has(p1, o1).optional(),
+					.where(
+							toIri(start).has(p, target),
+							target.has(p1, o1).optional(),
 							s2.has(p2, target).optional());
 		}
 		update(q.getQueryString()).execute();

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/EX.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/EX.java
@@ -34,6 +34,7 @@ public class EX {
 	public static final IRI sunflowers = SimpleValueFactory.getInstance().createIRI(base, "sunflowers");
 	public static final IRI potatoEaters = SimpleValueFactory.getInstance().createIRI(base, "potatoEaters");
 	public static final IRI guernica = SimpleValueFactory.getInstance().createIRI(base, "guernica");
+	public static final IRI homeAddress = SimpleValueFactory.getInstance().createIRI(base, "homeAddress");
 
 	public static IRI of(String localName) {
 		return SimpleValueFactory.getInstance().createIRI(base, localName);


### PR DESCRIPTION
GitHub issue resolved: #5024 

Briefly describe the changes proposed in this PR:

`RDF4JTemplate.delete(IRI, List<PropertyPath>)` is meant to
1. delete the 'star' around `IRI`
2. find all nodes from `IRI` by the specified property paths and delete the 'star' around them.

The problem was that the  `source - propertypath - target` pattern was optional, and so the star pattern around the target could match all triples. Now that pattern is not optional, which limits deletes to any matches of that pattern.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

