### PR TITLE
GH-5030: fix FedXDataset support for queries with FROM clauses

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/FallbackDataset.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/FallbackDataset.java
@@ -113,4 +113,12 @@ public class FallbackDataset implements Dataset, Serializable {
 		}
 	}
 
+	public Dataset getPrimary() {
+		return primary;
+	}
+
+	public Dataset getFallback() {
+		return fallback;
+	}
+
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
@@ -24,6 +24,8 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.query.AbstractTupleQueryResultHandler;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -35,6 +37,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
+import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.util.Repositories;
 import org.junit.jupiter.api.Assertions;
@@ -572,6 +575,85 @@ public class BasicTests extends SPARQLBaseTest {
 					Assertions.assertFalse(tqr.hasNext(), "Result is expected to have a single result");
 				}
 			}
+		}
+
+	}
+
+	@Test
+	public void test_reduceFederation() throws Exception {
+
+		List<Endpoint> endpoints = prepareTest(
+				Arrays.asList("/tests/basic/data_emptyStore.ttl", "/tests/basic/data_emptyStore.ttl"));
+
+		Repository repo1 = getRepository(1);
+		Repository repo2 = getRepository(2);
+
+		String repo1Id = endpoints.get(0).getId();
+
+		IRI graph1 = Values.iri("http://example.org/graph1");
+		IRI graph2 = Values.iri("http://example.org/graph2");
+
+		try (RepositoryConnection con = repo1.getConnection()) {
+			con.add(Values.iri("http://example.org/repo1/p1"), RDF.TYPE, FOAF.PERSON, graph1);
+			con.add(Values.iri("http://example.org/repo2/p2"), RDF.TYPE, FOAF.PERSON, graph2);
+		}
+
+		try (RepositoryConnection con = repo2.getConnection()) {
+			con.add(Values.iri("http://example.org/repo2/p3"), RDF.TYPE, FOAF.PERSON, graph1);
+		}
+
+		Repository fedxRepo = fedxRule.getRepository();
+
+		// 1: regular federation
+		try (RepositoryConnection con = fedxRepo.getConnection()) {
+			TupleQuery tupleQuery = con.prepareTupleQuery(
+					"PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
+							+ "SELECT * WHERE { "
+							+ "   ?subClass a foaf:Person. "
+							+ " } "
+			);
+
+			// expect from both repos
+			Assertions.assertEquals(3, QueryResults.asSet(tupleQuery.evaluate()).size());
+
+			// now we scope it additional to graph1
+			tupleQuery = con.prepareTupleQuery(
+					"PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
+							+ "SELECT * FROM <http://example.org/graph1> WHERE { "
+							+ "   ?subClass a foaf:Person. "
+							+ " } ");
+
+			// expect results defined in graph1 (1 in repo1, 2 from repo2)
+			Assertions.assertEquals(2, QueryResults.asSet(tupleQuery.evaluate()).size());
+		}
+
+		// 2: reduce to federation member 1 id
+		// 2a: additionall restrict to named graph
+		FedXDataset fedXDataset = new FedXDataset(new SimpleDataset());
+		fedXDataset.addEndpoint(repo1Id);
+
+		try (RepositoryConnection con = fedxRepo.getConnection()) {
+			TupleQuery tupleQuery = con.prepareTupleQuery(
+					"PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
+							+ "SELECT * WHERE { "
+							+ "   ?subClass a foaf:Person. "
+							+ " } "
+			);
+			tupleQuery.setDataset(fedXDataset);
+
+			// expect result from repo 1
+			Assertions.assertEquals(2, QueryResults.asSet(tupleQuery.evaluate()).size());
+
+			// now we scope it additional to graph1
+			tupleQuery = con.prepareTupleQuery(
+					"PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
+							+ "SELECT * FROM <http://example.org/graph1> WHERE { "
+							+ "   ?subClass a foaf:Person. "
+							+ " } ");
+			tupleQuery.setDataset(fedXDataset);
+
+			// expect result from graph1 from repo1
+			Assertions.assertEquals(1, QueryResults.asSet(tupleQuery.evaluate()).size());
 		}
 
 	}


### PR DESCRIPTION


GitHub issue resolved: #5030 

FedX supports interpret the Dataset being defined on the query: if it is of type FedXDataset, the federation is reduced to the members defined by FedXDataset#getEndpoints().

This is a nice means to evaluate a query on a subset of the federation and is generally working fine.

When the query contains a FROM clause, however, the externally passed Dataset is wrapped into a FallbackDataset (which internally keeps the FedXDataset as primary one.

This change now inspects the FallbackDataset and unwraps it to reduce the members. Note that for execution still the "FallbackDataset" is used.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

