### PR TITLE
GH-5033: fix pushing of limits for simple ASK queries in FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/LimitOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/LimitOptimizer.java
@@ -65,6 +65,18 @@ public class LimitOptimizer extends AbstractSimpleQueryModelVisitor<Optimization
 			applicableLimitInScope = node.getLimit();
 		}
 		super.meet(node);
+
+		TupleExpr expr = node.getArg();
+		// if the top most element is a statement (e.g. for an ASK query with single statement pattern),
+		// i.e. no join, union or
+		// any other complex pattern, we can push the limit
+		// => this case typically represents a query with a single BGP
+		if (expr instanceof FedXStatementPattern) {
+			if (applicableLimitInScope > 0) {
+				pushLimit((FedXStatementPattern) expr, applicableLimitInScope);
+			}
+		}
+
 		applicableLimitInScope = -1;
 
 	}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/LimitTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/LimitTests.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated;
+
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LimitTests extends SPARQLBaseTest {
+
+	@Test
+	public void testLimitPushing_Select_SingleStatement() throws Exception {
+
+		// datsets contain both instances of foaf:Person
+		prepareTest(
+				Arrays.asList("/tests/data/data1.ttl", "/tests/data/data2.ttl"));
+
+		Repository fedxRepo = fedxRule.getRepository();
+
+		try (RepositoryConnection conn = fedxRepo.getConnection()) {
+
+			String query = "SELECT * WHERE { ?person a <" + FOAF.PERSON.stringValue() + "> } LIMIT 2";
+			TupleQuery tq = conn.prepareTupleQuery(query);
+			Assertions.assertEquals(2, QueryResults.asList(tq.evaluate()).size());
+
+			// check that the query plan contains information about limit
+			String queryPlan = fedxRule.getFederationContext().getQueryManager().getQueryPlan(query);
+			Assertions.assertTrue(queryPlan.contains("Upper Limit: 2"));
+		}
+	}
+
+	@Test
+	public void testLimitPushing_Ask_SingleStatement() throws Exception {
+
+		// datsets contain both instances of foaf:Person
+		prepareTest(
+				Arrays.asList("/tests/data/data1.ttl", "/tests/data/data2.ttl"));
+
+		Repository fedxRepo = fedxRule.getRepository();
+
+		try (RepositoryConnection conn = fedxRepo.getConnection()) {
+
+			String query = "ASK { ?person a <" + FOAF.PERSON.stringValue() + "> }";
+			Assertions.assertTrue(conn.prepareBooleanQuery(query).evaluate());
+
+			// check that the query plan contains information about limit
+			String queryPlan = fedxRule.getFederationContext().getQueryManager().getQueryPlan(query);
+			Assertions.assertTrue(queryPlan.contains("Upper Limit: 1"));
+
+			// also run a query with no backing data
+			query = "ASK { ?organization a <" + FOAF.ORGANIZATION.stringValue() + "> }";
+			Assertions.assertFalse(conn.prepareBooleanQuery(query).evaluate());
+		}
+	}
+}


### PR DESCRIPTION

GitHub issue resolved: #5033 

This change makes sure to push limits for simple ASK queries with a single statement patterns into the query.

The optimization is the same as applied for simple SELECT queries with a LIMIT.

Rational: if the limit is not pushed, the federation engine will first fetch all data for the statement pattern and only then locally check if there is at least one, i.e it will cause performance issues and memory pressure when there are many triples matching the statement pattern (for instance millions of persons).

Query plan of a simple ASK query after this fix (note the upper limit):

```
QueryRoot
   Slice (limit=1)
      StatementSourcePattern
         Var (name=person)
         Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
         Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
         StatementSource (id=sparql_localhost:18080_repositories_endpoint1, type=REMOTE)
         StatementSource (id=sparql_localhost:18080_repositories_endpoint2, type=REMOTE)
         Upper Limit: 1
```

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

