### PR TITLE
GH-5040 add the old rdf:type when using legacy vocabulary

### DIFF
--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -156,6 +156,7 @@ public class RepositoryConfig {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
 		model.setNamespace("rep", RepositoryConfigSchema.NAMESPACE);
+		model.add(repositoryNode, RDF.TYPE, RepositoryConfigSchema.REPOSITORY);
 
 		if (id != null) {
 			model.add(repositoryNode, RepositoryConfigSchema.REPOSITORYID, literal(id));


### PR DESCRIPTION
GitHub issue resolved: #5040 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

