### PR TITLE
GH-5060: use more recent version of zookeeper to fix CVE

### DIFF
--- a/core/sail/solr/pom.xml
+++ b/core/sail/solr/pom.xml
@@ -12,8 +12,22 @@
 	<properties>
 		<!-- FIXME: Support for embedded Solr server require non-provided Java EE dependencies -->
 		<enforce-javaee-provided.fail>false</enforce-javaee-provided.fail>
+		<!-- use at least 3.7 to fix CVE -->
+		<zookeeper.version>3.7.2</zookeeper.version>
 	</properties>
 	<dependencies>
+		<!-- use at least zookeeper 3.7.2 to fix CVE, can be removed if solr provides a newer version -->
+		<dependency>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper</artifactId>
+			<version>${zookeeper.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper-jute</artifactId>
+			<version>${zookeeper.version}</version>
+		</dependency>
+		<!-- -->
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-lucene-api</artifactId>


### PR DESCRIPTION
GitHub issue resolved: # 5060<!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use a newer version of zookeeper for fix CVE

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

