### PR TITLE
GH-5059 remove calls to E(...) when the return value is already being checked

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbContextIdIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbContextIdIterator.java
@@ -104,12 +104,12 @@ class LmdbContextIdIterator implements Closeable {
 					Varint.writeUnsigned(minKeyBuf, record[0]);
 					minKeyBuf.flip();
 					keyData.mv_data(minKeyBuf);
-					lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_SET));
-					if (lastResult != 0) {
+					lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_SET);
+					if (lastResult != MDB_SUCCESS) {
 						// use MDB_SET_RANGE if key was deleted
-						lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE));
+						lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
 					}
-					if (lastResult != 0) {
+					if (lastResult != MDB_SUCCESS) {
 						closeInternal(false);
 						return null;
 					}
@@ -119,16 +119,16 @@ class LmdbContextIdIterator implements Closeable {
 			}
 
 			if (fetchNext) {
-				lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT));
+				lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
 				fetchNext = false;
 			} else {
 				if (minKeyBuf != null) {
 					// set cursor to min key
 					keyData.mv_data(minKeyBuf);
-					lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE));
+					lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
 				} else {
 					// set cursor to first item
-					lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT));
+					lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
 				}
 			}
 

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -138,12 +138,12 @@ class LmdbRecordIterator implements RecordIterator {
 					index.toKey(minKeyBuf, quad[0], quad[1], quad[2], quad[3]);
 					minKeyBuf.flip();
 					keyData.mv_data(minKeyBuf);
-					lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_SET));
-					if (lastResult != 0) {
+					lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_SET);
+					if (lastResult != MDB_SUCCESS) {
 						// use MDB_SET_RANGE if key was deleted
-						lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE));
+						lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
 					}
-					if (lastResult != 0) {
+					if (lastResult != MDB_SUCCESS) {
 						closeInternal(false);
 						return null;
 					}
@@ -153,16 +153,16 @@ class LmdbRecordIterator implements RecordIterator {
 			}
 
 			if (fetchNext) {
-				lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT));
+				lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
 				fetchNext = false;
 			} else {
 				if (minKeyBuf != null) {
 					// set cursor to min key
 					keyData.mv_data(minKeyBuf);
-					lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE));
+					lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
 				} else {
 					// set cursor to first item
-					lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT));
+					lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
 				}
 			}
 
@@ -172,7 +172,7 @@ class LmdbRecordIterator implements RecordIterator {
 					lastResult = MDB_NOTFOUND;
 				} else if (groupMatcher != null && !groupMatcher.matches(keyData.mv_data())) {
 					// value doesn't match search key/mask, fetch next value
-					lastResult = E(mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT));
+					lastResult = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
 				} else {
 					// Matching value found
 					index.keyToQuad(keyData.mv_data(), quad);
@@ -183,8 +183,6 @@ class LmdbRecordIterator implements RecordIterator {
 			}
 			closeInternal(false);
 			return null;
-		} catch (IOException e) {
-			throw new SailException(e);
 		} finally {
 			txnLock.unlockRead(stamp);
 		}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbUtil.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbUtil.java
@@ -105,7 +105,7 @@ final class LmdbUtil {
 			int err;
 			try {
 				ret = transaction.exec(stack, txn);
-				err = E(mdb_txn_commit(txn));
+				err = mdb_txn_commit(txn);
 			} catch (Throwable t) {
 				mdb_txn_abort(txn);
 				throw t;

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbUtil.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbUtil.java
@@ -16,6 +16,7 @@ package org.eclipse.rdf4j.sail.lmdb;
 
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.util.lmdb.LMDB.MDB_DBS_FULL;
 import static org.lwjgl.util.lmdb.LMDB.MDB_KEYEXIST;
 import static org.lwjgl.util.lmdb.LMDB.MDB_NOTFOUND;
 import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
@@ -39,11 +40,15 @@ import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.Pointer;
 import org.lwjgl.util.lmdb.MDBCmpFuncI;
 import org.lwjgl.util.lmdb.MDBVal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for working with LMDB.
  */
 final class LmdbUtil {
+
+	private static final Logger logger = LoggerFactory.getLogger(LmdbUtil.class);
 
 	/**
 	 * Minimum free space in an LMDB db before automatically resizing the map.
@@ -61,7 +66,9 @@ final class LmdbUtil {
 
 	static int E(int rc) throws IOException {
 		if (rc != MDB_SUCCESS && rc != MDB_NOTFOUND && rc != MDB_KEYEXIST) {
-			throw new IOException(mdb_strerror(rc));
+			IOException ioException = new IOException(mdb_strerror(rc));
+			logger.info("Possible LMDB error: {}", mdb_strerror(rc), ioException);
+			throw ioException;
 		}
 		return rc;
 	}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/PersistentSet.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/PersistentSet.java
@@ -126,7 +126,7 @@ class PersistentSet<T extends Serializable> extends AbstractSet<T> {
 			keyVal.mv_data(keyBuf);
 
 			if (add) {
-				if (E(mdb_put(factory.writeTxn, dbi, keyVal, dataVal, MDB_NOOVERWRITE)) == MDB_SUCCESS) {
+				if (mdb_put(factory.writeTxn, dbi, keyVal, dataVal, MDB_NOOVERWRITE) == MDB_SUCCESS) {
 					size++;
 					return true;
 				}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRecordCache.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRecordCache.java
@@ -135,9 +135,9 @@ final class TxnRecordCache {
 			keyBuf.flip();
 			keyVal.mv_data(keyBuf);
 
-			boolean foundExplicit = E(mdb_get(writeTxn, dbiExplicit, keyVal, dataVal)) == MDB_SUCCESS &&
+			boolean foundExplicit = mdb_get(writeTxn, dbiExplicit, keyVal, dataVal) == MDB_SUCCESS &&
 					(dataVal.mv_data().get(0) & 0b1) != 0;
-			boolean foundImplicit = !foundExplicit && E(mdb_get(writeTxn, dbiInferred, keyVal, dataVal)) == MDB_SUCCESS
+			boolean foundImplicit = !foundExplicit && mdb_get(writeTxn, dbiInferred, keyVal, dataVal) == MDB_SUCCESS
 					&&
 					(dataVal.mv_data().get(0) & 0b1) != 0;
 
@@ -197,17 +197,13 @@ final class TxnRecordCache {
 		}
 
 		public Record next() {
-			try {
-				if (E(mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT)) == MDB_SUCCESS) {
-					Varint.readListUnsigned(keyData.mv_data(), quad);
-					byte op = valueData.mv_data().get(0);
-					Record r = new Record();
-					r.quad = quad;
-					r.add = op == 1;
-					return r;
-				}
-			} catch (IOException e) {
-				throw new SailException(e);
+			if (mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT) == MDB_SUCCESS) {
+				Varint.readListUnsigned(keyData.mv_data(), quad);
+				byte op = valueData.mv_data().get(0);
+				Record r = new Record();
+				r.quad = quad;
+				r.add = op == 1;
+				return r;
 			}
 			close();
 			return null;


### PR DESCRIPTION
GitHub issue resolved: #5059 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

