### PR TITLE
GH-5055 make mapdb3 default for the FedX engine as well

### DIFF
--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -92,7 +92,7 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-collection-factory-mapdb</artifactId>
+			<artifactId>rdf4j-collection-factory-mapdb3</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.collection.factory.api.CollectionFactory;
-import org.eclipse.rdf4j.collection.factory.mapdb.MapDbCollectionFactory;
+import org.eclipse.rdf4j.collection.factory.mapdb.MapDb3CollectionFactory;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.ResolvableEndpoint;
@@ -247,6 +247,6 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 
 	@Override
 	public Supplier<CollectionFactory> getCollectionFactory() {
-		return () -> new MapDbCollectionFactory(getIterationCacheSyncThreshold());
+		return () -> new MapDb3CollectionFactory(getIterationCacheSyncThreshold());
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #5055 

Briefly describe the changes proposed in this PR:

Also use MapDB3 for FedX

Hand tested that this resolves the reported problem
