### PR TITLE
GH-4779: Un-deprecate RDFa parser setting

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
@@ -35,7 +35,8 @@ public class RDFaParserSettings {
 
 	/**
 	 * Enables or disables <a href= "http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion" >vocabulary
-	 * expansion</a> feature.
+	 * expansion</a> feature. Note that although these settings are not used within RDF4J, they are in use by external
+	 * plugins.
 	 * <p>
 	 * Defaults to false
 	 * <p>
@@ -43,7 +44,6 @@ public class RDFaParserSettings {
 	 *
 	 * @see <a href="http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion">RDFa Vocabulary Expansion</a>
 	 */
-	@Deprecated(since = "4.3.0", forRemoval = true)
 	public static final BooleanRioSetting VOCAB_EXPANSION_ENABLED = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.rdfa.vocab_expansion", "Vocabulary Expansion", Boolean.FALSE);
 


### PR DESCRIPTION
GitHub issue resolved: https://github.com/eclipse-rdf4j/rdf4j/issues/4779

Briefly describe the changes proposed in this PR:

PR #4858 reinstated some settings needed for RDFa support but I missed one that is used internally by the Semargl library. This PR removes the deprecation of `VOCAB_EXPANSION_ENABLED` so that 3rd party libraries which depend on it can work with RDF4J v5.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made - N/A
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

