### PR TITLE
GH-5053: avoid log spam for configurations class with legacy settings

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
@@ -165,7 +165,13 @@ public class Configurations {
 		var fallbackObjects = model.filter(subject, fallbackProperty, null).objects();
 
 		if (!fallbackObjects.isEmpty() && !preferredObjects.equals(fallbackObjects)) {
-			logger.warn("Discrepancy between use of the old and new config vocabulary.");
+			var msg = "Discrepancy between use of the old and new config vocabulary.";
+			// depending on whether preferred is set, we log on warn or debug
+			if (preferredObjects.isEmpty()) {
+				logger.debug(msg);
+			} else {
+				logger.warn(msg);
+			}
 
 			if (preferredObjects.containsAll(fallbackObjects)) {
 				return preferredObjects;
@@ -235,7 +241,13 @@ public class Configurations {
 	private static void logDiscrepancyWarning(Optional<? extends Value> preferred,
 			Optional<? extends Value> fallback) {
 		if (!fallback.isEmpty() && !preferred.equals(fallback)) {
-			logger.warn("Discrepancy between use of the old and new config vocabulary.");
+			var msg = "Discrepancy between use of the old and new config vocabulary.";
+			// depending on whether preferred is set, we log on warn or debug
+			if (preferred.isEmpty()) {
+				logger.debug(msg);
+			} else {
+				logger.warn(msg);
+			}
 		}
 	}
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ConfigurationsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ConfigurationsTest.java
@@ -101,6 +101,7 @@ public class ConfigurationsTest {
 		var result = Configurations.getLiteralValue(m, subject, RDFS.LABEL, RDFS.COMMENT);
 		assertThat(result).contains(literal("label"));
 		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.WARN);
+		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
 	}
 
 	@Test
@@ -116,7 +117,21 @@ public class ConfigurationsTest {
 		System.setProperty("org.eclipse.rdf4j.model.vocabulary.useLegacyConfig", "");
 
 		assertThat(result).contains(literal("label"));
-		assertLogged("Discrepancy between use of the old and new config vocabulary.", Level.WARN);
+		assertLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
+	}
+
+	@Test
+	public void testGetLiteralValue_onlyLegacy() {
+
+		var subject = bnode();
+		var m = new ModelBuilder().subject(subject)
+				.add(RDFS.COMMENT, "comment")
+				.build();
+
+		var result = Configurations.getLiteralValue(m, subject, RDFS.LABEL, RDFS.COMMENT);
+
+		assertThat(result).contains(literal("comment"));
+		assertLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
 	}
 
 	@Test
@@ -158,6 +173,7 @@ public class ConfigurationsTest {
 		var result = Configurations.getResourceValue(m, subject, RDFS.LABEL, RDFS.COMMENT);
 		assertThat(result).contains(iri("urn:label"));
 		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.WARN);
+		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
 	}
 
 	@Test
@@ -183,6 +199,7 @@ public class ConfigurationsTest {
 		var result = Configurations.getIRIValue(m, subject, RDFS.LABEL, RDFS.COMMENT);
 		assertThat(result).contains(iri("urn:label"));
 		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.WARN);
+		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
 	}
 
 	@Test
@@ -197,6 +214,7 @@ public class ConfigurationsTest {
 		var result = Configurations.getPropertyValues(m, subject, RDFS.LABEL, RDFS.COMMENT);
 		assertThat(result).hasSize(2);
 		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.WARN);
+		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
 	}
 
 	@Test
@@ -213,6 +231,7 @@ public class ConfigurationsTest {
 		var result = Configurations.getPropertyValues(m, subject, RDFS.LABEL, RDFS.COMMENT);
 		assertThat(result).hasSize(2);
 		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.WARN);
+		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
 	}
 
 	@Test
@@ -229,6 +248,7 @@ public class ConfigurationsTest {
 		var result = Configurations.getPropertyValues(m, subject, RDFS.LABEL, RDFS.COMMENT);
 		assertThat(result).hasSize(2);
 		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.WARN);
+		assertNotLogged("Discrepancy between use of the old and new config vocabulary.", Level.DEBUG);
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #5053

When there is only a value for the legacy setting (i.e. the new config setting is not used) we now log on level debug. Otherwise on warn.

The rational is: when users still have persisted legacy repository configurations, the log is easily spammed with warnings.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

