### PR TITLE
GH-5095 Correctly call startRDF() and endRDF*() when parsing JSON-LD

### DIFF
--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -20,8 +20,6 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -43,9 +41,6 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -125,6 +120,10 @@ public class JSONLDParser extends AbstractRDFParser {
 			throws RDFParseException, RDFHandlerException, IOException {
 		clear();
 
+		if (rdfHandler != null) {
+			rdfHandler.startRDF();
+		}
+
 		try {
 
 			Document document = getDocument(in, reader);
@@ -179,6 +178,9 @@ public class JSONLDParser extends AbstractRDFParser {
 			}
 
 			RDFHandler rdfHandler = getRDFHandler();
+			if (rdfHandler != null) {
+				extractPrefixes(document, rdfHandler::handleNamespace);
+			}
 
 			JsonLd.toRdf(document).options(opts).base(baseURI).get(new RdfConsumer<>() {
 				@Override
@@ -242,7 +244,7 @@ public class JSONLDParser extends AbstractRDFParser {
 			});
 
 			if (rdfHandler != null) {
-				extractPrefixes(document, rdfHandler::handleNamespace);
+				rdfHandler.endRDF();
 			}
 
 		} catch (no.hasmac.jsonld.JsonLdError e) {


### PR DESCRIPTION
GitHub issue resolved: #5095 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

