### PR TITLE
Improve release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -167,7 +167,6 @@ mvn versions:set -DnewVersion="${MVN_VERSION_RELEASE}"
 mvn versions:commit
 
 
-
 # delete old release branch if it exits
 if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
   git branch --delete --force "${BRANCH}" &>/dev/null
@@ -180,19 +179,10 @@ git tag "${MVN_VERSION_RELEASE}"
 
 echo "";
 echo "Pushing release branch to github"
-read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 # push release branch and tag
 git push -u origin "${BRANCH}"
 git push origin "${MVN_VERSION_RELEASE}"
-
-echo "";
-echo "You need to tell Jenkins to start the release deployment processes, for SDK and maven artifacts"
-echo "- SDK deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-sdk/ "
-echo "- Maven deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-ossrh/ "
-echo "(if you are on linux or windows, remember to use CTRL+SHIFT+C to copy)."
-echo "Log in, then choose 'Build with Parameters' and type in ${MVN_VERSION_RELEASE}"
-read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 # Cleanup
 mvn clean -Dmaven.clean.failOnError=false
@@ -219,15 +209,13 @@ git push
 
 echo "";
 echo "About to create PR"
-read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 echo "";
 
 echo "Creating pull request to merge release branch back into main"
-gh pr create --title "next development iteration: ${MVN_NEXT_SNAPSHOT_VERSION}" --body "Merge using merge commit rather than rebase"
+gh pr create -B main --title "next development iteration: ${MVN_NEXT_SNAPSHOT_VERSION}" --body "Merge using merge commit rather than rebase"
 
 echo "";
 echo "Preparing a merge-branch to merge into develop"
-read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 
 
@@ -255,7 +243,6 @@ mvn clean -Dmaven.clean.failOnError=false
 mvn clean -Dmaven.clean.failOnError=false
 
 echo "Build javadocs"
-read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 git checkout "${MVN_VERSION_RELEASE}"
 
@@ -289,7 +276,13 @@ cd scripts
 echo ""
 echo "DONE!"
 
-
+echo "";
+echo "You need to tell Jenkins to start the release deployment processes, for SDK and maven artifacts"
+echo "- SDK deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-sdk/ "
+echo "- Maven deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-ossrh/ "
+echo "(if you are on linux or windows, remember to use CTRL+SHIFT+C to copy)."
+echo "Log in, then choose 'Build with Parameters' and type in ${MVN_VERSION_RELEASE}"
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 echo ""
 echo "You will now want to inform the community about the new release!"


### PR DESCRIPTION
Improve release script to delay calling jenkins until we know that the build went through correctly, also improve the automation by reducing the number of times you need to press any key to continue.