### PR TITLE
GH-5105: make MonitoringImpl in FedX thread safe

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/monitoring/MonitoringImpl.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/monitoring/MonitoringImpl.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.rdf4j.federated.FedXConfig;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
@@ -50,11 +51,7 @@ public class MonitoringImpl implements MonitoringService {
 
 	@Override
 	public void monitorRemoteRequest(Endpoint e) {
-		MonitoringInformation m = requestMap.get(e);
-		if (m == null) {
-			m = new MonitoringInformation(e);
-			requestMap.put(e, m);
-		}
+		MonitoringInformation m = requestMap.computeIfAbsent(e, (endpoint) -> new MonitoringInformation(endpoint));
 		m.increaseRequests();
 	}
 
@@ -75,20 +72,19 @@ public class MonitoringImpl implements MonitoringService {
 
 	public static class MonitoringInformation {
 		private final Endpoint e;
-		private int numberOfRequests = 0;
+		private AtomicInteger numberOfRequests = new AtomicInteger(0);
 
 		public MonitoringInformation(Endpoint e) {
 			this.e = e;
 		}
 
 		private void increaseRequests() {
-			// TODO make thread safe
-			numberOfRequests++;
+			numberOfRequests.incrementAndGet();
 		}
 
 		@Override
 		public String toString() {
-			return e.getName() + " => " + numberOfRequests;
+			return e.getName() + " => " + numberOfRequests.get();
 		}
 
 		public Endpoint getE() {
@@ -96,7 +92,7 @@ public class MonitoringImpl implements MonitoringService {
 		}
 
 		public int getNumberOfRequests() {
-			return numberOfRequests;
+			return numberOfRequests.get();
 		}
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #5105 

The monitoring service in FedX is a useful tool for evaluations / benchmarks to inspect the number of requests sent to the endpoints.

This change makes the implementation thread safe.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

