### PR TITLE
GH-5108 add a java system property to modify the limit for when we can still use SPARQL validation approach with sh:maxCount

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxLengthConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxLengthConstraintComponent.java
@@ -89,6 +89,6 @@ public class MaxLengthConstraintComponent extends SimpleAbstractConstraintCompon
 
 	@Override
 	public int hashCode() {
-		return (int) (maxLength ^ (maxLength >>> 32)) + "MaxLengthConstraintComponent".hashCode();
+		return Long.hashCode(maxLength) + "MaxLengthConstraintComponent".hashCode();
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
@@ -227,6 +227,6 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 
 	@Override
 	public int hashCode() {
-		return (int) (minCount ^ (minCount >>> 32)) + "MinCountConstraintComponent".hashCode();
+		return Long.hashCode(minCount) + "MinCountConstraintComponent".hashCode();
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinLengthConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinLengthConstraintComponent.java
@@ -89,6 +89,6 @@ public class MinLengthConstraintComponent extends SimpleAbstractConstraintCompon
 
 	@Override
 	public int hashCode() {
-		return (int) (minLength ^ (minLength >>> 32)) + "MinLengthConstraintComponent".hashCode();
+		return Long.hashCode(minLength) + "MinLengthConstraintComponent".hashCode();
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #5108 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

