### PR TITLE
GH-5124 configurable http timeouts

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/SPARQLServiceResolver.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/SPARQLServiceResolver.java
@@ -76,7 +76,19 @@ public class SPARQLServiceResolver extends AbstractFederatedServiceResolver
 
 	@Override
 	public HttpClient getHttpClient() {
-		return getHttpClientSessionManager().getHttpClient();
+		HttpClientSessionManager httpClientSessionManager = getHttpClientSessionManager();
+
+		try {
+			if (httpClientSessionManager instanceof SharedHttpClientSessionManager) {
+				((SharedHttpClientSessionManager) httpClientSessionManager).setDefaultSparqlServiceTimeouts();
+			}
+			return getHttpClientSessionManager().getHttpClient();
+		} finally {
+			if (httpClientSessionManager instanceof SharedHttpClientSessionManager) {
+				((SharedHttpClientSessionManager) httpClientSessionManager).setDefaultTimeouts();
+			}
+		}
+
 	}
 
 	@Override
@@ -86,6 +98,7 @@ public class SPARQLServiceResolver extends AbstractFederatedServiceResolver
 			getHttpClientSessionManager();
 			toSetDependentClient = dependentClient;
 		}
+
 		// The strange lifecycle results in the possibility that the
 		// dependentClient will be null due to a call to setSesameClient, so add
 		// a null guard here for that possibility

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/RemoteRepositoryProvider.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/RemoteRepositoryProvider.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.endpoint.provider;
 
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
@@ -40,13 +42,19 @@ public class RemoteRepositoryProvider implements EndpointProvider<RemoteReposito
 		}
 
 		try {
+
 			HTTPRepository repo = new HTTPRepository(repositoryServer, repositoryName);
+			SharedHttpClientSessionManager httpClientSessionManager = (SharedHttpClientSessionManager) repo
+					.getHttpClientSessionManager();
+
 			HttpClientBuilder httpClientBuilder = HttpClients.custom()
 					.useSystemProperties()
+					.setDefaultRequestConfig(httpClientSessionManager.getDefaultRequestConfig())
 					.setMaxConnTotal(20)
 					.setMaxConnPerRoute(20);
-			((SharedHttpClientSessionManager) repo.getHttpClientSessionManager())
-					.setHttpClientBuilder(httpClientBuilder);
+
+			httpClientSessionManager.setHttpClientBuilder(httpClientBuilder);
+
 			try {
 				repo.init();
 			} finally {


### PR DESCRIPTION
GitHub issue resolved: #5124 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - introduced timeout for the underlying Apache HttpClient
 - made them configurable
 - made different timeouts for when using with a SPARQL SERVICE call

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

