### PR TITLE
Add link to Jelly to about.md

### DIFF
--- a/site/content/about.md
+++ b/site/content/about.md
@@ -107,3 +107,5 @@ The metaphactory platform is developed by [metaphacts GmbH](https://www.metaphac
   an RDF service backend for Knowledge Management, used by thesaurus management platform [VocBench](http://vocbench.uniroma2.it/).
 - [Sesame Tools](https://github.com/joshsh/sesametools)<br>
   a collection of utility classes for use with Sesame/RDF4J.
+- [Jelly](https://w3id.org/jelly/jelly-jvm)<br>
+  a high-performance binary RDF serialization format with an implementation for RDF4J. Can be used as a JAR plugin.


### PR DESCRIPTION
GitHub issue resolved: N/A

Briefly describe the changes proposed in this PR:

Added a link to the Jelly serialization format implementation for RDF4J: https://w3id.org/jelly/jelly-jvm

Jelly is a binary RDF format with a strong performance focus. The implementation for RDF4J can be either used as a Maven dependency, or as a JAR plugin that you drop into your classpath.

Jelly was also implemented for Apache Jena. An implementation for rdflib is planned.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made *(not applicable)*
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change *(do I need to this?)*

