### PR TITLE
GH-5148 Introduce "soft fail" for corrupt ValueStore

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/CorruptValue.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/CorruptValue.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.sail.nativerdf.ValueStoreRevision;
  * CorruptValue is used when a NativeValue cannot be read from the ValueStore and if soft failure is enabled (see
  * ValueStore#softFailOnCorruptData).
  *
- * There is no method isCorruptValue() is it would exist for a "regular" implementation of NativeValue. Since
+ * There is no method isCorruptValue() as it would exist for a "regular" implementation of NativeValue. Since
  * CorruptValue is only to be used in exceptional situations, the recommended way of checking for it is using
  * "instanceof".
  *

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/CorruptValue.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/CorruptValue.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors, Aduna, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf.model;
+
+import org.eclipse.rdf4j.sail.nativerdf.ValueStoreRevision;
+
+/**
+ * CorruptValue is used when a NativeValue cannot be read from the ValueStore and if soft failure is enabled (see
+ * ValueStore#softFailOnCorruptData).
+ *
+ * There is no method isCorruptValue() is it would exist for a "regular" implementation of NativeValue. Since
+ * CorruptValue is only to be used in exceptional situations, the recommended way of checking for it is using
+ * "instanceof".
+ *
+ * @author Hannes Ebner
+ */
+public class CorruptValue implements NativeValue {
+
+	/*-----------*
+	 * Constants *
+	 *-----------*/
+
+	private static final long serialVersionUID = 8829067881854394802L;
+
+	/*----------*
+	 * Variables *
+	 *----------*/
+
+	private volatile ValueStoreRevision revision;
+
+	private volatile int internalID;
+
+	/*--------------*
+	 * Constructors *
+	 *--------------*/
+
+	public CorruptValue(ValueStoreRevision revision, int internalID) {
+		setInternalID(internalID, revision);
+	}
+
+	/*---------*
+	 * Methods *
+	 *---------*/
+
+	@Override
+	public void setInternalID(int internalID, ValueStoreRevision revision) {
+		this.internalID = internalID;
+		this.revision = revision;
+	}
+
+	@Override
+	public ValueStoreRevision getValueStoreRevision() {
+		return revision;
+	}
+
+	@Override
+	public int getInternalID() {
+		return internalID;
+	}
+
+	public String stringValue() {
+		return Integer.toString(internalID);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o instanceof CorruptValue && internalID != NativeValue.UNKNOWN_ID) {
+			CorruptValue otherCorruptValue = (CorruptValue) o;
+
+			if (otherCorruptValue.internalID != NativeValue.UNKNOWN_ID && revision.equals(otherCorruptValue.revision)) {
+				// CorruptValue is from the same revision of the same native store with both IDs set
+				return internalID == otherCorruptValue.internalID;
+			}
+		}
+
+		return super.equals(o);
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #5148

Briefly describe the changes proposed in this PR:

 - Improved use of a corrupted ValueStore by handling error situations in `ValueStore.data2value()` with SailException (previously it was possible to get an `ArrayIndexOutOfBoundsException` and `IllegalArgumentException`).
 - Introduction of a new system property `org.eclipse.rdf4j.sail.nativerdf.softFailOnCorruptData` to enable "soft failure mode" and to avoid exceptions as described above. Instead, an instance of the newly introduced CorruptValue will be returned.
 - This solves the problem of not being able to iterate (and in consequence, backup) over the NativeStore in order to save uncorrupted statements. Without "soft failure mode" the `RepositoryConnection` would be forcefully closed when hitting the first corrupted value.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

