### PR TITLE
GH-5151: use VALUES clause for FedX bind join with no free vars

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -935,7 +935,10 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 	 * @param bindings
 	 * @return the result iteration
 	 * @throws QueryEvaluationException
+	 * @deprecated with VALUES implementation, control flow goes via
+	 *             {@link #evaluateBoundJoinStatementPattern(StatementTupleExpr, List)}
 	 */
+	@Deprecated(forRemoval = true)
 	public abstract CloseableIteration<BindingSet> evaluateGroupedCheck(
 			CheckStatementPattern stmt, final List<BindingSet> bindings) throws QueryEvaluationException;
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
@@ -118,8 +118,9 @@ public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 	/**
 	 * Alternative evaluation implementation using UNION. Nowadays we use a VALUES clause based implementation
 	 *
-	 * @deprecated
+	 * @deprecated no longer used
 	 */
+	@Deprecated(forRemoval = true)
 	protected CloseableIteration<BindingSet> evaluateBoundJoinStatementPattern_UNION(
 			StatementTupleExpr stmt, List<BindingSet> bindings)
 			throws QueryEvaluationException {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBindJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBindJoin.java
@@ -45,12 +45,7 @@ public class ControlledWorkerBindJoin extends ControlledWorkerBindJoinBase {
 		final TaskCreator taskCreator;
 		if (expr instanceof StatementTupleExpr) {
 			StatementTupleExpr stmt = (StatementTupleExpr) expr;
-			if (stmt.hasFreeVarsFor(bs)) {
-				taskCreator = new BoundJoinTaskCreator(strategy, stmt);
-			} else {
-				expr = new CheckStatementPattern(stmt, queryInfo);
-				taskCreator = new CheckJoinTaskCreator(strategy, (CheckStatementPattern) expr);
-			}
+			taskCreator = new BoundJoinTaskCreator(strategy, stmt);
 		} else if (expr instanceof FedXService) {
 			taskCreator = new FedXServiceJoinTaskCreator(strategy, (FedXService) expr);
 		} else {
@@ -77,6 +72,7 @@ public class ControlledWorkerBindJoin extends ControlledWorkerBindJoinBase {
 		}
 	}
 
+	@Deprecated(forRemoval = true)
 	protected class CheckJoinTaskCreator implements TaskCreator {
 		protected final FederationEvalStrategy _strategy;
 		protected final CheckStatementPattern _expr;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelCheckJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelCheckJoinTask.java
@@ -24,7 +24,9 @@ import org.eclipse.rdf4j.query.BindingSet;
  * {@link FederationEvalStrategy#evaluateGroupedCheck(CheckStatementPattern, List)} for further details.
  *
  * @author Andreas Schwarte
+ * @deprecated now integrated in {@link ParallelBoundJoinTask} (with VALUES clause)
  */
+@Deprecated(forRemoval = true)
 public class ParallelCheckJoinTask extends ParallelTaskBase<BindingSet> {
 
 	protected final FederationEvalStrategy strategy;

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BoundJoinTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BoundJoinTests.java
@@ -45,4 +45,12 @@ public class BoundJoinTests extends SPARQLBaseTest {
 			execute("/tests/boundjoin/query01.rq", "/tests/boundjoin/query01.srx", false, true);
 		});
 	}
+
+	@Test
+	public void testBoundCheck() throws Exception {
+
+		/* test with VALUES clause based bound join, check join */
+		prepareTest(Arrays.asList("/tests/data/data1.ttl", "/tests/data/data2.ttl"));
+		execute("/tests/boundjoin/query02_checkJoin.rq", "/tests/boundjoin/query02_checkJoin.srx", false, true);
+	}
 }

--- a/tools/federation/src/test/resources/tests/boundjoin/query02_checkJoin.rq
+++ b/tools/federation/src/test/resources/tests/boundjoin/query02_checkJoin.rq
@@ -1,0 +1,10 @@
+# bound join query (where in the bind join all variables are bound)
+PREFIX ns1: <http://namespace1.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+
+SELECT ?person ?name WHERE {
+ ?person rdf:type foaf:Person .
+ ?person foaf:age 25 .
+}

--- a/tools/federation/src/test/resources/tests/boundjoin/query02_checkJoin.srx
+++ b/tools/federation/src/test/resources/tests/boundjoin/query02_checkJoin.srx
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sparql xmlns='http://www.w3.org/2005/sparql-results#'>
+	<head>
+		<variable name='person'/>
+		<variable name='name'/>
+		<variable name='publication'/>
+	</head>
+	<results>
+		<result>
+			<binding name='person'>
+				<uri>http://namespace1.org/Person_4</uri>
+			</binding>
+		</result>
+		<result>
+			<binding name='person'>
+				<uri>http://namespace2.org/Person_6</uri>
+			</binding>
+		</result>
+	</results>
+</sparql>

--- a/tools/federation/src/test/resources/tests/data/data1.ttl
+++ b/tools/federation/src/test/resources/tests/data/data1.ttl
@@ -24,6 +24,7 @@
 :Person_4 rdf:type foaf:Person .
 :Person_4 rdf:type :Person .
 :Person_4 foaf:name "Person4" .
+:Person_4 foaf:age "25"^^xsd:integer .
 
 :Person_5 rdf:type foaf:Person .
 :Person_5 rdf:type :Person .

--- a/tools/federation/src/test/resources/tests/data/data2.ttl
+++ b/tools/federation/src/test/resources/tests/data/data2.ttl
@@ -9,7 +9,7 @@
 :Person_6 rdf:type foaf:Person .
 :Person_6 rdf:type :Person .
 :Person_6 foaf:name "Person6" .
-:Person_1 foaf:age "25"^^xsd:integer .
+:Person_6 foaf:age "25"^^xsd:integer .
 
 :Person_7 rdf:type foaf:Person .
 :Person_7 rdf:type :Person .


### PR DESCRIPTION
GitHub issue resolved: #GH-5151

For evaluation of bind joins the implementation for quite some time
makes use of a VALUES clause query.

Except for one code-path: for bind joins - where in the join all
arguments are bound - it was still using the old UNION query approach.
This approach is error prone and no longer required, i.e. the check join
can be executed with the same logic as the regular VALUES clause.

Note: an additional unit test for covering bind joins with no free vars
is added.

This change also marks a number of methods and classes used for the old
UNION based approach as deprecated. The implementations are internal to
the FedX engine and can be removed in the next major release.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

