### PR TITLE
GH-5197: preparation for supporting fair sub-query execution in FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
@@ -66,7 +66,7 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 
 	private FederationEvaluationStrategyFactory strategyFactory;
 
-	private SchedulerFactory schedulerFactory;
+	private SchedulerFactory schedulerFactory = DefaultSchedulerFactory.INSTANCE;
 
 	private WriteStrategyFactory writeStrategyFactory;
 
@@ -101,9 +101,6 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 	}
 
 	/* package */ SchedulerFactory getSchedulerFactory() {
-		if (schedulerFactory == null) {
-			schedulerFactory = DefaultSchedulerFactory.INSTANCE;
-		}
 		return schedulerFactory;
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
@@ -22,6 +22,8 @@ import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.ResolvableEndpoint;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStrategyFactory;
+import org.eclipse.rdf4j.federated.evaluation.concurrent.DefaultSchedulerFactory;
+import org.eclipse.rdf4j.federated.evaluation.concurrent.SchedulerFactory;
 import org.eclipse.rdf4j.federated.exception.ExceptionUtil;
 import org.eclipse.rdf4j.federated.exception.FedXException;
 import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
@@ -64,6 +66,8 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 
 	private FederationEvaluationStrategyFactory strategyFactory;
 
+	private SchedulerFactory schedulerFactory;
+
 	private WriteStrategyFactory writeStrategyFactory;
 
 	private File dataDir;
@@ -94,6 +98,22 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 
 	public void setFederationEvaluationStrategy(FederationEvaluationStrategyFactory strategyFactory) {
 		this.strategyFactory = strategyFactory;
+	}
+
+	/* package */ SchedulerFactory getSchedulerFactory() {
+		if (schedulerFactory == null) {
+			schedulerFactory = DefaultSchedulerFactory.INSTANCE;
+		}
+		return schedulerFactory;
+	}
+
+	/**
+	 * Set the {@link SchedulerFactory}. Can only be done before initialization of the federation
+	 *
+	 * @param schedulerFactory the {@link SchedulerFactory}
+	 */
+	public void setSchedulerFactory(SchedulerFactory schedulerFactory) {
+		this.schedulerFactory = schedulerFactory;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
@@ -26,6 +26,7 @@ import org.eclipse.rdf4j.federated.evaluation.SparqlFederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.NamingThreadFactory;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.Scheduler;
+import org.eclipse.rdf4j.federated.evaluation.concurrent.SchedulerFactory;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.TaskWrapper;
 import org.eclipse.rdf4j.federated.evaluation.union.ControlledWorkerUnion;
 import org.eclipse.rdf4j.federated.evaluation.union.SynchronousWorkerUnion;
@@ -118,26 +119,28 @@ public class FederationManager {
 			log.debug("Scheduler for join and union are reset.");
 		}
 
+		SchedulerFactory schedulerFactory = federation.getSchedulerFactory();
+
 		Optional<TaskWrapper> taskWrapper = federationContext.getConfig().getTaskWrapper();
 		if (joinScheduler != null) {
 			joinScheduler.abort();
 		}
-		joinScheduler = new ControlledWorkerScheduler<>(federationContext.getConfig().getJoinWorkerThreads(),
-				"Join Scheduler");
+		joinScheduler = schedulerFactory.createJoinScheduler(federationContext,
+				federationContext.getConfig().getJoinWorkerThreads());
 		taskWrapper.ifPresent(joinScheduler::setTaskWrapper);
 
 		if (unionScheduler != null) {
 			unionScheduler.abort();
 		}
-		unionScheduler = new ControlledWorkerScheduler<>(federationContext.getConfig().getUnionWorkerThreads(),
-				"Union Scheduler");
+		unionScheduler = schedulerFactory.createUnionScheduler(federationContext,
+				federationContext.getConfig().getUnionWorkerThreads());
 		taskWrapper.ifPresent(unionScheduler::setTaskWrapper);
 
 		if (leftJoinScheduler != null) {
 			leftJoinScheduler.abort();
 		}
-		leftJoinScheduler = new ControlledWorkerScheduler<>(federationContext.getConfig().getLeftJoinWorkerThreads(),
-				"Left Join Scheduler");
+		leftJoinScheduler = schedulerFactory.createLeftJoinScheduler(federationContext,
+				federationContext.getConfig().getLeftJoinWorkerThreads());
 		taskWrapper.ifPresent(leftJoinScheduler::setTaskWrapper);
 
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
@@ -18,6 +18,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerBindJoin;
 import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerJoin;
@@ -127,6 +128,7 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T>, TaskWrapperAw
 	 *
 	 * @return
 	 */
+	@Experimental
 	protected BlockingQueue<Runnable> createBlockingQueue() {
 		return new LinkedBlockingQueue<>();
 	}
@@ -141,6 +143,7 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T>, TaskWrapperAw
 	 * @param name     the base name for threads in the pool
 	 * @return
 	 */
+	@Experimental
 	protected ExecutorService createExecutorService(int nWorkers, String name) {
 
 		ThreadPoolExecutor executor = new ThreadPoolExecutor(nWorkers, nWorkers, 60L, TimeUnit.SECONDS, this._taskQueue,

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/DefaultSchedulerFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/DefaultSchedulerFactory.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.evaluation.concurrent;
+
+import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.query.BindingSet;
+
+/**
+ * The default {@link SchedulerFactory}
+ */
+public class DefaultSchedulerFactory implements SchedulerFactory {
+
+	public static final DefaultSchedulerFactory INSTANCE = new DefaultSchedulerFactory();
+
+	@Override
+	public ControlledWorkerScheduler<BindingSet> createJoinScheduler(FederationContext federationContext,
+			int nWorkers) {
+		return new ControlledWorkerScheduler<>(nWorkers,
+				"Join Scheduler");
+	}
+
+	@Override
+	public ControlledWorkerScheduler<BindingSet> createUnionScheduler(FederationContext federationContext,
+			int nWorkers) {
+		return new ControlledWorkerScheduler<>(nWorkers,
+				"Union Scheduler");
+	}
+
+	@Override
+	public ControlledWorkerScheduler<BindingSet> createLeftJoinScheduler(FederationContext federationContext,
+			int nWorkers) {
+		return new ControlledWorkerScheduler<>(nWorkers,
+				"Left Join Scheduler");
+	}
+
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/SchedulerFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/SchedulerFactory.java
@@ -11,6 +11,10 @@
 package org.eclipse.rdf4j.federated.evaluation.concurrent;
 
 import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerBindJoin;
+import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerBindLeftJoin;
+import org.eclipse.rdf4j.federated.evaluation.join.ParallelBindLeftJoinTask;
+import org.eclipse.rdf4j.federated.evaluation.join.ParallelBoundJoinTask;
 import org.eclipse.rdf4j.query.BindingSet;
 
 /**
@@ -22,16 +26,19 @@ import org.eclipse.rdf4j.query.BindingSet;
 public interface SchedulerFactory {
 
 	/**
-	 * Create a {@link ControlledWorkerScheduler} for joins
+	 * Create a {@link ControlledWorkerScheduler} for regular joins (e.g., the sub-queries generated as part of bind
+	 * joins)
 	 *
 	 * @param federationContext
 	 * @param nWorkers
 	 * @return
+	 * @see ControlledWorkerBindJoin
+	 * @see ParallelBoundJoinTask
 	 */
 	ControlledWorkerScheduler<BindingSet> createJoinScheduler(FederationContext federationContext, int nWorkers);
 
 	/**
-	 * Create a {@link ControlledWorkerScheduler} for unions
+	 * Create a {@link ControlledWorkerScheduler} for unions (e.g., for executing UNION operands in parallel)
 	 *
 	 * @param federationContext
 	 * @param nWorkers
@@ -40,11 +47,14 @@ public interface SchedulerFactory {
 	ControlledWorkerScheduler<BindingSet> createUnionScheduler(FederationContext federationContext, int nWorkers);
 
 	/**
-	 * Create a {@link ControlledWorkerScheduler} for left joins
+	 * Create a {@link ControlledWorkerScheduler} for left joins (e.g., the sub-queries generated as part of left bind
+	 * joins, i.e. OPTIONAL)
 	 *
 	 * @param federationContext
 	 * @param nWorkers
 	 * @return
+	 * @see ControlledWorkerBindLeftJoin
+	 * @see ParallelBindLeftJoinTask
 	 */
 	ControlledWorkerScheduler<BindingSet> createLeftJoinScheduler(FederationContext federationContext, int nWorkers);
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/SchedulerFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/SchedulerFactory.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.evaluation.concurrent;
+
+import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.query.BindingSet;
+
+/**
+ * Factory for creating {@link ControlledWorkerScheduler} for executing subqueries (e.g. joins) in the background
+ *
+ * @see DefaultSchedulerFactory
+ * @author Andreas Schwarte
+ */
+public interface SchedulerFactory {
+
+	/**
+	 * Create a {@link ControlledWorkerScheduler} for joins
+	 *
+	 * @param federationContext
+	 * @param nWorkers
+	 * @return
+	 */
+	ControlledWorkerScheduler<BindingSet> createJoinScheduler(FederationContext federationContext, int nWorkers);
+
+	/**
+	 * Create a {@link ControlledWorkerScheduler} for unions
+	 *
+	 * @param federationContext
+	 * @param nWorkers
+	 * @return
+	 */
+	ControlledWorkerScheduler<BindingSet> createUnionScheduler(FederationContext federationContext, int nWorkers);
+
+	/**
+	 * Create a {@link ControlledWorkerScheduler} for left joins
+	 *
+	 * @param federationContext
+	 * @param nWorkers
+	 * @return
+	 */
+	ControlledWorkerScheduler<BindingSet> createLeftJoinScheduler(FederationContext federationContext, int nWorkers);
+}


### PR DESCRIPTION
GitHub issue resolved: #5197 

This change adds preparational infrastructure for having different
implementations of schedulers. Configuration is here prepared by means
of defining a "SchedulerFactory" interface with a default implementation
aside (which essentially mimics the current behavior).

Note that for ease of development some aspects of
ControlledWorkerScheduler are made accessible to sub-classes. The idea
is that in the end version there is an abstract scheduler class
providing shared functionality and different implementation (e.g. the
current FIFO one and a fair implementation)

-----

Note: I would like to see this preparation merged in RDF4J 5.1 such that we can prepare (and test) an implementation of a fair scheduler asynchronously already. The final target version for the implementation is RDF4J 5.2

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

