### PR TITLE
 GH-5121: support empty left bind join (OPTIONAL) in FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBindLeftJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBindLeftJoin.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.federated.evaluation.join;
 import java.util.List;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.federated.algebra.EmptyStatementPattern;
 import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
@@ -42,7 +43,9 @@ public class ControlledWorkerBindLeftJoin extends ControlledWorkerBindJoinBase {
 		if (expr instanceof StatementTupleExpr) {
 			StatementTupleExpr stmt = (StatementTupleExpr) expr;
 			taskCreator = new LeftBoundJoinTaskCreator(strategy, stmt);
-
+		} else if (expr instanceof EmptyStatementPattern) {
+			EmptyStatementPattern stmt = (EmptyStatementPattern) expr;
+			taskCreator = new EmptyLeftBoundJoinTaskCreator(strategy, stmt);
 		} else {
 			throw new RuntimeException("Expr is of unexpected type: " + expr.getClass().getCanonicalName()
 					+ ". Please report this problem.");
@@ -67,4 +70,20 @@ public class ControlledWorkerBindLeftJoin extends ControlledWorkerBindJoinBase {
 		}
 	}
 
+	static protected class EmptyLeftBoundJoinTaskCreator implements TaskCreator {
+		protected final FederationEvalStrategy _strategy;
+		protected final EmptyStatementPattern _expr;
+
+		public EmptyLeftBoundJoinTaskCreator(
+				FederationEvalStrategy strategy, EmptyStatementPattern expr) {
+			super();
+			_strategy = strategy;
+			_expr = expr;
+		}
+
+		@Override
+		public ParallelTask<BindingSet> getTask(ParallelExecutor<BindingSet> control, List<BindingSet> bindings) {
+			return new ParallelEmptyBindLeftJoinTask(control, _strategy, _expr, bindings);
+		}
+	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelEmptyBindLeftJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelEmptyBindLeftJoinTask.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.evaluation.join;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.federated.algebra.EmptyStatementPattern;
+import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
+import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelExecutor;
+import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTaskBase;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.repository.sparql.federation.CollectionIteration;
+
+/**
+ * A {@link ParallelTaskBase} for executing bind left joins, where the join argument is an
+ * {@link EmptyStatementPattern}. The effective result is that the input bindings from the left operand are passed
+ * through.
+ *
+ * @author Andreas Schwarte
+ */
+public class ParallelEmptyBindLeftJoinTask extends ParallelTaskBase<BindingSet> {
+
+	protected final FederationEvalStrategy strategy;
+	protected final EmptyStatementPattern rightArg;
+	protected final List<BindingSet> bindings;
+	protected final ParallelExecutor<BindingSet> joinControl;
+
+	public ParallelEmptyBindLeftJoinTask(ParallelExecutor<BindingSet> joinControl, FederationEvalStrategy strategy,
+			EmptyStatementPattern expr, List<BindingSet> bindings) {
+		this.strategy = strategy;
+		this.rightArg = expr;
+		this.bindings = bindings;
+		this.joinControl = joinControl;
+	}
+
+	@Override
+	public ParallelExecutor<BindingSet> getControl() {
+		return joinControl;
+	}
+
+	@Override
+	protected CloseableIteration<BindingSet> performTaskInternal() throws Exception {
+		// simply return the input bindings (=> the empty statement pattern cannot add results)
+		return new CollectionIteration<BindingSet>(bindings);
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #5121 

Previously we introduced support for left bind joins in FedX. The case
of empty left bind joins (i.e. where the clause inside the OPTIONAL does
not provide any statements) was not handled and resulted in an exception

This change now adds support for empty optional joins and passes the
results from the left-handside through.

----

Note: this is a follow up issue and fix for #5121, which we found by using RDF4J 5.1-M1. The fix should be added to 5.1.0

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

