### PR TITLE
GH-5210 Enable implementing sails to benefit from parent sail buffering

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.concurrent.locks.Lock;
 import org.eclipse.rdf4j.common.concurrent.locks.diagnostics.ConcurrentCleaner;
@@ -733,10 +734,8 @@ public abstract class AbstractSailConnection implements SailConnection {
 		synchronized (added) {
 			model = added.remove(op);
 		}
-		if (model != null) {
-			for (Statement st : model) {
-				addStatementInternal(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
-			}
+		if (model != null && !model.isEmpty()) {
+			bulkAddStatementsInternal(model);
 		}
 	}
 
@@ -972,6 +971,14 @@ public abstract class AbstractSailConnection implements SailConnection {
 
 	protected abstract void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts)
 			throws SailException;
+
+	@Experimental
+	protected void bulkAddStatementsInternal(final Collection<? extends Statement> statements)
+			throws SailException {
+		for (final Statement st : statements) {
+			addStatementInternal(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
+		}
+	}
 
 	protected abstract void removeStatementsInternal(Resource subj, IRI pred, Value obj, Resource... contexts)
 			throws SailException;


### PR DESCRIPTION
GitHub issue resolved: #5210 

Briefly describe the changes proposed in this PR:

This PR adds an overridable internal method `bulkAddStatementsInternal` which implementing SAILs can use to leverage the existing multithreading-safe, buffering implemented in `AbstractSailConnection`. This change should be fully backwards compatible as it defaults to the exiting implementation.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

