### PR TITLE
GH-5214 LMDB supports linux ppc

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -413,7 +413,13 @@
 			<dependency>
 				<groupId>org.lwjgl</groupId>
 				<artifactId>lwjgl-lmdb</artifactId>
-				<classifier>natives-macos-arm64</classifier>
+				<classifier>natives-linux-arm64</classifier>
+				<version>${lwjgl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.lwjgl</groupId>
+				<artifactId>lwjgl-lmdb</artifactId>
+				<classifier>natives-linux-ppc64le</classifier>
 				<version>${lwjgl.version}</version>
 			</dependency>
 			<dependency>
@@ -425,7 +431,19 @@
 			<dependency>
 				<groupId>org.lwjgl</groupId>
 				<artifactId>lwjgl-lmdb</artifactId>
+				<classifier>natives-macos-arm64</classifier>
+				<version>${lwjgl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.lwjgl</groupId>
+				<artifactId>lwjgl-lmdb</artifactId>
 				<classifier>natives-windows</classifier>
+				<version>${lwjgl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.lwjgl</groupId>
+				<artifactId>lwjgl-lmdb</artifactId>
+				<classifier>natives-windows-arm64</classifier>
 				<version>${lwjgl.version}</version>
 			</dependency>
 			<dependency>
@@ -437,6 +455,18 @@
 			<dependency>
 				<groupId>org.lwjgl</groupId>
 				<artifactId>lwjgl</artifactId>
+				<classifier>natives-linux-arm64</classifier>
+				<version>${lwjgl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.lwjgl</groupId>
+				<artifactId>lwjgl</artifactId>
+				<classifier>natives-linux-ppc64le</classifier>
+				<version>${lwjgl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.lwjgl</groupId>
+				<artifactId>lwjgl</artifactId>
 				<classifier>natives-macos</classifier>
 				<version>${lwjgl.version}</version>
 			</dependency>
@@ -450,6 +480,12 @@
 				<groupId>org.lwjgl</groupId>
 				<artifactId>lwjgl</artifactId>
 				<classifier>natives-windows</classifier>
+				<version>${lwjgl.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.lwjgl</groupId>
+				<artifactId>lwjgl</artifactId>
+				<classifier>natives-windows-arm64</classifier>
 				<version>${lwjgl.version}</version>
 			</dependency>
 		</dependencies>

--- a/core/sail/lmdb/pom.xml
+++ b/core/sail/lmdb/pom.xml
@@ -32,6 +32,13 @@
 		<dependency>
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl-lmdb</artifactId>
+			<classifier>natives-linux-ppc64le</classifier>
+			<version>${lwjgl.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-lmdb</artifactId>
 			<classifier>natives-macos</classifier>
 			<version>${lwjgl.version}</version>
 			<scope>runtime</scope>
@@ -68,6 +75,13 @@
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl</artifactId>
 			<classifier>natives-linux-arm64</classifier>
+			<version>${lwjgl.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl</artifactId>
+			<classifier>natives-linux-ppc64le</classifier>
 			<version>${lwjgl.version}</version>
 			<scope>runtime</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
 		<jsonldjava.version>0.13.4</jsonldjava.version>
 		<last.japicmp.compare.version>5.0.0</last.japicmp.compare.version>
 		<jaxb.version>2.3.8</jaxb.version>
-		<lwjgl.version>3.3.5</lwjgl.version>
+		<lwjgl.version>3.3.3</lwjgl.version>
 		<lucene.version>8.9.0</lucene.version>
 		<solr.version>8.9.0</solr.version>
 		<elasticsearch.version>7.15.2</elasticsearch.version>

--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
 		<jsonldjava.version>0.13.4</jsonldjava.version>
 		<last.japicmp.compare.version>5.0.0</last.japicmp.compare.version>
 		<jaxb.version>2.3.8</jaxb.version>
-		<lwjgl.version>3.3.3</lwjgl.version>
+		<lwjgl.version>3.3.6</lwjgl.version>
 		<lucene.version>8.9.0</lucene.version>
 		<solr.version>8.9.0</solr.version>
 		<elasticsearch.version>7.15.2</elasticsearch.version>

--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
 		<jsonldjava.version>0.13.4</jsonldjava.version>
 		<last.japicmp.compare.version>5.0.0</last.japicmp.compare.version>
 		<jaxb.version>2.3.8</jaxb.version>
-		<lwjgl.version>3.3.3</lwjgl.version>
+		<lwjgl.version>3.3.5</lwjgl.version>
 		<lucene.version>8.9.0</lucene.version>
 		<solr.version>8.9.0</solr.version>
 		<elasticsearch.version>7.15.2</elasticsearch.version>


### PR DESCRIPTION
GH-5214 lmdb supports linux ppc, updated to latest version and also some cleanup in the bom pom


GitHub issue resolved: #5214 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

