### PR TITLE
GH-5227: fix binding assigner optimizer in FedX

### DIFF
--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategyTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategyTest.java
@@ -10,9 +10,23 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.evaluation;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.federated.SPARQLBaseTest;
+import org.eclipse.rdf4j.federated.cache.SourceSelectionCache;
+import org.eclipse.rdf4j.federated.cache.SourceSelectionCache.StatementSourceAssurance;
+import org.eclipse.rdf4j.federated.endpoint.Endpoint;
+import org.eclipse.rdf4j.federated.structures.SubQuery;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -45,5 +59,51 @@ public class FederationEvalStrategyTest extends SPARQLBaseTest {
 		String queryPlan = federationContext().getQueryManager().getQueryPlan(query);
 
 		Assertions.assertTrue(queryPlan.startsWith("QueryRoot"));
+	}
+
+	@Test
+	public void testSourceSelectionCache_setBindings() throws Exception {
+
+		var bob = Values.iri("http://example.com/bob");
+
+		List<Endpoint> endpoints = prepareTest(
+				Arrays.asList("/tests/basic/data_emptyStore.ttl", "/tests/basic/data_emptyStore.ttl"));
+
+		Repository repo1 = getRepository(1);
+		Repository repo2 = getRepository(2);
+
+		String repo1Id = endpoints.get(0).getId();
+
+		try (RepositoryConnection con = repo1.getConnection()) {
+			con.add(bob, RDF.TYPE, FOAF.PERSON);
+		}
+
+		try (RepositoryConnection con = repo2.getConnection()) {
+			con.add(FOAF.PERSON, RDF.TYPE, OWL.CLASS);
+		}
+
+		Repository fedxRepo = fedxRule.getRepository();
+
+		fedxRule.enableDebug();
+
+		try (var conn = fedxRepo.getConnection()) {
+
+			TupleQuery tq = conn.prepareTupleQuery("SELECT * WHERE { ?s a ?type }");
+			tq.setBinding("s", bob);
+
+			try (var tqr = tq.evaluate()) {
+				// just consume the result
+				Assertions.assertEquals(Set.of(FOAF.PERSON),
+						tqr.stream().map(bs -> bs.getValue("type")).collect(Collectors.toSet()));
+			}
+		}
+
+		SourceSelectionCache cache = federationContext().getSourceSelectionCache();
+
+		var assurance = cache.getAssurance(new SubQuery(bob, RDF.TYPE, null),
+				federationContext().getEndpointManager().getEndpoint(repo1Id));
+
+		// we expect that the source selection cache can assure statements
+		Assertions.assertEquals(StatementSourceAssurance.HAS_REMOTE_STATEMENTS, assurance);
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #5227 

The federation optimizer was missing to execute the binding assigner (which injects external bindings into the statement pattern). The consequence was potentially incorrect results (due to source source selection with partial knowledge) as well as sub-optimal source selection

Issue is covered with a unit test, which is failing in two places prior to this change.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

