### PR TITLE
GH-5229: fix left bind join in FedX for single binding input

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -953,10 +953,6 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 	 */
 	public CloseableIteration<BindingSet> evaluateLeftBoundJoinStatementPattern(
 			StatementTupleExpr stmt, final List<BindingSet> bindings) throws QueryEvaluationException {
-		// we can omit the bound join handling
-		if (bindings.size() == 1) {
-			return evaluate(stmt, bindings.get(0));
-		}
 
 		FilterValueExpr filterExpr = null;
 		if (stmt instanceof FilterTuple) {


### PR DESCRIPTION
GitHub issue resolved: #5229 

This change fixes a situation that can incorrectly cause empty results. It happens when the input of the left argument is a single binding set and for special source selection situations (e.g. the right argument is marked as ExclusiveStatement while the endpoint does not provide data)

To avoid the issue we also use the regular left join logic also for a single binding set input, which can handle the situation properly.

Issue is covered with a unit test.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

