### PR TITLE
GH-5231: fix poor query performance for hasStatements() in FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -338,6 +338,27 @@ public class FedXConnection extends AbstractSailConnection {
 	}
 
 	@Override
+	protected boolean hasStatementInternal(Resource subj, IRI pred, Value obj, boolean includeInferred,
+			Resource[] contexts) {
+		try {
+			Dataset dataset = new SimpleDataset();
+			FederationEvalStrategy strategy = federationContext.createStrategy(dataset);
+			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, 0, includeInferred, federationContext, strategy,
+					dataset);
+			federationContext.getMonitoringService().monitorQuery(queryInfo);
+			return strategy.hasStatements(queryInfo, subj, pred, obj, contexts);
+
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			if (e instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+			}
+			throw new SailException(e);
+		}
+	}
+
+	@Override
 	protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
 		try {
 			getWriteStrategyInternal().addStatement(subj, pred, obj, contexts);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.SingletonIteration;
@@ -638,10 +639,16 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 
 	/**
 	 * Returns the accessible federation members in the context of the query. By default this is all federation members.
+	 * <p>
+	 * Specialized implementations of the {@link FederationEvalStrategy} may override and define custom behavior (e.g.,
+	 * to support resilience).
+	 * </p>
+	 *
 	 *
 	 * @param queryInfo
 	 * @return
 	 */
+	@Experimental
 	protected List<Endpoint> getAccessibleFederationMembers(QueryInfo queryInfo) {
 		return federationContext.getFederation().getMembers();
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -562,7 +562,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 			IRI pred, Value obj, Resource... contexts)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 
-		List<Endpoint> members = federationContext.getFederation().getMembers();
+		List<Endpoint> members = getAccessibleFederationMembers(queryInfo);
 
 		// a bound query: if at least one fed member provides results
 		// return the statement, otherwise empty result
@@ -603,6 +603,47 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		// TODO distinct iteration ?
 
 		return union;
+	}
+
+	/**
+	 * Returns true if the federation has statements
+	 *
+	 * @param queryInfo information about the query
+	 * @param subj      the subject or <code>null</code>
+	 * @param pred      the predicate or <code>null</code>
+	 * @param obj       the object or <code>null</code>
+	 * @param contexts  optional list of contexts
+	 * @return the statement iteration
+	 *
+	 * @throws RepositoryException
+	 * @throws MalformedQueryException
+	 * @throws QueryEvaluationException
+	 */
+	public boolean hasStatements(QueryInfo queryInfo, Resource subj,
+			IRI pred, Value obj, Resource... contexts)
+			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+
+		List<Endpoint> members = getAccessibleFederationMembers(queryInfo);
+
+		// form the union of results from relevant endpoints
+		List<StatementSource> sources = CacheUtils.checkCacheForStatementSourcesUpdateCache(cache, members, subj, pred,
+				obj, queryInfo, contexts);
+
+		if (sources.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the accessible federation members in the context of the query. By default this is all federation members.
+	 *
+	 * @param queryInfo
+	 * @return
+	 */
+	protected List<Endpoint> getAccessibleFederationMembers(QueryInfo queryInfo) {
+		return federationContext.getFederation().getMembers();
 	}
 
 	public CloseableIteration<BindingSet> evaluateService(FedXService service,


### PR DESCRIPTION
GitHub issue resolved: #5231 

The previous implementation of the FedXConnection was delegating "hasStatements()" to the implementation of "getStatements()", where the latter was actually fetching data from the federation members.

For checks hasStatements() checks like {null, rdf:type, null} or even {null, null, null} the implementation is problematic as it would fetch all data matching the pattern from the federation members, only to answer if it actually exists.

We now make use of "existence" check on the federation members, and can actually rely on the source selection cache for this.

Unit test coverage has been added.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

