### PR TITLE
GH-5234: fix limited programmatic configuration support of FedX source selection cache

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCache.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCache.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.federated.cache;
 
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
@@ -47,6 +48,14 @@ public class SourceSelectionMemoryCache implements SourceSelectionCache {
 	public SourceSelectionMemoryCache(String cacheSpec) {
 		cacheSpec = cacheSpec == null ? DEFAULT_CACHE_SPEC : cacheSpec;
 		this.cache = CacheBuilder.from(CacheBuilderSpec.parse(cacheSpec)).build();
+	}
+
+	/**
+	 *
+	 * @param cacheSupplier provider for an instantiated Guava cache
+	 */
+	public SourceSelectionMemoryCache(Supplier<Cache<SubQuery, Entry>> cacheSupplier) {
+		this.cache = cacheSupplier.get();
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #5234 

Add an additional constructor accepting a supplier for an initialized cache.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

