### PR TITLE
fix issue with testsuites benchmark sometimes causing japicmp to trigger by mistake

### DIFF
--- a/testsuites/benchmark/pom.xml
+++ b/testsuites/benchmark/pom.xml
@@ -115,6 +115,13 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
fix issue with testsuites benchmark sometimes causing japicmp to trigger by mistake