### PR TITLE
GH-5260 LMDB Store: Add valueEvictionInterval config

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreSchema.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreSchema.java
@@ -71,6 +71,11 @@ public class LmdbStoreSchema {
 	 */
 	public final static IRI AUTO_GROW;
 
+	/**
+	 * <tt>http://rdf4j.org/config/sail/lmdb#valueEvictionInterval</tt>
+	 */
+	public final static IRI VALUE_EVICTION_INTERVAL;
+
 	static {
 		ValueFactory factory = SimpleValueFactory.getInstance();
 		TRIPLE_INDEXES = factory.createIRI(NAMESPACE, "tripleIndexes");
@@ -82,5 +87,6 @@ public class LmdbStoreSchema {
 		NAMESPACE_CACHE_SIZE = factory.createIRI(NAMESPACE, "namespaceCacheSize");
 		NAMESPACE_ID_CACHE_SIZE = factory.createIRI(NAMESPACE, "namespaceIDCacheSize");
 		AUTO_GROW = factory.createIRI(NAMESPACE, "autoGrow");
+		VALUE_EVICTION_INTERVAL = factory.createIRI(NAMESPACE, "valueEvictionInterval");
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfigTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfigTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.bnode;
+import static org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig.VALUE_CACHE_SIZE;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.util.Values;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LmdbStoreConfigTest {
+
+	@ParameterizedTest
+	@ValueSource(longs = { 1, 205454, 0, -1231 })
+	void testThatLmdbStoreConfigParseAndExportValueEvictionInterval(final long valueEvictionInterval) {
+		testParseAndExport(
+				LmdbStoreSchema.VALUE_EVICTION_INTERVAL,
+				Values.literal(valueEvictionInterval),
+				LmdbStoreConfig::getValueEvictionInterval,
+				valueEvictionInterval,
+				true
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = { true, false })
+	void testThatLmdbStoreConfigParseAndExportAutoGrow(final boolean autoGrow) {
+		testParseAndExport(
+				LmdbStoreSchema.AUTO_GROW,
+				Values.literal(autoGrow),
+				LmdbStoreConfig::getAutoGrow,
+				autoGrow,
+				!autoGrow
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 1, 205454, 0, -1231 })
+	void testThatLmdbStoreConfigParseAndExportValueCacheSize(final int valueCacheSize) {
+		testParseAndExport(
+				LmdbStoreSchema.VALUE_CACHE_SIZE,
+				Values.literal(valueCacheSize >= 0 ? valueCacheSize : VALUE_CACHE_SIZE),
+				LmdbStoreConfig::getValueCacheSize,
+				valueCacheSize >= 0 ? valueCacheSize : VALUE_CACHE_SIZE,
+				true
+		);
+	}
+
+	// TODO: Add more tests for other properties
+
+	/**
+	 * Generic method to test parsing and exporting of config properties.
+	 *
+	 * @param property         The schema property to test
+	 * @param value            The literal value to use in the test
+	 * @param getter           Function to get the value from the config object
+	 * @param expectedValue    The expected value after parsing
+	 * @param expectedContains The expected result of the contains check
+	 * @param <T>              The type of the value being tested
+	 */
+	private <T> void testParseAndExport(
+			IRI property,
+			Literal value,
+			java.util.function.Function<LmdbStoreConfig, T> getter,
+			T expectedValue,
+			boolean expectedContains
+	) {
+		final BNode implNode = bnode();
+		final LmdbStoreConfig lmdbStoreConfig = new LmdbStoreConfig();
+		final Model configModel = new ModelBuilder()
+				.add(implNode, property, value)
+				.build();
+
+		// Parse the config
+		lmdbStoreConfig.parse(configModel, implNode);
+		assertThat(getter.apply(lmdbStoreConfig)).isEqualTo(expectedValue);
+
+		// Export the config
+		final Model exportedModel = new LinkedHashModel();
+		final Resource exportImplNode = lmdbStoreConfig.export(exportedModel);
+
+		// Verify the export
+		assertThat(exportedModel.contains(exportImplNode, property, value))
+				.isEqualTo(expectedContains);
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->
#5260 
Briefly describe the changes proposed in this PR:

The pull request adds a configurable valueEvictionInterval to the LMDB Store, allowing for control over garbage collection (GC). If valueEvictionInterval is less than or equal to 0, GC is disabled. Tests were added to verify this new behavior.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

