### PR TITLE
GH-5266 Fix the CI by upgrading actions/cache@v2

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         java-version: ${{ matrix.jdk }}
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/main-status.yml
+++ b/.github/workflows/main-status.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         java-version: ${{ matrix.jdk }}
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         java-version: ${{ matrix.jdk }}
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -48,7 +48,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-jdk11-maven-${{ hashFiles('**/pom.xml') }}
@@ -81,7 +81,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache local Maven repository
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-jdk11-maven-${{ hashFiles('**/pom.xml') }}
@@ -107,7 +107,7 @@ jobs:
         with:
           java-version: 11
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk11-maven-${{ hashFiles('**/pom.xml') }}
@@ -133,7 +133,7 @@ jobs:
         with:
           java-version: 11
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk11-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
GitHub issue resolved: #5266

Briefly describe the changes proposed in this PR:

Upgrade actions/cache@v2 to actions/cache@v4

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

