### PR TITLE
docs: Fix content => context typo in RepositoryConnection JavaDoc

### DIFF
--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -372,7 +372,7 @@ public interface RepositoryConnection extends AutoCloseable {
 			throws RepositoryException, MalformedQueryException;
 
 	/**
-	 * Gets all resources that are used as content identifiers. Care should be taken that the returned
+	 * Gets all resources that are used as context identifiers. Care should be taken that the returned
 	 * {@link RepositoryResult} is closed to free any resources that it keeps hold of.
 	 *
 	 * @return a RepositoryResult object containing Resources that are used as context identifiers.


### PR DESCRIPTION
Fix _"content"_ to _"context"_ typo in RepositoryConnection JavaDoc.

This PR only changes JavaDoc, no code.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

