### PR TITLE
GH-5277 Add check for geospatial lucene answers

### DIFF
--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
@@ -27,7 +27,7 @@ import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
  * <li>a WktWriter that only supports points</li>.
  * </ul>
  */
-abstract class SpatialSupport {
+public abstract class SpatialSupport {
 
 	private static final SpatialContext spatialContext;
 
@@ -50,15 +50,15 @@ abstract class SpatialSupport {
 		wktWriter = support.createWktWriter();
 	}
 
-	static SpatialContext getSpatialContext() {
+	public static SpatialContext getSpatialContext() {
 		return spatialContext;
 	}
 
-	static SpatialAlgebra getSpatialAlgebra() {
+	public static SpatialAlgebra getSpatialAlgebra() {
 		return spatialAlgebra;
 	}
 
-	static WktWriter getWktWriter() {
+	public static WktWriter getWktWriter() {
 		return wktWriter;
 	}
 

--- a/core/sail/lucene-api/pom.xml
+++ b/core/sail/lucene-api/pom.xml
@@ -22,6 +22,11 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-queryalgebra-geosparql</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-repository-sail</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneGeoTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneGeoTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.util.Repositories;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.lucene.LuceneSail;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.Test;
+
+public class LuceneGeoTest {
+	@Test
+	public void geoFailTest() {
+		MemoryStore store = new MemoryStore();
+		LuceneSail lucene = new LuceneSail();
+		lucene.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
+		lucene.setParameter(LuceneSail.WKT_FIELDS, "https://example.org/#location");
+		lucene.setBaseSail(store);
+		SailRepository repo = new SailRepository(lucene);
+		try {
+			repo.init();
+
+			Repositories.consume(repo, conn -> {
+				try {
+					conn.add(new StringReader(
+							"@prefix ex: <https://example.org/#> ."
+									// point in
+									+ "ex:s ex:location \"POINT(9.6929555 45.6762274)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> ."
+					// point out
+									+ "ex:s ex:location \"POINT(9.18457 45.466873)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> ."
+					), "https://example.org/#", RDFFormat.TURTLE);
+				} catch (IOException e) {
+					throw new AssertionError(e);
+				}
+			});
+
+			lucene.reindex();
+
+			// a random polygon of Milan
+			// POLYGON((9.000892639160158 45.3796432523812,9.381294250488283 45.3796432523812,9.381294250488283
+			// 45.55420812072298,9.000892639160158 45.55420812072298,9.000892639160158 45.3796432523812))
+			Repositories.consumeNoTransaction(repo, conn -> {
+				try (TupleQueryResult res = conn.prepareTupleQuery(
+						"PREFIX ex: <https://example.org/#> "
+								+ "SELECT * { "
+								+ "  ?s ex:location ?loc "
+								+ "  FILTER (<http://www.opengis.net/def/function/geosparql/ehContains>(\"POLYGON((9.000892639160158 45.3796432523812,9.381294250488283 45.3796432523812,9.381294250488283 45.55420812072298,9.000892639160158 45.55420812072298,9.000892639160158 45.3796432523812))\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>, ?loc)) "
+								+ "} "
+				).evaluate()) {
+					assertTrue(res.hasNext(), "missing good value");
+					BindingSet next = res.next();
+					assertEquals(Values.iri("https://example.org/#s"), next.getValue("s"));
+					assertEquals(Values.literal("POINT(9.18457 45.466873)", CoreDatatype.GEO.WKT_LITERAL),
+							next.getValue("loc"));
+					assertFalse(res.hasNext(), "more value(s) :"
+							+ res.stream().map(Object::toString).collect(Collectors.joining("\n", "\n", "")));
+				}
+			});
+
+		} finally {
+			repo.shutDown();
+		}
+
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #5277 

Briefly describe the changes proposed in this PR:

I have added a validation step before returning the geometries obtained by the search index. This step is done by reusing the `rdf4j-queryalgebra-geosparql` functions.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

