### PR TITLE
GH-5279: support up to 6 triple indexes in LmdbStore

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -201,7 +201,8 @@ class TripleStore implements Closeable {
 			env = pp.get(0);
 		}
 
-		E(mdb_env_set_maxdbs(env, 12));
+		// 1 for contexts, 12 for triple indexes (2 per index)
+		E(mdb_env_set_maxdbs(env, 13));
 		E(mdb_env_set_maxreaders(env, 256));
 
 		// Open environment

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreManyIndexesTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreManyIndexesTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test ensuring {@link TripleStore} can handle up to 6 indexes.
+ */
+public class TripleStoreManyIndexesTest {
+	private File dataDir;
+
+	@BeforeEach
+	public void before(@TempDir File dataDir) throws Exception {
+		this.dataDir = dataDir;
+	}
+
+	@Test
+	public void testSixIndexes() throws Exception {
+		TripleStore tripleStore = new TripleStore(dataDir,
+				new LmdbStoreConfig("spoc,posc,ospc,cspo,cpos,cosp"));
+		tripleStore.startTransaction();
+		tripleStore.storeTriple(1, 2, 3, 1, true);
+		tripleStore.commit();
+
+		try (TxnManager.Txn txn = tripleStore.getTxnManager().createReadTxn()) {
+			var it = tripleStore.getTriples(txn, 1, 2, 3, 1, true);
+			assertNotNull("Store should have a stored statement", it.next());
+		}
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #5279 

Briefly describe the changes proposed in this PR:

- The added test can be used to reproduce the issue with the current main-branch version of RDF4J.
- I changed the maxdbs parameter to 13, which allows the test to pass.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

