### PR TITLE
remove logValues and enable lmdb gc on init

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
@@ -235,13 +235,8 @@ class ValueStore extends AbstractValueFactory {
 			return null;
 		});
 
-		if (logger.isDebugEnabled()) {
-			// trigger deletion of values marked for GC
-			startTransaction(true);
-			commit();
-			// print current values in store
-			logValues();
-		}
+		startTransaction(true);
+		commit();
 	}
 
 	private void logValues() throws IOException {


### PR DESCRIPTION
GitHub issue resolved: #5259 

Briefly describe the changes proposed in this PR:

Removing the debug-level requirement on lmdb valuestore initialize so gc collection can be enabled. Also, removed the call to logValues to dump entire lmdb file

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

