### PR TITLE
GH-5330 throw an exception for unknown repo in getRepositoryCon

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
@@ -133,8 +133,11 @@ public class RepositoryInterceptor extends ServerInterceptor {
 	 * @param request the {@link HttpServletRequest} for which a {@link RepositoryConnection} is to be returned
 	 * @return a configured {@link RepositoryConnection}
 	 */
-	public static RepositoryConnection getRepositoryConnection(HttpServletRequest request) {
+	public static RepositoryConnection getRepositoryConnection(HttpServletRequest request) throws ClientHTTPException {
 		Repository repo = getRepository(request);
+		if (repo == null) {
+			throw new ClientHTTPException(SC_NOT_FOUND, "Unknown repository: " + getRepositoryID(request));
+		}
 		RepositoryConnection conn = repo.getConnection();
 		conn.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
 		conn.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_LANGUAGE_TAGS);

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
@@ -115,7 +115,7 @@ public class NamespaceController extends AbstractController {
 	}
 
 	private ModelAndView getRemoveNamespaceResult(HttpServletRequest request, String prefix)
-			throws ServerHTTPException {
+			throws ServerHTTPException, ClientHTTPException {
 		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
 			repositoryCon.removeNamespace(prefix);
 		} catch (RepositoryException e) {

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespacesController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespacesController.java
@@ -117,7 +117,7 @@ public class NamespacesController extends AbstractController {
 	}
 
 	private ModelAndView getClearNamespacesResult(HttpServletRequest request, HttpServletResponse response)
-			throws ServerHTTPException {
+			throws ServerHTTPException, ClientHTTPException {
 		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
 			try {
 				repositoryCon.clearNamespaces();


### PR DESCRIPTION
GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->
#5330 

Briefly describe the changes proposed in this PR:

Adds a null check for the repository in `getRepositoryConnection` to ensure that an appropriate `ClientHTTPException` is thrown when the requested repository is not found, preventing potential `NullPointerExceptions`.

Otherwise, it returns a `InternalSeverError`

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

