### PR TITLE
GH-5310 Correctly evaluate constant grouping constants for empty result sets.

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
@@ -319,8 +319,12 @@ public class GroupIterator extends AbstractCloseableIteratorIteration<BindingSet
 			} else {
 				List<AggregateCollector> collectors = makeCollectors(aggregates);
 				List<Predicate<?>> predicates = new ArrayList<>(aggregates.size());
-				for (int i = 0; i < aggregates.size(); i++) {
-					predicates.add(ALWAYS_TRUE_BINDING_SET);
+				for (var ag : aggregates) {
+					if (ag.agg instanceof WildCardCountAggregate) {
+						predicates.add(ALWAYS_TRUE_BINDING_SET);
+					} else {
+						predicates.add(ALWAYS_TRUE_VALUE);
+					}
 				}
 				final Entry entry = new Entry(null, collectors, predicates);
 				entry.addSolution(EmptyBindingSet.getInstance(), aggregates);
@@ -407,40 +411,33 @@ public class GroupIterator extends AbstractCloseableIteratorIteration<BindingSet
 				return new AggregatePredicateCollectorSupplier<>(wildCardCountAggregate, potentialDistinctTest,
 						() -> new CountCollector(vf), ge.getName());
 			} else {
-				QueryStepEvaluator f = new QueryStepEvaluator(
-						strategy.precompile(((Count) operator).getArg(), context));
+				QueryStepEvaluator f = precompileArg(operator);
 				CountAggregate agg = new CountAggregate(f);
-				Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-						: ALWAYS_TRUE_VALUE_SUPPLIER;
+				Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 				return new AggregatePredicateCollectorSupplier<>(agg, predicate, () -> new CountCollector(vf),
 						ge.getName());
 			}
 		} else if (operator instanceof Min) {
 			MinAggregate agg = new MinAggregate(precompileArg(operator), shouldValueComparisonBeStrict());
-			Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-					: ALWAYS_TRUE_VALUE_SUPPLIER;
+			Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 			return new AggregatePredicateCollectorSupplier<>(agg, predicate, ValueCollector::new, ge.getName());
 		} else if (operator instanceof Max) {
 			MaxAggregate agg = new MaxAggregate(precompileArg(operator), shouldValueComparisonBeStrict());
-			Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-					: ALWAYS_TRUE_VALUE_SUPPLIER;
+			Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 			return new AggregatePredicateCollectorSupplier<>(agg, predicate, ValueCollector::new, ge.getName());
 		} else if (operator instanceof Sum) {
 
 			SumAggregate agg = new SumAggregate(precompileArg(operator));
-			Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-					: ALWAYS_TRUE_VALUE_SUPPLIER;
+			Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 			return new AggregatePredicateCollectorSupplier<>(agg, predicate, () -> new IntegerCollector(vf),
 					ge.getName());
 		} else if (operator instanceof Avg) {
 			AvgAggregate agg = new AvgAggregate(precompileArg(operator));
-			Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-					: ALWAYS_TRUE_VALUE_SUPPLIER;
+			Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 			return new AggregatePredicateCollectorSupplier<>(agg, predicate, () -> new AvgCollector(vf), ge.getName());
 		} else if (operator instanceof Sample) {
 			SampleAggregate agg = new SampleAggregate(precompileArg(operator));
-			Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-					: ALWAYS_TRUE_VALUE_SUPPLIER;
+			Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 			return new AggregatePredicateCollectorSupplier<>(agg, predicate, SampleCollector::new, ge.getName());
 		} else if (operator instanceof GroupConcat) {
 			ValueExpr separatorExpr = ((GroupConcat) operator).getSeparator();
@@ -451,19 +448,17 @@ public class GroupIterator extends AbstractCloseableIteratorIteration<BindingSet
 			} else {
 				agg = new ConcatAggregate(precompileArg(operator));
 			}
-			Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-					: ALWAYS_TRUE_VALUE_SUPPLIER;
+			Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 			return new AggregatePredicateCollectorSupplier<>(agg, predicate, () -> new StringBuilderCollector(vf),
 					ge.getName());
 		} else if (operator instanceof AggregateFunctionCall) {
 			var aggOperator = (AggregateFunctionCall) operator;
-			Supplier<Predicate<Value>> predicate = operator.isDistinct() ? DistinctValues::new
-					: ALWAYS_TRUE_VALUE_SUPPLIER;
+			Supplier<Predicate<Value>> predicate = createDistinctValueTest(operator);
 			var factory = CustomAggregateFunctionRegistry.getInstance().get(aggOperator.getIRI());
 
 			var function = factory.orElseThrow(
 					() -> new QueryEvaluationException("Unknown aggregate function '" + aggOperator.getIRI() + "'"))
-					.buildFunction(new QueryStepEvaluator(strategy.precompile(aggOperator.getArg(), context)));
+					.buildFunction(precompileArg(aggOperator));
 			return new AggregatePredicateCollectorSupplier<>(function, predicate, () -> factory.get().getCollector(),
 					ge.getName());
 
@@ -472,8 +467,21 @@ public class GroupIterator extends AbstractCloseableIteratorIteration<BindingSet
 		return null;
 	}
 
+	/**
+	 * Create a predicate that tests if the value is distinct (returning true if the value was not seen yet), or always
+	 * returns true if the operator is not distinct.
+	 *
+	 * @param operator
+	 * @return a supplier that returns a predicate that tests if the value is distinct, or always returns true if the
+	 *         operator is not distinct.
+	 */
+	private Supplier<Predicate<Value>> createDistinctValueTest(AggregateOperator operator) {
+		return operator.isDistinct() ? DistinctValues::new : ALWAYS_TRUE_VALUE_SUPPLIER;
+	}
+
 	private QueryStepEvaluator precompileArg(AggregateOperator operator) {
-		return new QueryStepEvaluator(strategy.precompile(((UnaryValueOperator) operator).getArg(), context));
+		ValueExpr ve = ((UnaryValueOperator) operator).getArg();
+		return new QueryStepEvaluator(strategy.precompile(ve, context));
 	}
 
 	private boolean shouldValueComparisonBeStrict() {
@@ -491,7 +499,7 @@ public class GroupIterator extends AbstractCloseableIteratorIteration<BindingSet
 
 		@Override
 		public Value getFinalValue() {
-			return SimpleValueFactory.getInstance().createLiteral(Long.toString(value), CoreDatatype.XSD.INTEGER);
+			return vf.createLiteral(Long.toString(value), CoreDatatype.XSD.INTEGER);
 		}
 	}
 
@@ -561,7 +569,7 @@ public class GroupIterator extends AbstractCloseableIteratorIteration<BindingSet
 			}
 
 			if (count == 0) {
-				return SimpleValueFactory.getInstance().createLiteral("0", CoreDatatype.XSD.INTEGER);
+				return vf.createLiteral("0", CoreDatatype.XSD.INTEGER);
 			}
 
 			Literal sizeLit = SimpleValueFactory.getInstance().createLiteral(count);
@@ -791,9 +799,9 @@ public class GroupIterator extends AbstractCloseableIteratorIteration<BindingSet
 		@Override
 		public Value getFinalValue() throws ValueExprEvaluationException {
 			if (concatenated == null || concatenated.length() == 0) {
-				return SimpleValueFactory.getInstance().createLiteral("");
+				return vf.createLiteral("");
 			}
-			return SimpleValueFactory.getInstance().createLiteral(concatenated.toString());
+			return vf.createLiteral(concatenated.toString());
 		}
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIteratorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIteratorTest.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -35,10 +36,27 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.query.algebra.*;
-import org.eclipse.rdf4j.query.algebra.evaluation.*;
+import org.eclipse.rdf4j.query.algebra.AggregateFunctionCall;
+import org.eclipse.rdf4j.query.algebra.Avg;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.Count;
+import org.eclipse.rdf4j.query.algebra.EmptySet;
+import org.eclipse.rdf4j.query.algebra.Group;
+import org.eclipse.rdf4j.query.algebra.GroupConcat;
+import org.eclipse.rdf4j.query.algebra.GroupElem;
+import org.eclipse.rdf4j.query.algebra.MathExpr;
+import org.eclipse.rdf4j.query.algebra.Max;
+import org.eclipse.rdf4j.query.algebra.Min;
+import org.eclipse.rdf4j.query.algebra.Sample;
+import org.eclipse.rdf4j.query.algebra.Sum;
+import org.eclipse.rdf4j.query.algebra.ValueConstant;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.DefaultEvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.MathUtil;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector;
@@ -53,85 +71,41 @@ import org.junit.jupiter.api.Test;
  * @author Bart Hanssens
  */
 public class GroupIteratorTest {
-	private final static ValueFactory vf = SimpleValueFactory.getInstance();
-	private static final EvaluationStrategy evaluator = new StrictEvaluationStrategy(null, null);
-	private static final QueryEvaluationContext context = new QueryEvaluationContext.Minimal(
-			vf.createLiteral(Date.from(Instant.now())), null, null);
-	private static BindingSetAssignment EMPTY_ASSIGNMENT;
-	private static BindingSetAssignment NONEMPTY_ASSIGNMENT;
-	private static AggregateFunctionFactory aggregateFunctionFactory;
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+	private static final EvaluationStrategy EVALUATOR = new DefaultEvaluationStrategy(null, null);
+	private static final QueryEvaluationContext CONTEXT = new QueryEvaluationContext.Minimal(
+			VF.createLiteral(Date.from(Instant.now())), null, null);
+	private static final BindingSetAssignment EMPTY_ASSIGNMENT = new BindingSetAssignment();
+	private static final BindingSetAssignment NONEMPTY_ASSIGNMENT = new BindingSetAssignment();
+	private static final AggregateFunctionFactory AGGREGATE_FUNCTION_FACTORY = new FakeAggregateFunctionFactory();
 
 	@BeforeAll
 	public static void init() {
-		EMPTY_ASSIGNMENT = new BindingSetAssignment();
 		EMPTY_ASSIGNMENT.setBindingSets(Collections.emptyList());
-		NONEMPTY_ASSIGNMENT = new BindingSetAssignment();
 		var list = new ArrayList<BindingSet>();
 		for (int i = 1; i < 10; i++) {
 			var bindings = new QueryBindingSet();
-			bindings.addBinding("a", vf.createLiteral(i));
+			bindings.addBinding("a", VF.createLiteral(i));
 			list.add(bindings);
 		}
 		NONEMPTY_ASSIGNMENT.setBindingSets(Collections.unmodifiableList(list));
-		aggregateFunctionFactory = new AggregateFunctionFactory() {
-			@Override
-			public String getIri() {
-				return "https://www.rdf4j.org/aggregate#x";
-			}
-
-			@Override
-			public AggregateFunction<SumCollector, Value> buildFunction(Function<BindingSet, Value> evaluationStep) {
-				return new AggregateFunction<>(evaluationStep) {
-
-					private ValueExprEvaluationException typeError = null;
-
-					@Override
-					public void processAggregate(BindingSet s, Predicate<Value> distinctValue, SumCollector sum)
-							throws QueryEvaluationException {
-						if (typeError != null) {
-							// halt further processing if a type error has been raised
-							return;
-						}
-						Value v = evaluate(s);
-						if (v instanceof Literal) {
-							if (distinctValue.test(v)) {
-								Literal nextLiteral = (Literal) v;
-								if (nextLiteral.getDatatype() != null
-										&& XMLDatatypeUtil.isNumericDatatype(nextLiteral.getDatatype())) {
-									sum.value = MathUtil.compute(sum.value, nextLiteral, MathExpr.MathOp.PLUS);
-								} else {
-									typeError = new ValueExprEvaluationException("not a number: " + v);
-								}
-							} else {
-								typeError = new ValueExprEvaluationException("not a number: " + v);
-							}
-						}
-					}
-				};
-			}
-
-			@Override
-			public SumCollector getCollector() {
-				return new SumCollector();
-			}
-		};
-		CustomAggregateFunctionRegistry.getInstance().add(aggregateFunctionFactory);
+		CustomAggregateFunctionRegistry.getInstance().add(AGGREGATE_FUNCTION_FACTORY);
 	}
 
 	@AfterAll
 	public static void cleanUp() {
-		CustomAggregateFunctionRegistry.getInstance().remove(aggregateFunctionFactory);
+		CustomAggregateFunctionRegistry.getInstance().remove(AGGREGATE_FUNCTION_FACTORY);
 	}
 
 	@Test
 	public void testAvgEmptySet() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("avg", new Avg(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
 			assertThat(gi.next().getBinding("avg").getValue())
 					.describedAs("AVG on empty set should result in 0")
-					.isEqualTo(vf.createLiteral("0", XSD.INTEGER));
+					.isEqualTo(VF.createLiteral("0", XSD.INTEGER));
 		}
 	}
 
@@ -139,10 +113,37 @@ public class GroupIteratorTest {
 	public void testMaxEmptySet_DefaultGroup() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("max", new Max(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
 			assertThat(gi.hasNext()).isTrue();
 			assertThat(gi.next().size()).isEqualTo(0);
+		}
+	}
+
+	@Test
+	public void testMaxSet_DefaultGroup() throws QueryEvaluationException {
+		Group group = new Group(NONEMPTY_ASSIGNMENT);
+		group.addGroupElement(new GroupElem("max", new Max(new Var("a"))));
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
+
+			assertThat(gi.hasNext()).isTrue();
+			BindingSet next = gi.next();
+			assertEquals(1, next.size());
+			assertEquals(VF.createLiteral(9), next.getBinding("max").getValue());
+		}
+	}
+
+	@Test
+	public void testMaxConstantEmptySet_DefaultGroup() throws QueryEvaluationException {
+		Group group = new Group(EMPTY_ASSIGNMENT);
+		Literal one = VF.createLiteral(1);
+		group.addGroupElement(new GroupElem("max", new Max(new ValueConstant(one))));
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
+
+			assertThat(gi.hasNext()).isTrue();
+			BindingSet next = gi.next();
+			assertEquals(1, next.size());
+			assertEquals(one, next.getBinding("max").getValue());
 		}
 	}
 
@@ -152,7 +153,7 @@ public class GroupIteratorTest {
 		group.addGroupElement(new GroupElem("max", new Max(new Var("a"))));
 		group.addGroupBindingName("x"); // we are grouping by variable x
 
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
 			assertThat(gi.hasNext()).isFalse();
 		}
@@ -162,7 +163,7 @@ public class GroupIteratorTest {
 	public void testMinEmptySet() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("min", new Min(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
 			assertThat(gi.hasNext()).isTrue();
 			assertThat(gi.next().size()).isEqualTo(0);
@@ -173,7 +174,7 @@ public class GroupIteratorTest {
 	public void testSampleEmptySet() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("sample", new Sample(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
 			assertThat(gi.hasNext()).isTrue();
 			assertThat(gi.next().size()).isEqualTo(0);
@@ -184,11 +185,11 @@ public class GroupIteratorTest {
 	public void testGroupConcatEmptySet() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("groupconcat", new GroupConcat(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
 			assertThat(gi.next().getBinding("groupconcat").getValue())
 					.describedAs("GROUP_CONCAT on empty set should result in empty string")
-					.isEqualTo(vf.createLiteral(""));
+					.isEqualTo(VF.createLiteral(""));
 		}
 	}
 
@@ -196,9 +197,9 @@ public class GroupIteratorTest {
 	public void testAvgNotZero() throws QueryEvaluationException {
 		Group group = new Group(NONEMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("avg", new Avg(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
-			assertThat(gi.next().getBinding("avg").getValue()).isEqualTo(vf.createLiteral("5", XSD.DECIMAL));
+			assertThat(gi.next().getBinding("avg").getValue()).isEqualTo(VF.createLiteral("5", XSD.DECIMAL));
 		}
 	}
 
@@ -206,9 +207,9 @@ public class GroupIteratorTest {
 	public void testCountNotZero() throws QueryEvaluationException {
 		Group group = new Group(NONEMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("count", new Count(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
-			assertThat(gi.next().getBinding("count").getValue()).isEqualTo(vf.createLiteral("9", XSD.INTEGER));
+			assertThat(gi.next().getBinding("count").getValue()).isEqualTo(VF.createLiteral("9", XSD.INTEGER));
 		}
 	}
 
@@ -216,9 +217,9 @@ public class GroupIteratorTest {
 	public void testSumNotZero() throws QueryEvaluationException {
 		Group group = new Group(NONEMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("sum", new Sum(new Var("a"))));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 
-			assertThat(gi.next().getBinding("sum").getValue()).isEqualTo(vf.createLiteral("45", XSD.INTEGER));
+			assertThat(gi.next().getBinding("sum").getValue()).isEqualTo(VF.createLiteral("45", XSD.INTEGER));
 		}
 	}
 
@@ -226,9 +227,9 @@ public class GroupIteratorTest {
 	public void testCustomAggregateFunction_Nonempty() throws QueryEvaluationException {
 		Group group = new Group(NONEMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("customSum",
-				new AggregateFunctionCall(new Var("a"), aggregateFunctionFactory.getIri(), false)));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
-			assertThat(gi.next().getBinding("customSum").getValue()).isEqualTo(vf.createLiteral("45", XSD.INTEGER));
+				new AggregateFunctionCall(new Var("a"), AGGREGATE_FUNCTION_FACTORY.getIri(), false)));
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
+			assertThat(gi.next().getBinding("customSum").getValue()).isEqualTo(VF.createLiteral("45", XSD.INTEGER));
 		}
 	}
 
@@ -236,9 +237,9 @@ public class GroupIteratorTest {
 	public void testCustomAggregateFunction_Empty() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("customSum",
-				new AggregateFunctionCall(new Var("a"), aggregateFunctionFactory.getIri(), false)));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
-			assertThat(gi.next().getBinding("customSum").getValue()).isEqualTo(vf.createLiteral("0", XSD.INTEGER));
+				new AggregateFunctionCall(new Var("a"), AGGREGATE_FUNCTION_FACTORY.getIri(), false)));
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
+			assertThat(gi.next().getBinding("customSum").getValue()).isEqualTo(VF.createLiteral("0", XSD.INTEGER));
 		}
 	}
 
@@ -246,7 +247,7 @@ public class GroupIteratorTest {
 	public void testCustomAggregateFunction_WrongIri() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("customSum", new AggregateFunctionCall(new Var("a"), "urn:i", false)));
-		try (GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context)) {
+		try (GroupIterator gi = new GroupIterator(EVALUATOR, group, EmptyBindingSet.getInstance(), CONTEXT)) {
 			assertThatExceptionOfType(QueryEvaluationException.class)
 					.isThrownBy(() -> gi.next().getBinding("customSum").getValue());
 		}
@@ -262,7 +263,7 @@ public class GroupIteratorTest {
 		// Latch to record whether the iteration under GroupIterator was closed
 		CountDownLatch closed = new CountDownLatch(1);
 
-		EvaluationStrategy evaluator = new StrictEvaluationStrategy(null, null) {
+		EvaluationStrategy evaluator = new DefaultEvaluationStrategy(null, null) {
 			@Override
 			protected QueryEvaluationStep prepare(EmptySet emptySet, QueryEvaluationContext context)
 					throws QueryEvaluationException {
@@ -283,7 +284,7 @@ public class GroupIteratorTest {
 		};
 
 		Group group = new Group(new EmptySet());
-		GroupIterator groupIterator = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), context);
+		GroupIterator groupIterator = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance(), CONTEXT);
 
 		Thread iteratorThread = new Thread(groupIterator::next, "GroupIteratorTest#testGroupIteratorClose");
 		try {
@@ -298,11 +299,54 @@ public class GroupIteratorTest {
 		}
 	}
 
+	private static final class FakeAggregateFunctionFactory implements AggregateFunctionFactory {
+		@Override
+		public String getIri() {
+			return "https://www.rdf4j.org/aggregate#x";
+		}
+
+		@Override
+		public AggregateFunction<SumCollector, Value> buildFunction(Function<BindingSet, Value> evaluationStep) {
+			return new AggregateFunction<>(evaluationStep) {
+
+				private ValueExprEvaluationException typeError = null;
+
+				@Override
+				public void processAggregate(BindingSet s, Predicate<Value> distinctValue, SumCollector sum)
+						throws QueryEvaluationException {
+					if (typeError != null) {
+						// halt further processing if a type error has been raised
+						return;
+					}
+					Value v = evaluate(s);
+					if (v instanceof Literal) {
+						if (distinctValue.test(v)) {
+							Literal nextLiteral = (Literal) v;
+							if (nextLiteral.getDatatype() != null
+									&& XMLDatatypeUtil.isNumericDatatype(nextLiteral.getDatatype())) {
+								sum.value = MathUtil.compute(sum.value, nextLiteral, MathExpr.MathOp.PLUS);
+							} else {
+								typeError = new ValueExprEvaluationException("not a number: " + v);
+							}
+						} else {
+							typeError = new ValueExprEvaluationException("not a number: " + v);
+						}
+					}
+				}
+			};
+		}
+
+		@Override
+		public SumCollector getCollector() {
+			return new SumCollector();
+		}
+	}
+
 	/**
 	 * Dummy collector to verify custom aggregate functions
 	 */
 	private static class SumCollector implements AggregateCollector {
-		protected Literal value = vf.createLiteral("0", CoreDatatype.XSD.INTEGER);
+		protected Literal value = VF.createLiteral("0", CoreDatatype.XSD.INTEGER);
 
 		@Override
 		public Value getFinalValue() {


### PR DESCRIPTION



GitHub issue resolved: #GH-5310

Briefly describe the changes proposed in this PR:

The logic to deal with group elements and empty results set was not correct for constant operator values.
This is fixed, plus minor code cleanups.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [X] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

