### PR TITLE
GH-5397 Fix incorrect SHACL format inference

### DIFF
--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -186,7 +186,7 @@ public class Verify extends ConsoleCommand {
 				writeln("Loading shapes from " + shaclPath);
 
 				URL shaclURL = new URL(shaclPath);
-				RDFFormat format = Rio.getParserFormatForFileName(reportFile).orElse(RDFFormat.TURTLE);
+				RDFFormat format = Rio.getParserFormatForFileName(shaclPath).orElse(RDFFormat.TURTLE);
 
 				try (SailRepositoryConnection conn = repo.getConnection()) {
 					conn.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -128,6 +128,25 @@ public class VerifyTest extends AbstractCommandTest {
 	}
 
 	@Test
+	public final void testShaclInvalidFormat() throws IOException {
+		File report = new File(locationFile, "testShaclInvalid.nt");
+		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_invalid.ttl"), report.toString());
+		assertTrue(io.wasErrorWritten());
+		assertTrue(Files.size(report.toPath()) > 0);
+	}
+
+	@Test
+	public final void testShaclValidFormat() throws IOException {
+		File report = new File(locationFile, "testShaclValid.nt");
+		assertTrue(report.createNewFile());
+		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_valid.ttl"), report.toString());
+
+		verify(mockConsoleIO, never()).writeError(anyString());
+		assertFalse(Files.size(report.toPath()) > 0);
+		assertFalse(io.wasErrorWritten());
+	}
+
+	@Test
 	public final void testShaclValidWorkDir() throws IOException {
 		setWorkingDir(cmd);
 


### PR DESCRIPTION
GitHub issue resolved: #5397 


Briefly describe the changes proposed in this PR:

Change SHACL format inference to be based on the SHACL itself (`shaclPath`), instead of the report file (`reportFile`).

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

