### PR TITLE
GH-5395 Change console convert, export, verify to use OutputStreams when writing

### DIFF
--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.console.command;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -132,7 +132,7 @@ public class Convert extends ConsoleCommand {
 		String baseURI = pathFrom.toUri().toString();
 
 		try (BufferedInputStream r = new BufferedInputStream(Files.newInputStream(pathFrom));
-				BufferedWriter w = Files.newBufferedWriter(pathTo)) {
+				BufferedOutputStream w = new BufferedOutputStream(Files.newOutputStream(pathTo))) {
 			RDFWriter writer = Rio.createWriter(fmtTo.get(), w);
 			parser.setRDFHandler(writer);
 
@@ -140,6 +140,8 @@ public class Convert extends ConsoleCommand {
 			writeln("Converting file ...");
 
 			parser.parse(r, baseURI);
+
+			w.flush();
 
 			long diff = (System.nanoTime() - startTime) / 1_000_000;
 			writeln("Data has been written to file (" + diff + " ms)");

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
@@ -10,9 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import java.io.IOException;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -127,8 +125,8 @@ public class Export extends ConsoleCommand {
 		}
 
 		try (RepositoryConnection conn = repository.getConnection();
-				Writer w = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.CREATE,
-						StandardOpenOption.TRUNCATE_EXISTING)) {
+				BufferedOutputStream w = new BufferedOutputStream(Files.newOutputStream(path, StandardOpenOption.CREATE,
+						StandardOpenOption.TRUNCATE_EXISTING))) {
 
 			RDFFormat fmt = Rio.getWriterFormatForFileName(fileName)
 					.orElseThrow(() -> new UnsupportedRDFormatException("No RDF parser for " + fileName));
@@ -138,6 +136,8 @@ public class Export extends ConsoleCommand {
 			writeln("Exporting data...");
 
 			conn.export(writer, contexts);
+
+			w.flush();
 
 			long diff = (System.nanoTime() - startTime) / 1_000_000;
 			writeln("Data has been written to file (" + diff + " ms)");

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -279,8 +279,9 @@ public class Verify extends ConsoleCommand {
 
 		RDFFormat format = Rio.getParserFormatForFileName(reportFile).orElse(RDFFormat.TURTLE);
 
-		try (Writer w = Files.newBufferedWriter(Paths.get(reportFile))) {
+		try (BufferedOutputStream w = new BufferedOutputStream(Files.newOutputStream(Paths.get(reportFile)))) {
 			Rio.write(model, w, format, cfg);
+			w.flush();
 		} catch (IOException ex) {
 			writeError("Could not write report to " + reportFile, ex);
 		}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -67,6 +67,14 @@ public class ConvertTest extends AbstractCommandTest {
 	}
 
 	@Test
+	public final void testConvertToBinary() {
+		File binary = new File(locationFile, "alien.brf");
+		cmd.execute("convert", from.getAbsolutePath(), binary.getAbsolutePath());
+
+		assertTrue(binary.length() > 0, "File is empty");
+	}
+
+	@Test
 	public final void testConvertWorkDir() {
 		setWorkingDir(cmd);
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -69,6 +69,15 @@ public class ExportTest extends AbstractCommandTest {
 	}
 
 	@Test
+	public final void testExportAllToBinary() throws RepositoryException {
+		File binary = new File(locationFile, "all.brf");
+		cmd.execute("export", binary.getAbsolutePath());
+		assertTrue(binary.length() > 0, "File is empty");
+
+		binary.delete();
+	}
+
+	@Test
 	public final void testExportWorkDir() throws RepositoryException, IOException {
 		setWorkingDir(cmd);
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -128,6 +128,25 @@ public class VerifyTest extends AbstractCommandTest {
 	}
 
 	@Test
+	public final void testShaclInvalidToBinary() throws IOException {
+		File report = new File(locationFile, "testShaclInvalid.brf");
+		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_invalid.ttl"), report.toString());
+		assertTrue(io.wasErrorWritten());
+		assertTrue(Files.size(report.toPath()) > 0);
+	}
+
+	@Test
+	public final void testShaclValidToBinary() throws IOException {
+		File report = new File(locationFile, "testShaclValid.brf");
+		assertTrue(report.createNewFile());
+		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_valid.ttl"), report.toString());
+
+		verify(mockConsoleIO, never()).writeError(anyString());
+		assertFalse(Files.size(report.toPath()) > 0);
+		assertFalse(io.wasErrorWritten());
+	}
+
+	@Test
 	public final void testShaclValidWorkDir() throws IOException {
 		setWorkingDir(cmd);
 


### PR DESCRIPTION
GitHub issue resolved: #5395

Briefly describe the changes proposed in this PR:

I change `BufferedWriters` to `BufferedOutputStreams` for console `convert, export, verify` commands. This is required as binary formats can't be written using `Writers`.

This PR is dependent on #5398 - otherwise tests for `verify` will fail as the application will attempt to read a binary format from a .ttl file.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

