### PR TITLE
GH-5400: add missing resources (dcat:resource and dcat:hasVersion) to the DCAT vocabulary class

### DIFF
--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/DCAT.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/DCAT.java
@@ -122,8 +122,14 @@ public class DCAT {
 	/** dcat:record */
 	public static final IRI HAS_RECORD;
 
+	/** dcat:resource */
+	public static final IRI HAS_RESOURCE;
+
 	/** dcat:service */
 	public static final IRI HAS_SERVICE;
+
+	/** dcat:hasVersion */
+	public static final IRI HAS_VERSION;
 
 	/** dcat;inCatalog, inverse property, see section 7 of DCAT v3 */
 	public static final IRI IN_CATALOG;
@@ -221,7 +227,9 @@ public class DCAT {
 		HAS_CURRENT_VERSION = Vocabularies.createIRI(NAMESPACE, "hasCurrentVersion");
 		HAS_DISTRIBUTION = Vocabularies.createIRI(NAMESPACE, "distribution");
 		HAS_RECORD = Vocabularies.createIRI(NAMESPACE, "record");
+		HAS_RESOURCE = Vocabularies.createIRI(NAMESPACE, "resource");
 		HAS_SERVICE = Vocabularies.createIRI(NAMESPACE, "service");
+		HAS_VERSION = Vocabularies.createIRI(NAMESPACE, "hasVersion");
 		IN_CATALOG = Vocabularies.createIRI(NAMESPACE, "inCatalog");
 		IN_SERIES = Vocabularies.createIRI(NAMESPACE, "inSeries");
 		IS_DISTRIBUTION_OF = Vocabularies.createIRI(NAMESPACE, "isDistributionOf");


### PR DESCRIPTION
GitHub issue resolved: #5400

Briefly describe the changes proposed in this PR:

Add two static fields for the missing vocabulary resources:
* [dcat:resource](https://www.w3.org/TR/vocab-dcat-3/#Property:catalog_resource)
* [dcat:hasVersion](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_has_version)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

