### PR TITLE
GH-5358: fix query evaluation errors when using VALUES clause in SERVICE

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
@@ -340,6 +340,16 @@ public class RepositoryFederatedServiceIntegrationTest {
 		}
 	}
 
+	@Test
+	public void test_ValuesClause() {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { VALUES ?var { 'val1' 'val2' } ?s ?p ?var  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1")));
+	}
+
 	private void addData(Repository repo, Collection<? extends Statement> m) {
 		try (RepositoryConnection conn = repo.getConnection()) {
 			conn.add(m);

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/SparqlFederatedServiceIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/SparqlFederatedServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Eclipse RDF4J contributors.
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/SparqlFederatedServiceIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/SparqlFederatedServiceIntegrationTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql.federation;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class SparqlFederatedServiceIntegrationTest {
+
+	@Test
+	@Disabled("manual test to demonstrate the original issue of GH-5358")
+	public void testValues_Wikidata() {
+		Repository repo = new SailRepository(new MemoryStore());
+		try (var conn = repo.getConnection()) {
+
+			var tq = conn.prepareTupleQuery("PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+					+ "PREFIX sh: <http://www.w3.org/ns/shacl#>\n"
+					+ "SELECT * WHERE {\n"
+					+ "  SERVICE <https://query.wikidata.org/sparql> {\n"
+					+ "   VALUES ?resource {\n"
+					+ "     <http://www.wikidata.org/entity/Q7455975>\n"
+					+ "   }\n"
+					+ "   ?resource <http://www.wikidata.org/prop/direct/P856> ?website\n"
+					+ "  }\n"
+					+ "}");
+
+			try (var tqr = tq.evaluate()) {
+				tqr.stream().forEach(bs -> System.out.println(bs));
+			}
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/BindingSetAssignmentInlinerOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/BindingSetAssignmentInlinerOptimizer.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
@@ -52,6 +53,11 @@ public class BindingSetAssignmentInlinerOptimizer implements QueryOptimizer {
 				}
 			}
 			super.meet(bsa);
+		}
+
+		@Override
+		public void meet(Service node) throws RuntimeException {
+			// do not inject bindings inside service clauses
 		}
 
 		@Override


### PR DESCRIPTION
GitHub issue resolved: #5358

The BindingSetAssingmentInlinerOptimizer attempts to inject a single value from VALUES clauses into matching variables.

For SERVICE causes this is problematic (when they later get evaluated through the SparqlFederatedService):

the SPARQLFederatedService computes the set of bound variables and applies logic. Here it is important, that binding set assignments are not inlined. Otherwise, a query evaluation exception is thrown due to a malformed query.

The actual query at evaluation time (in case such inlining happened) would contain something like

VALUES <http://www.example.com/MyResource> {
   <http://www.example.com/MyResource>
}

i.e. the variable name of the VALUES clause incorrectly replaced.

This change fixes it by not applying inlining insider SERVICE nodes.

Various unit tests on different levels have been added, which I used to get closer to the problem.



----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

