### PR TITLE
Extend methods of SailConnectionListener with inferred argument

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnectionListener.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnectionListener.java
@@ -13,12 +13,32 @@ package org.eclipse.rdf4j.sail;
 import org.eclipse.rdf4j.model.Statement;
 
 public interface SailConnectionListener {
+	/**
+	 * Notifies the listener that a statement has been added in a transaction that it has registered itself with.
+	 *
+	 * @param st       The statement that was added.
+	 * @param inferred The flag that indicates whether the statement is inferred or explicit.
+	 */
+	default void statementAdded(Statement st, boolean inferred) {
+		statementAdded(st);
+	}
+
+	/**
+	 * Notifies the listener that a statement has been removed in a transaction that it has registered itself with.
+	 *
+	 * @param st       The statement that was removed.
+	 * @param inferred The flag that indicates whether the statement was inferred or explicit.
+	 */
+	default void statementRemoved(Statement st, boolean inferred) {
+		statementRemoved(st);
+	}
 
 	/**
 	 * Notifies the listener that a statement has been added in a transaction that it has registered itself with.
 	 *
 	 * @param st The statement that was added.
 	 */
+	@Deprecated(since = "5.2.0", forRemoval = true)
 	void statementAdded(Statement st);
 
 	/**
@@ -26,5 +46,6 @@ public interface SailConnectionListener {
 	 *
 	 * @param st The statement that was removed.
 	 */
+	@Deprecated(since = "5.2.0", forRemoval = true)
 	void statementRemoved(Statement st);
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractNotifyingSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractNotifyingSailConnection.java
@@ -48,16 +48,26 @@ public abstract class AbstractNotifyingSailConnection extends AbstractSailConnec
 		return !listeners.isEmpty();
 	}
 
+	@Deprecated(since = "5.2.0", forRemoval = true)
 	protected void notifyStatementAdded(Statement st) {
+		notifyStatementAdded(st, false);
+	}
+
+	protected void notifyStatementAdded(Statement st, boolean inferred) {
 		for (SailConnectionListener listener : listeners) {
-			listener.statementAdded(st);
+			listener.statementAdded(st, inferred);
 		}
 
 	}
 
+	@Deprecated(since = "5.2.0", forRemoval = true)
 	protected void notifyStatementRemoved(Statement st) {
+		notifyStatementRemoved(st, false);
+	}
+
+	protected void notifyStatementRemoved(Statement st, boolean inferred) {
 		for (SailConnectionListener listener : listeners) {
-			listener.statementRemoved(st);
+			listener.statementRemoved(st, inferred);
 		}
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #5118 

Briefly describe the changes proposed in this PR:

Extend methods of SailConnectionListener with inferred argument to distinguish between explicit and inferred statements.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

