### PR TITLE
GH-4992  fix for parent

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -449,7 +449,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 				// create an extension linking the operator to the variable
 				// name.
-				ExtensionElem pe = new ExtensionElem(operator, alias);
+				ExtensionElem pe = new ExtensionElem(operator.clone(), alias);
 				extension.addElement(pe);
 
 				// add the aggregate operator to the group.
@@ -494,7 +494,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 					// name.
 					String alias = var.getName();
 
-					ExtensionElem pe = new ExtensionElem(operator, alias);
+					ExtensionElem pe = new ExtensionElem(operator.clone(), alias);
 					extension.addElement(pe);
 
 					// add the aggregate operator to the group.
@@ -576,7 +576,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 							Extension anonymousExtension = new Extension();
 							Var anonVar = createAnonVar();
 							expr.replaceChildNode(operator, anonVar);
-							anonymousExtension.addElement(new ExtensionElem(operator, anonVar.getName()));
+							anonymousExtension.addElement(new ExtensionElem(operator.clone(), anonVar.getName()));
 
 							anonymousExtension.setArg(result);
 							result = anonymousExtension;
@@ -593,7 +593,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 				// SELECT expressions need to be captured as an extension, so that original and alias are
 				// available for the ORDER BY clause (which gets applied _before_ projection). See GH-4066
 				// and https://www.w3.org/TR/sparql11-query/#sparqlSolMod .
-				ExtensionElem extElem = new ExtensionElem(valueExpr, alias);
+				ExtensionElem extElem = new ExtensionElem(cloneIfAggregate(valueExpr), alias);
 				extension.addElement(extElem);
 				elem.setSourceExpression(extElem);
 			} else if (child instanceof ASTVar) {
@@ -661,6 +661,13 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		}
 
 		return result;
+	}
+
+	private ValueExpr cloneIfAggregate(ValueExpr valueExpr) {
+		if (valueExpr instanceof AggregateOperator) {
+			return ((AggregateOperator) valueExpr).clone();
+		}
+		return valueExpr;
 	}
 
 	private static boolean isIllegalCombinedWithGroupByExpression(ValueExpr expr, List<ProjectionElem> elements,


### PR DESCRIPTION
GitHub issue resolved: #4992
This pull request improves the handling of aggregate operators in SPARQL query parsing, ensuring that each aggregate operator instance is properly cloned and parented in the query model tree. This prevents shared references and ensures correct parent-child relationships, which is critical for query correctness and further processing. The changes also add comprehensive tests to verify these relationships across various query constructs.

### Aggregate operator handling improvements

* Updated `TupleExprBuilder.java` to clone aggregate operator instances before adding them to `ExtensionElem`, preventing shared references between group and extension nodes and ensuring correct parent assignment. [[1]](diffhunk://#diff-bbccb2ab14ceed75efc33659f7ed7a65b205d950d03fc04f1e0ed406ab7aa93cL452-R452) [[2]](diffhunk://#diff-bbccb2ab14ceed75efc33659f7ed7a65b205d950d03fc04f1e0ed406ab7aa93cL497-R497) [[3]](diffhunk://#diff-bbccb2ab14ceed75efc33659f7ed7a65b205d950d03fc04f1e0ed406ab7aa93cL579-R579) [[4]](diffhunk://#diff-bbccb2ab14ceed75efc33659f7ed7a65b205d950d03fc04f1e0ed406ab7aa93cL596-R596)
* Added a helper method `cloneIfAggregate(ValueExpr valueExpr)` to centralize the logic for cloning aggregate operators.

### Test enhancements

* Added new tests in `TupleExprBuilderTest.java` to verify that aggregate operators have the correct parent references in projections, order by, having, and group by clauses, and that cloned instances are used where required.
* Introduced utility methods and context classes in the test suite to collect and check aggregate operator instances and their parent nodes, improving test coverage and maintainability.
* Added necessary imports to support new test logic and aggregate operator handling. <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

