### PR TITLE
Handle Instant literals in TemporalAccessorLiteral

### DIFF
--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.model.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.IllformedLocaleException;
@@ -105,6 +107,17 @@ public class LiteralsTest {
 		// invalid
 		assertThatExceptionOfType(IllformedLocaleException.class)
 				.isThrownBy(() -> Literals.normalizeLanguageTag("ru-ua-latn"));
+	}
+
+	@Test
+	public void valuesLiteralSupportsInstant() {
+		Instant instant = Instant.parse("2022-08-01T21:14:38.470534100Z");
+
+		Literal literal = Values.literal(instant);
+
+		assertThat(Instant.parse(literal.getLabel())).isEqualTo(instant);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.DATETIME);
+		assertThat(literal.temporalAccessorValue()).isEqualTo(instant);
 	}
 
 	/**


### PR DESCRIPTION
GitHub issue resolved: #4104 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

