### PR TITLE
GH-4856 include UTF-8 charset in CSV tuple MIME type

### DIFF
--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
@@ -81,8 +81,9 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	/**
 	 * SPARQL Query Result CSV Format.
 	 */
-	public static final TupleQueryResultFormat CSV = new TupleQueryResultFormat("SPARQL/CSV", List.of("text/csv"),
-			StandardCharsets.UTF_8, List.of("csv"), SPARQL_RESULTS_CSV_URI, NO_RDF_STAR);
+	public static final TupleQueryResultFormat CSV = new TupleQueryResultFormat("SPARQL/CSV",
+			List.of("text/csv;charset=UTF-8", "text/csv"), StandardCharsets.UTF_8, List.of("csv"),
+			SPARQL_RESULTS_CSV_URI, NO_RDF_STAR);
 
 	/**
 	 * SPARQL Query Result TSV Format.

--- a/core/queryresultio/api/src/test/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormatTest.java
+++ b/core/queryresultio/api/src/test/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormatTest.java
@@ -1,0 +1,17 @@
+package org.eclipse.rdf4j.query.resultio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TupleQueryResultFormatTest {
+
+	@Test
+	@DisplayName("CSV default MIME type should include UTF-8 charset parameter as required by spec")
+	void csvMimeTypeShouldIncludeCharsetParameter() {
+		assertThat(TupleQueryResultFormat.CSV.getDefaultMIMEType())
+				.as("MIME type should advertise UTF-8 charset")
+				.isEqualTo("text/csv;charset=UTF-8");
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #4856 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

