### PR TITLE
GH-5723: add RDF4JHttpClientConfig#toBuilder() and refactor

### DIFF
--- a/core/http/client-api/src/main/java/org/eclipse/rdf4j/http/client/spi/RDF4JHttpClientConfig.java
+++ b/core/http/client-api/src/main/java/org/eclipse/rdf4j/http/client/spi/RDF4JHttpClientConfig.java
@@ -173,6 +173,27 @@ public class RDF4JHttpClientConfig {
 	}
 
 	/**
+	 * Returns a new {@link Builder} pre-populated with all settings from this config. Useful for creating a modified
+	 * copy without having to re-specify every field.
+	 *
+	 * @return a {@link Builder} seeded from this config
+	 */
+	public Builder toBuilder() {
+		return new Builder()
+				.connectTimeoutMs(connectTimeoutMs)
+				.socketTimeoutMs(socketTimeoutMs)
+				.connectionRequestTimeoutMs(connectionRequestTimeoutMs)
+				.maxConnectionsPerRoute(maxConnectionsPerRoute)
+				.maxConnectionsTotal(maxConnectionsTotal)
+				.maxRedirects(maxRedirects)
+				.followRedirects(followRedirects)
+				.idleConnectionTimeoutMs(idleConnectionTimeoutMs)
+				.sslContext(sslContext)
+				.disableHostnameVerification(disableHostnameVerification)
+				.defaultHeaders(defaultHeaders);
+	}
+
+	/**
 	 * Returns a new {@link RDF4JHttpClientConfig} with all settings at their default values.
 	 *
 	 * @return a default {@link RDF4JHttpClientConfig}

--- a/core/http/client-api/src/test/java/org/eclipse/rdf4j/http/client/spi/RDF4JHttpClientConfigTest.java
+++ b/core/http/client-api/src/test/java/org/eclipse/rdf4j/http/client/spi/RDF4JHttpClientConfigTest.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.client.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class RDF4JHttpClientConfigTest {
+
+	@Test
+	void toBuilderCopiesAllFields() {
+		RDF4JHttpClientConfig original = RDF4JHttpClientConfig.newBuilder()
+				.connectTimeoutMs(1_000)
+				.socketTimeoutMs(2_000)
+				.connectionRequestTimeoutMs(3_000)
+				.maxConnectionsPerRoute(10)
+				.maxConnectionsTotal(20)
+				.maxRedirects(3)
+				.followRedirects(false)
+				.idleConnectionTimeoutMs(60_000L)
+				.disableHostnameVerification(true)
+				.defaultHeaders(List.of(HttpHeader.of("X-Custom", "value")))
+				.build();
+
+		RDF4JHttpClientConfig copy = original.toBuilder().build();
+
+		assertThat(copy.getConnectTimeoutMs()).isEqualTo(original.getConnectTimeoutMs());
+		assertThat(copy.getSocketTimeoutMs()).isEqualTo(original.getSocketTimeoutMs());
+		assertThat(copy.getConnectionRequestTimeoutMs()).isEqualTo(original.getConnectionRequestTimeoutMs());
+		assertThat(copy.getMaxConnectionsPerRoute()).isEqualTo(original.getMaxConnectionsPerRoute());
+		assertThat(copy.getMaxConnectionsTotal()).isEqualTo(original.getMaxConnectionsTotal());
+		assertThat(copy.getMaxRedirects()).isEqualTo(original.getMaxRedirects());
+		assertThat(copy.isFollowRedirects()).isEqualTo(original.isFollowRedirects());
+		assertThat(copy.getIdleConnectionTimeoutMs()).isEqualTo(original.getIdleConnectionTimeoutMs());
+		assertThat(copy.isDisableHostnameVerification()).isEqualTo(original.isDisableHostnameVerification());
+		assertThat(copy.getDefaultHeaders())
+				.usingRecursiveFieldByFieldElementComparator()
+				.isEqualTo(original.getDefaultHeaders());
+		assertThat(copy.getSslContext()).isEqualTo(original.getSslContext());
+	}
+
+	@Test
+	void toBuilderOverrideDoesNotAffectOriginal() {
+		RDF4JHttpClientConfig original = RDF4JHttpClientConfig.newBuilder()
+				.connectTimeoutMs(5_000)
+				.socketTimeoutMs(10_000)
+				.connectionRequestTimeoutMs(15_000)
+				.defaultHeader("X-Original", "yes")
+				.build();
+
+		RDF4JHttpClientConfig modified = original.toBuilder()
+				.connectTimeoutMs(1_000)
+				.socketTimeoutMs(2_000)
+				.connectionRequestTimeoutMs(3_000)
+				.defaultHeaders(List.of(HttpHeader.of("X-Modified", "yes")))
+				.build();
+
+		// original is unchanged
+		assertThat(original.getConnectTimeoutMs()).isEqualTo(5_000);
+		assertThat(original.getSocketTimeoutMs()).isEqualTo(10_000);
+		assertThat(original.getConnectionRequestTimeoutMs()).isEqualTo(15_000);
+		assertThat(original.getDefaultHeaders())
+				.extracting(HttpHeader::getName, HttpHeader::getValue)
+				.containsExactly(tuple("X-Original", "yes"));
+
+		// modified has new values
+		assertThat(modified.getConnectTimeoutMs()).isEqualTo(1_000);
+		assertThat(modified.getSocketTimeoutMs()).isEqualTo(2_000);
+		assertThat(modified.getConnectionRequestTimeoutMs()).isEqualTo(3_000);
+		assertThat(modified.getDefaultHeaders())
+				.extracting(HttpHeader::getName, HttpHeader::getValue)
+				.containsExactly(tuple("X-Modified", "yes"));
+	}
+
+	@Test
+	void toBuilderDefaultHeadersListIsIndependent() {
+		RDF4JHttpClientConfig original = RDF4JHttpClientConfig.newBuilder()
+				.defaultHeader("X-A", "1")
+				.build();
+
+		// Adding a header via toBuilder should not affect the original
+		RDF4JHttpClientConfig withExtra = original.toBuilder()
+				.defaultHeader("X-B", "2")
+				.build();
+
+		assertThat(original.getDefaultHeaders()).hasSize(1);
+		assertThat(original.getDefaultHeaders())
+				.extracting(HttpHeader::getName, HttpHeader::getValue)
+				.containsExactly(tuple("X-A", "1"));
+		assertThat(withExtra.getDefaultHeaders()).hasSize(2);
+	}
+}

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -283,11 +283,9 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	public static final int SPARQL_SOCKET_TIMEOUT = Integer.parseInt(
 			System.getProperty(SPARQL_SOCKET_TIMEOUT_PROPERTY, String.valueOf(DEFAULT_SPARQL_SOCKET_TIMEOUT)));
 
-	// Variables for the currently used timeouts
+	// Full config used when lazily creating the internal HTTP client
 
-	private int currentConnectionTimeout = CONNECTION_TIMEOUT;
-	private int currentConnectionRequestTimeout = CONNECTION_REQUEST_TIMEOUT;
-	private int currentSocketTimeout = SOCKET_TIMEOUT;
+	private volatile RDF4JHttpClientConfig currentConfig = buildDefaultConfig();
 
 	private final Logger logger = LoggerFactory.getLogger(SharedHttpClientSessionManager.class);
 
@@ -358,15 +356,20 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	}
 
 	/**
-	 * Set an optional {@link RDF4JHttpClientConfig} to be used when creating the inner HTTP client (if not provided
-	 * externally as dependent client).
+	 * Sets the {@link RDF4JHttpClientConfig} to be used when creating the internal HTTP client (if not provided
+	 * externally via {@link #setHttpClient(RDF4JHttpClient)}). The full configuration is applied, including timeouts,
+	 * connection limits, SSL context, default headers, and redirect policy.
 	 *
-	 * @param config the configuration for the managed HTTP client
+	 * <p>
+	 * This method always updates the stored configuration. However, if an external HTTP client has already been
+	 * assigned via {@link #setHttpClient(RDF4JHttpClient)}, or if the internal client has already been lazily
+	 * initialised, the new configuration will <em>not</em> be applied to the already-created client. In that case
+	 * {@link #getDefaultHttpClientConfig()} will return the updated config even though it is not in use.
+	 *
+	 * @param config the configuration for the managed HTTP client; must not be {@code null}
 	 */
 	public void setHttpClientConfig(RDF4JHttpClientConfig config) {
-		this.currentConnectionTimeout = config.getConnectTimeoutMs();
-		this.currentConnectionRequestTimeout = config.getConnectionRequestTimeoutMs();
-		this.currentSocketTimeout = config.getSocketTimeoutMs();
+		this.currentConfig = Objects.requireNonNull(config, "config must not be null");
 	}
 
 	@Override
@@ -457,20 +460,23 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	}
 
 	private RDF4JHttpClient createHttpClient() {
-		RDF4JHttpClientConfig config = getDefaultHttpClientConfig();
-		return RDF4JHttpClients.newDefaultClient(config);
+		return RDF4JHttpClients.newDefaultClient(currentConfig);
 	}
 
 	/**
-	 * Returns the default {@link RDF4JHttpClientConfig} using the currently set timeout values.
+	 * Returns the {@link RDF4JHttpClientConfig} that will be used when lazily creating the internal HTTP client.
 	 *
-	 * @return a configured {@link RDF4JHttpClientConfig} with the current timeouts.
+	 * @return the current {@link RDF4JHttpClientConfig}; never {@code null}
 	 */
 	public RDF4JHttpClientConfig getDefaultHttpClientConfig() {
+		return currentConfig;
+	}
+
+	private static RDF4JHttpClientConfig buildDefaultConfig() {
 		return RDF4JHttpClientConfig.newBuilder()
-				.connectTimeoutMs(currentConnectionTimeout)
-				.connectionRequestTimeoutMs(currentConnectionRequestTimeout)
-				.socketTimeoutMs(currentSocketTimeout)
+				.connectTimeoutMs(CONNECTION_TIMEOUT)
+				.connectionRequestTimeoutMs(CONNECTION_REQUEST_TIMEOUT)
+				.socketTimeoutMs(SOCKET_TIMEOUT)
 				.maxConnectionsPerRoute(MAX_CONN_PER_ROUTE)
 				.maxConnectionsTotal(MAX_CONN_TOTAL)
 				.followRedirects(true)
@@ -488,9 +494,11 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	 * </p>
 	 */
 	public void setDefaultSparqlServiceTimeouts() {
-		this.currentConnectionTimeout = SPARQL_CONNECTION_TIMEOUT;
-		this.currentConnectionRequestTimeout = SPARQL_CONNECTION_REQUEST_TIMEOUT;
-		this.currentSocketTimeout = SPARQL_SOCKET_TIMEOUT;
+		this.currentConfig = currentConfig.toBuilder()
+				.connectTimeoutMs(SPARQL_CONNECTION_TIMEOUT)
+				.connectionRequestTimeoutMs(SPARQL_CONNECTION_REQUEST_TIMEOUT)
+				.socketTimeoutMs(SPARQL_SOCKET_TIMEOUT)
+				.build();
 	}
 
 	/**
@@ -503,9 +511,11 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	 * </p>
 	 */
 	public void setDefaultTimeouts() {
-		this.currentConnectionTimeout = CONNECTION_TIMEOUT;
-		this.currentConnectionRequestTimeout = CONNECTION_REQUEST_TIMEOUT;
-		this.currentSocketTimeout = SOCKET_TIMEOUT;
+		this.currentConfig = currentConfig.toBuilder()
+				.connectTimeoutMs(CONNECTION_TIMEOUT)
+				.connectionRequestTimeoutMs(CONNECTION_REQUEST_TIMEOUT)
+				.socketTimeoutMs(SOCKET_TIMEOUT)
+				.build();
 	}
 
 }


### PR DESCRIPTION
SharedHttpClientSessionManager

  - Add toBuilder() to RDF4JHttpClientConfig to allow creating modified copies without re-specifying all fields
  - Replace the three separate timeout fields in SharedHttpClientSessionManager
    with a single volatile RDF4JHttpClientConfig, so that setHttpClientConfig()
    now propagates the full config (not just the three timeout values)
  - Use toBuilder() in setDefaultSparqlServiceTimeouts() and setDefaultTimeouts() to apply only the timeout overrides while preserving all other config settings


GitHub issue resolved: #5723 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

