### PR TITLE
GH-5723: propagate maxExecutionTime as per-request HTTP response timeout

### DIFF
--- a/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClient.java
+++ b/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClient.java
@@ -18,11 +18,13 @@ import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.util.Timeout;
 import org.eclipse.rdf4j.http.client.spi.HttpHeader;
 import org.eclipse.rdf4j.http.client.spi.HttpRequest;
 import org.eclipse.rdf4j.http.client.spi.HttpRequestBody;
@@ -100,6 +102,11 @@ public class ApacheHC5RDF4JHttpClient implements RDF4JHttpClient {
 		for (HttpHeader header : request.getHeaders()) {
 			hcRequest.addHeader(header.getName(), header.getValue());
 		}
+
+		// Apply per-request response timeout if present
+		request.getResponseTimeout()
+				.ifPresent(timeout -> hcRequest
+						.setConfig(RequestConfig.custom().setResponseTimeout(Timeout.of(timeout)).build()));
 
 		// Set body. Repeatable (byte-backed) bodies use ByteArrayEntity so that Apache HC5's
 		// RedirectExec can follow redirects and the 408 retry loop can re-send the request.

--- a/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClient.java
+++ b/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClient.java
@@ -47,9 +47,17 @@ public class ApacheHC5RDF4JHttpClient implements RDF4JHttpClient {
 	 */
 	private final int maxRetries408;
 
-	public ApacheHC5RDF4JHttpClient(CloseableHttpClient httpClient, int maxConnectionsPerRoute) {
+	/**
+	 * Default request config used as the base when building per-request overrides, so that factory-level settings
+	 * (connectionRequestTimeout, redirectsEnabled, cookieSpec) are preserved.
+	 */
+	private final RequestConfig defaultRequestConfig;
+
+	public ApacheHC5RDF4JHttpClient(CloseableHttpClient httpClient, int maxConnectionsPerRoute,
+			RequestConfig defaultRequestConfig) {
 		this.httpClient = httpClient;
 		this.maxRetries408 = maxConnectionsPerRoute + 1;
+		this.defaultRequestConfig = defaultRequestConfig;
 	}
 
 	@Override
@@ -103,10 +111,13 @@ public class ApacheHC5RDF4JHttpClient implements RDF4JHttpClient {
 			hcRequest.addHeader(header.getName(), header.getValue());
 		}
 
-		// Apply per-request response timeout if present
+		// Apply per-request response timeout if present, copying from the default config so that
+		// factory-level settings (connectionRequestTimeout, redirectsEnabled, cookieSpec) are preserved.
 		request.getResponseTimeout()
 				.ifPresent(timeout -> hcRequest
-						.setConfig(RequestConfig.custom().setResponseTimeout(Timeout.of(timeout)).build()));
+						.setConfig(RequestConfig.copy(defaultRequestConfig)
+								.setResponseTimeout(Timeout.of(timeout))
+								.build()));
 
 		// Set body. Repeatable (byte-backed) bodies use ByteArrayEntity so that Apache HC5's
 		// RedirectExec can follow redirects and the 408 retry loop can re-send the request.

--- a/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClientFactory.java
+++ b/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClientFactory.java
@@ -136,7 +136,7 @@ public class ApacheHC5RDF4JHttpClientFactory implements RDF4JHttpClientFactory {
 		}
 
 		CloseableHttpClient httpClient = buildHttpClient(builder, config);
-		return new ApacheHC5RDF4JHttpClient(httpClient, config.getMaxConnectionsPerRoute());
+		return new ApacheHC5RDF4JHttpClient(httpClient, config.getMaxConnectionsPerRoute(), requestConfig);
 	}
 
 	/**

--- a/core/http/client-api/src/main/java/org/eclipse/rdf4j/http/client/spi/HttpRequest.java
+++ b/core/http/client-api/src/main/java/org/eclipse/rdf4j/http/client/spi/HttpRequest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.http.client.spi;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -48,12 +49,14 @@ public class HttpRequest {
 	private final URI uri;
 	private final List<HttpHeader> headers;
 	private final HttpRequestBody body;
+	private final Duration responseTimeout;
 
 	private HttpRequest(Builder builder) {
 		this.method = builder.method;
 		this.uri = builder.uri;
 		this.headers = new ArrayList<>(builder.headers);
 		this.body = builder.body;
+		this.responseTimeout = builder.responseTimeout;
 	}
 
 	/**
@@ -143,6 +146,17 @@ public class HttpRequest {
 	}
 
 	/**
+	 * Returns the optional response timeout for this request. When present, the HTTP client must abort the request if
+	 * no response data arrives within this duration. Overrides any client-level socket timeout for this specific
+	 * request.
+	 *
+	 * @return an {@link Optional} containing the response timeout, or empty if no per-request timeout is set
+	 */
+	public Optional<Duration> getResponseTimeout() {
+		return Optional.ofNullable(responseTimeout);
+	}
+
+	/**
 	 * Creates a new {@link Builder} for the given HTTP method and target URI.
 	 *
 	 * @param method the HTTP method (e.g. {@code "GET"}, {@code "POST"}); must not be {@code null}
@@ -165,7 +179,8 @@ public class HttpRequest {
 	public static Builder copyOf(HttpRequest original, URI uri) {
 		return new Builder(original.method, uri)
 				.headers(original.headers)
-				.body(original.body);
+				.body(original.body)
+				.responseTimeout(original.responseTimeout);
 	}
 
 	/**
@@ -181,6 +196,7 @@ public class HttpRequest {
 		private final URI uri;
 		private final List<HttpHeader> headers = new ArrayList<>();
 		private HttpRequestBody body;
+		private Duration responseTimeout;
 
 		private Builder(String method, URI uri) {
 			this.method = method;
@@ -233,6 +249,19 @@ public class HttpRequest {
 		 */
 		public Builder body(HttpRequestBody body) {
 			this.body = body;
+			return this;
+		}
+
+		/**
+		 * Sets the response timeout for this request. When set, the HTTP client must abort the request if no response
+		 * data arrives within this duration, overriding any client-level socket timeout. Pass {@code null} to clear a
+		 * previously set timeout.
+		 *
+		 * @param timeout the response timeout, or {@code null} for no per-request timeout
+		 * @return this builder
+		 */
+		public Builder responseTimeout(Duration timeout) {
+			this.responseTimeout = timeout;
 			return this;
 		}
 

--- a/core/http/client-jdk/src/main/java/org/eclipse/rdf4j/http/client/jdk/JdkRDF4JHttpClient.java
+++ b/core/http/client-jdk/src/main/java/org/eclipse/rdf4j/http/client/jdk/JdkRDF4JHttpClient.java
@@ -53,8 +53,10 @@ public class JdkRDF4JHttpClient implements RDF4JHttpClient {
 				builder.header(header.getName(), header.getValue());
 			}
 
-			// Set socket timeout if configured
-			if (config.getSocketTimeoutMs() > 0) {
+			// Per-request response timeout takes precedence over the global socket timeout from config
+			if (request.getResponseTimeout().isPresent()) {
+				builder.timeout(request.getResponseTimeout().get());
+			} else if (config.getSocketTimeoutMs() > 0) {
 				builder.timeout(Duration.ofMillis(config.getSocketTimeoutMs()));
 			}
 

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -22,6 +22,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -855,6 +856,9 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 		for (Map.Entry<String, String> additionalHeader : getAdditionalHttpHeaders().entrySet()) {
 			builder.header(additionalHeader.getKey(), additionalHeader.getValue());
 		}
+		if (maxQueryTime > 0) {
+			builder.responseTimeout(Duration.ofSeconds(maxQueryTime));
+		}
 		return builder.build();
 	}
 
@@ -917,6 +921,9 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 		// functionality to provide custom http headers as required by the applications
 		for (Map.Entry<String, String> additionalHeader : getAdditionalHttpHeaders().entrySet()) {
 			builder.header(additionalHeader.getKey(), additionalHeader.getValue());
+		}
+		if (maxExecutionTime > 0) {
+			builder.responseTimeout(Duration.ofSeconds(maxExecutionTime));
 		}
 		return builder.build();
 	}

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -22,6 +22,7 @@ import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -498,6 +499,9 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		for (Map.Entry<String, String> additionalHeader : additionalHttpHeaders.entrySet()) {
 			builder.header(additionalHeader.getKey(), additionalHeader.getValue());
 		}
+		if (maxQueryTime > 0) {
+			builder.responseTimeout(Duration.ofSeconds(maxQueryTime));
+		}
 		return builder.build();
 	}
 
@@ -528,6 +532,9 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 			for (Map.Entry<String, String> additionalHeader : additionalHttpHeaders.entrySet()) {
 				builder.header(additionalHeader.getKey(), additionalHeader.getValue());
 			}
+		}
+		if (maxQueryTime > 0) {
+			builder.responseTimeout(Duration.ofSeconds(maxQueryTime));
 		}
 		return builder.build();
 	}

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -752,11 +752,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 			}
 		}
 
-		HttpRequest methodWithAccept = withHeader(method, ACCEPT_PARAM_NAME,
-				String.join(", ", acceptValues));
+		method.addHeader(ACCEPT_PARAM_NAME, String.join(", ", acceptValues));
 
 		try {
-			return executeOK(methodWithAccept);
+			return executeOK(method);
 		} catch (RepositoryException | MalformedQueryException | QueryInterruptedException e) {
 			throw e;
 		} catch (RDF4JException e) {
@@ -901,11 +900,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 
 		List<String> acceptParams = RDFFormat.getAcceptParams(rdfFormats, requireContext, getPreferredRDFFormat());
 
-		HttpRequest methodWithAccept = withHeader(method, ACCEPT_PARAM_NAME,
-				String.join(", ", acceptParams));
+		method.addHeader(ACCEPT_PARAM_NAME, String.join(", ", acceptParams));
 
 		try {
-			return executeOK(methodWithAccept);
+			return executeOK(method);
 		} catch (RepositoryException | MalformedQueryException | QueryInterruptedException e) {
 			throw e;
 		} catch (RDF4JException e) {
@@ -972,10 +970,9 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 			}
 		}
 
-		HttpRequest methodWithAccept = withHeader(method, ACCEPT_PARAM_NAME,
-				String.join(", ", acceptValues));
+		method.addHeader(ACCEPT_PARAM_NAME, String.join(", ", acceptValues));
 
-		return executeOK(methodWithAccept);
+		return executeOK(method);
 	}
 
 	/**
@@ -1250,19 +1247,4 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		this.passThroughEnabled = passThroughEnabled;
 	}
 
-	/**
-	 * Creates a new {@link HttpRequest} with an additional header added to the existing request.
-	 *
-	 * @param request the original request
-	 * @param name    the header name
-	 * @param value   the header value
-	 * @return a new request with the additional header
-	 */
-	private static HttpRequest withHeader(HttpRequest request, String name, String value) {
-		HttpRequest.Builder builder = HttpRequest.newBuilder(request.getMethod(), request.getUri())
-				.headers(request.getHeaders())
-				.header(name, value);
-		request.getBody().ifPresent(builder::body);
-		return builder.build();
-	}
 }

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/query/AbstractHTTPQuery.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/query/AbstractHTTPQuery.java
@@ -70,8 +70,10 @@ public abstract class AbstractHTTPQuery extends AbstractQuery {
 	@Override
 	public void setMaxExecutionTime(int maxExecutionTimeSeconds) {
 		super.setMaxExecutionTime(maxExecutionTimeSeconds);
-		// TODO allow per query timeouts on the http connection used
-		// Note: connection timeout is now configured via HttpClientConfig when building the client.
+		// maxExecutionTimeSeconds is propagated as a per-request response timeout on the HTTP connection:
+		// concrete subclasses pass getMaxExecutionTime() to SPARQLProtocolSession, which sets it on the
+		// HttpRequest via HttpRequest.Builder#responseTimeout(Duration). The ApacheHC5RDF4JHttpClient
+		// implementation applies it as a per-request RequestConfig#setResponseTimeout override.
 	}
 
 	@Override

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
@@ -327,6 +327,32 @@ public class SPARQLProtocolSessionTest {
 		assertThat(request.getResponseTimeout()).isEmpty();
 	}
 
+	@ParameterizedTest(name = "[{0}]")
+	@MethodSource("httpClientFactories")
+	public void getUpdateMethod_setsResponseTimeout_whenMaxQueryTimeIsPositive(String factoryName) {
+		this.factoryName = factoryName;
+		sparqlSession = createProtocolSession();
+
+		HttpRequest request = sparqlSession.getUpdateMethod(
+				QueryLanguage.SPARQL, "INSERT DATA { <urn:s> <urn:p> <urn:o> }", null, null, true, 30);
+
+		assertThat(request.getResponseTimeout())
+				.isPresent()
+				.hasValue(Duration.ofSeconds(30));
+	}
+
+	@ParameterizedTest(name = "[{0}]")
+	@MethodSource("httpClientFactories")
+	public void getUpdateMethod_noResponseTimeout_whenMaxQueryTimeIsZero(String factoryName) {
+		this.factoryName = factoryName;
+		sparqlSession = createProtocolSession();
+
+		HttpRequest request = sparqlSession.getUpdateMethod(
+				QueryLanguage.SPARQL, "INSERT DATA { <urn:s> <urn:p> <urn:o> }", null, null, true, 0);
+
+		assertThat(request.getResponseTimeout()).isEmpty();
+	}
+
 	@Test
 	public void getContentTypeSerialisationTest() {
 		{

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
@@ -22,12 +22,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.http.client.spi.HttpHeader;
+import org.eclipse.rdf4j.http.client.spi.HttpRequest;
 import org.eclipse.rdf4j.http.client.spi.HttpResponse;
 import org.eclipse.rdf4j.http.client.spi.RDF4JHttpClient;
 import org.eclipse.rdf4j.http.client.spi.RDF4JHttpClients;
@@ -297,6 +299,32 @@ public class SPARQLProtocolSessionTest {
 
 		// check that the OutputStream received content in XML format
 		assertThat(out.toString()).startsWith("<");
+	}
+
+	@ParameterizedTest(name = "[{0}]")
+	@MethodSource("httpClientFactories")
+	public void getQueryMethod_setsResponseTimeout_whenMaxQueryTimeIsPositive(String factoryName) {
+		this.factoryName = factoryName;
+		sparqlSession = createProtocolSession();
+
+		HttpRequest request = sparqlSession.getQueryMethod(
+				QueryLanguage.SPARQL, "SELECT * WHERE { ?s ?p ?o }", null, null, true, 30);
+
+		assertThat(request.getResponseTimeout())
+				.isPresent()
+				.hasValue(Duration.ofSeconds(30));
+	}
+
+	@ParameterizedTest(name = "[{0}]")
+	@MethodSource("httpClientFactories")
+	public void getQueryMethod_noResponseTimeout_whenMaxQueryTimeIsZero(String factoryName) {
+		this.factoryName = factoryName;
+		sparqlSession = createProtocolSession();
+
+		HttpRequest request = sparqlSession.getQueryMethod(
+				QueryLanguage.SPARQL, "SELECT * WHERE { ?s ?p ?o }", null, null, true, 0);
+
+		assertThat(request.getResponseTimeout()).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
When setMaxExecutionTime(int) is called on an HTTP-based query or update, the value is now applied as a per-request response timeout on the HTTP connection, enforced client-side in addition to being sent as a server-sidehint.

HttpRequest gains an optional responseTimeout field (Duration). Both SPARQLProtocolSession and RDF4JProtocolSession (which overrides getQueryMethod/getUpdateMethod) set this field when maxQueryTime > 0. The Apache HC5 client applies it via RequestConfig#setResponseTimeout, overriding the client-level socket timeout for that specific request. The JDK client applies it via HttpRequest.Builder#timeout, with the per-request value taking precedence over the global socketTimeoutMs from RDF4JHttpClientConfig.


GitHub issue resolved: #5723


----

Local integration testing with Toxyproxy in between my local query execution and the database. When setting maxExecutionTime() to a low value, the query interrupts accordingly (in the same way as it was in RDF4J 5.x with HTTP client 4)

Example query with a timeout toxic of 5s

```
SPARQLRepository repo = new SPARQLRepository("http://localhost:5433/repositories/demo");
        try (var conn = repo.getConnection()) {
            var tq = conn.prepareTupleQuery("SELECT * WHERE { ?s ?p ?o } LIMIT 10");
            tq.setMaxExecutionTime(2);
            Iterations.asList(tq.evaluate()).forEach(bs -> System.out.println(bs));
            System.out.println("Complete");
        }
```

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

