### PR TITLE
GH-5775 Avoid regenerating ArrayBindingSet mask

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSet.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSet.java
@@ -144,7 +144,8 @@ public class ArrayBindingSet extends AbstractBindingSet implements MutableBindin
 		this.empty = toCopy.empty;
 		this.cachedSize = toCopy.cachedSize;
 		if (sharedSortedBindingNamesCache != null) {
-			this.activeBindingMask = calculateActiveBindingMask();
+			this.activeBindingMask = toCopy.bindingNames == names ? toCopy.activeBindingMask
+					: calculateActiveBindingMask();
 		}
 		assert !this.empty || size() == 0;
 	}


### PR DESCRIPTION
GitHub issue resolved: #5775 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

