### PR TITLE
GH-5799: use newer logback version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<enforce-javaee-provided.fail>true</enforce-javaee-provided.fail>
 		<slf4j.version>2.0.17</slf4j.version>
-		<logback.version>1.5.21</logback.version>
+		<logback.version>1.5.26</logback.version>
 		<log4j.version>2.25.4</log4j.version>
 		<httpclient.version>4.5.14</httpclient.version>
 		<httpclient5.version>5.4.3</httpclient5.version>


### PR DESCRIPTION
GitHub issue resolved: #5799 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use logback 1.5.26, which fixes the CVE (in 1.5.25) and a bug when shading jars 

(newer versions are available, but with an updated license, though the license compatibility should be even better: EPL v2 vs 1)

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

