### PR TITLE
GH-5813: introduce grouped source selection to reduce remote requests

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -58,6 +58,8 @@ public class FedXConfig {
 
 	private boolean includeInferredDefault = true;
 
+	private boolean enableGroupedSourceSelection = true;
+
 	private String sourceSelectionCacheSpec = null;
 
 	private SourceSelectionCacheFactory sourceSelectionCacheFactory = null;
@@ -494,5 +496,38 @@ public class FedXConfig {
 	 */
 	public int getConsumingIterationMax() {
 		return consumingIterationMax;
+	}
+
+	/**
+	 * Flag to enable or disable the grouped source selection strategy. Default={@code true}.
+	 *
+	 * <p>
+	 * When enabled, all statement patterns that require a remote check for a given endpoint are batched into a single
+	 * SPARQL SELECT query using {@code BIND(EXISTS { ... } AS ?stmt_i)} expressions, reducing the number of remote
+	 * requests from <em>O(S &times; M)</em> to <em>O(M)</em> where <em>S</em> is the number of statement patterns and
+	 * <em>M</em> the number of federation members. When disabled, one individual ASK query is sent per statement
+	 * pattern and endpoint (the classic FedX behaviour).
+	 * </p>
+	 *
+	 * @return {@code true} if grouped source selection is enabled
+	 */
+	public boolean isEnableGroupedSourceSelection() {
+		return enableGroupedSourceSelection;
+	}
+
+	/**
+	 * Enable or disable the grouped source selection strategy. Default={@code true}.
+	 *
+	 * <p>
+	 * Can only be set before federation initialization.
+	 * </p>
+	 *
+	 * @param flag {@code true} to enable grouped source selection, {@code false} to fall back to individual ASK queries
+	 * @return the current config
+	 * @see #isEnableGroupedSourceSelection()
+	 */
+	public FedXConfig withEnableGroupedSourceSelection(boolean flag) {
+		this.enableGroupedSourceSelection = flag;
+		return this;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategy.java
@@ -342,7 +342,7 @@ public class FederationEvaluationStrategy extends StrictEvaluationStrategy {
 		}
 
 		// Source Selection: all nodes are annotated with their source
-		SourceSelection sourceSelection = new SourceSelection(members, cache, queryInfo);
+		SourceSelection sourceSelection = new SourceSelection(members, cache, federationContext, queryInfo);
 		sourceSelection.doSourceSelection(info.getStatements());
 
 		relevantMembers.addAll(sourceSelection.getRelevantSources());
@@ -381,7 +381,7 @@ public class FederationEvaluationStrategy extends StrictEvaluationStrategy {
 			@SuppressWarnings("unused") // only used as artificial parent
 			HolderNode holderParent = new HolderNode(checkStmt);
 
-			SourceSelection sourceSelection = new SourceSelection(members, cache, queryInfo);
+			SourceSelection sourceSelection = new SourceSelection(members, cache, federationContext, queryInfo);
 			sourceSelection.doSourceSelection(List.of(checkStmt));
 
 			identifiedMembers = sourceSelection.getRelevantSources();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.federated.optimizer;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -21,8 +22,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.algebra.EmptyStatementPattern;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
+import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.algebra.StatementSource;
 import org.eclipse.rdf4j.federated.algebra.StatementSource.StatementSourceType;
 import org.eclipse.rdf4j.federated.algebra.StatementSourcePattern;
@@ -38,6 +41,7 @@ import org.eclipse.rdf4j.federated.exception.OptimizationException;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.federated.structures.SubQuery;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
@@ -45,10 +49,66 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Perform source selection during optimization
+ * Performs source selection during query optimization by determining, for each statement pattern in a BGP, which
+ * federation members (endpoints) can contribute results.
+ *
+ * <h2>Algorithm</h2>
+ * <p>
+ * For each statement pattern and each endpoint the {@link SourceSelectionCache} is consulted first. Patterns whose
+ * source membership is already known from a previous query are resolved without any remote communication. Only patterns
+ * with a {@link org.eclipse.rdf4j.federated.cache.SourceSelectionCache.StatementSourceAssurance#POSSIBLY_HAS_STATEMENTS
+ * POSSIBLY_HAS_STATEMENTS} assurance require a remote check. All remote checks are executed in parallel using the FedX
+ * worker-thread infrastructure ({@link SourceSelectionExecutorWithLatch}), and the calling thread blocks until every
+ * check has completed or the query timeout is reached.
+ * </p>
+ *
+ * <h2>Remote check strategies</h2>
+ * <p>
+ * Two strategies are supported for performing the remote checks, selected per endpoint based on the configuration:
+ * </p>
+ * <dl>
+ * <dt>Grouped source selection (default, {@link org.eclipse.rdf4j.federated.FedXConfig#isEnableGroupedSourceSelection()
+ * enableGroupedSourceSelection=true})</dt>
+ * <dd>All statement patterns that require a remote check for a given endpoint are batched into a single SPARQL SELECT
+ * query of the form:
+ *
+ * <pre>
+ * SELECT * WHERE {
+ *   BIND(EXISTS { &lt;pattern_0&gt; } AS ?stmt_0)
+ *   BIND(EXISTS { &lt;pattern_1&gt; } AS ?stmt_1)
+ *   ...
+ * }
+ * </pre>
+ *
+ * This reduces the number of remote requests from <em>O(S &times; M)</em> to <em>O(M)</em>, where <em>S</em> is the
+ * number of statement patterns and <em>M</em> the number of federation members. It is particularly effective in
+ * high-latency settings. Grouped checks are only used when more than two patterns require a check for the same
+ * endpoint; otherwise, individual ASK queries are sent. The grouped check is implemented in
+ * {@link ParallelGroupedCheckTask}.</dd>
+ * <dt>Individual ASK queries (classic FedX,
+ * {@link org.eclipse.rdf4j.federated.FedXConfig#isEnableGroupedSourceSelection()
+ * enableGroupedSourceSelection=false})</dt>
+ * <dd>One ASK query is sent per statement pattern and endpoint, yielding up to <em>S &times; M</em> remote requests.
+ * Implemented in {@link ParallelCheckTask}.</dd>
+ * </dl>
+ *
+ * <h2>Configuration</h2>
+ * <p>
+ * The source selection strategy is controlled via {@link org.eclipse.rdf4j.federated.FedXConfig}:
+ * </p>
+ * <ul>
+ * <li>{@link org.eclipse.rdf4j.federated.FedXConfig#withEnableGroupedSourceSelection(boolean)
+ * withEnableGroupedSourceSelection(boolean)} — enables or disables grouped source selection (default:
+ * {@code true})</li>
+ * <li>{@link org.eclipse.rdf4j.federated.FedXConfig#withSourceSelectionCacheSpec(String)
+ * withSourceSelectionCacheSpec(String)} — configures the Guava {@code CacheBuilderSpec} for the source selection
+ * cache</li>
+ * <li>{@link org.eclipse.rdf4j.federated.FedXConfig#withSourceSelectionCacheFactory(org.eclipse.rdf4j.federated.cache.SourceSelectionCacheFactory)
+ * withSourceSelectionCacheFactory(...)} — supplies a custom
+ * {@link org.eclipse.rdf4j.federated.cache.SourceSelectionCacheFactory}</li>
+ * </ul>
  *
  * @author Andreas Schwarte
- *
  */
 public class SourceSelection {
 
@@ -56,11 +116,14 @@ public class SourceSelection {
 
 	protected final List<Endpoint> endpoints;
 	protected final SourceSelectionCache cache;
+	protected final FederationContext federationContext;
 	protected final QueryInfo queryInfo;
 
-	public SourceSelection(List<Endpoint> endpoints, SourceSelectionCache cache, QueryInfo queryInfo) {
+	public SourceSelection(List<Endpoint> endpoints, SourceSelectionCache cache, FederationContext federationContext,
+			QueryInfo queryInfo) {
 		this.endpoints = endpoints;
 		this.cache = cache;
+		this.federationContext = federationContext;
 		this.queryInfo = queryInfo;
 	}
 
@@ -81,7 +144,8 @@ public class SourceSelection {
 	 */
 	public void doSourceSelection(List<StatementPattern> stmts) {
 
-		List<CheckTaskPair> remoteCheckTasks = new ArrayList<>();
+		// map remote check tasks per endpoint
+		Map<Endpoint, List<CheckTaskPair>> endpointToRemoteCheckTasks = new HashMap<>();
 
 		// for each statement determine the relevant sources
 		for (StatementPattern stmt : stmts) {
@@ -101,7 +165,8 @@ public class SourceSelection {
 				if (a == StatementSourceAssurance.HAS_REMOTE_STATEMENTS) {
 					addSource(stmt, new StatementSource(e.getId(), StatementSourceType.REMOTE));
 				} else if (a == StatementSourceAssurance.POSSIBLY_HAS_STATEMENTS) {
-					remoteCheckTasks.add(new CheckTaskPair(e, stmt, queryInfo));
+					endpointToRemoteCheckTasks.computeIfAbsent(e, (_) -> new ArrayList<>())
+							.add(new CheckTaskPair(e, stmt, queryInfo));
 				} else if (a == StatementSourceAssurance.NONE) {
 					// cannot provide any statements
 					continue;
@@ -113,8 +178,8 @@ public class SourceSelection {
 
 		// if remote checks are necessary, execute them using the concurrency
 		// infrastructure and block until everything is resolved
-		if (!remoteCheckTasks.isEmpty()) {
-			SourceSelectionExecutorWithLatch.run(this, remoteCheckTasks, cache);
+		if (!endpointToRemoteCheckTasks.isEmpty()) {
+			SourceSelectionExecutorWithLatch.run(this, endpointToRemoteCheckTasks, cache);
 		}
 
 		// iterate over input statements, BGP might be uses twice
@@ -184,8 +249,33 @@ public class SourceSelection {
 		 *
 		 * @param tasks
 		 */
-		public static void run(SourceSelection sourceSelection, List<CheckTaskPair> tasks, SourceSelectionCache cache) {
-			new SourceSelectionExecutorWithLatch(sourceSelection).executeRemoteSourceSelection(tasks, cache);
+		public static void run(SourceSelection sourceSelection,
+				Map<Endpoint, List<CheckTaskPair>> endpointToRemoteTasks, SourceSelectionCache cache) {
+			var sourceSelectionWithLatch = new SourceSelectionExecutorWithLatch(sourceSelection);
+
+			boolean groupedSourceSelectionEnabled = sourceSelection.federationContext.getConfig()
+					.isEnableGroupedSourceSelection();
+
+			List<ParallelSourceSelectionTask> tasks = new ArrayList<>();
+			for (var endpointEntry : endpointToRemoteTasks.entrySet()) {
+
+				var remoteCheckTasks = endpointEntry.getValue();
+
+				if (groupedSourceSelectionEnabled && remoteCheckTasks.size() > 2) {
+					// variant 1: grouped check per endpoint (single SELECT with BIND(EXISTS{}) per pattern)
+					List<StatementPattern> stmts = remoteCheckTasks.stream().map(c -> c.t).toList();
+					tasks.add(new ParallelGroupedCheckTask(endpointEntry.getKey(), stmts, sourceSelection.queryInfo,
+							sourceSelectionWithLatch));
+				} else {
+					// variant 2: individual ASK queries per statement pattern (classic behavior)
+					for (CheckTaskPair taskPair : remoteCheckTasks) {
+						tasks.add(new ParallelCheckTask(taskPair.e, taskPair.t, taskPair.queryInfo,
+								sourceSelectionWithLatch));
+					}
+				}
+			}
+
+			sourceSelectionWithLatch.executeRemoteSourceSelection(tasks, cache);
 		}
 
 		private final SourceSelection sourceSelection;
@@ -196,8 +286,7 @@ public class SourceSelection {
 
 		private SourceSelectionExecutorWithLatch(SourceSelection sourceSelection) {
 			this.sourceSelection = sourceSelection;
-			// TODO simpler access pattern
-			this.scheduler = sourceSelection.queryInfo.getFederationContext().getManager().getJoinScheduler();
+			this.scheduler = sourceSelection.federationContext.getManager().getJoinScheduler();
 		}
 
 		/**
@@ -206,14 +295,14 @@ public class SourceSelection {
 		 *
 		 * @param tasks
 		 */
-		private void executeRemoteSourceSelection(List<CheckTaskPair> tasks, SourceSelectionCache cache) {
+		private void executeRemoteSourceSelection(List<ParallelSourceSelectionTask> tasks, SourceSelectionCache cache) {
 			if (tasks.isEmpty()) {
 				return;
 			}
 
 			latch = new CountDownLatch(tasks.size());
-			for (CheckTaskPair task : tasks) {
-				scheduler.schedule(new ParallelCheckTask(task.e, task.t, task.queryInfo, this));
+			for (ParallelSourceSelectionTask task : tasks) {
+				scheduler.schedule(task);
 			}
 
 			try {
@@ -297,24 +386,45 @@ public class SourceSelection {
 		}
 	}
 
+	protected static abstract class ParallelSourceSelectionTask extends ParallelTaskBase<BindingSet> {
+
+		protected final Endpoint endpoint;
+		protected final SourceSelectionExecutorWithLatch control;
+		protected final QueryInfo queryInfo;
+
+		public ParallelSourceSelectionTask(Endpoint endpoint,
+				QueryInfo queryInfo, SourceSelectionExecutorWithLatch control) {
+			super();
+			this.endpoint = endpoint;
+			this.control = control;
+			this.queryInfo = queryInfo;
+		}
+
+		@Override
+		public ParallelExecutor<BindingSet> getControl() {
+			return control;
+		}
+
+		@Override
+		public void cancel() {
+			control.latch.countDown();
+			super.cancel();
+		}
+	}
+
 	/**
 	 * Task for sending an ASK request to the endpoints (for source selection)
 	 *
 	 * @author Andreas Schwarte
 	 */
-	protected static class ParallelCheckTask extends ParallelTaskBase<BindingSet> {
+	protected static class ParallelCheckTask extends ParallelSourceSelectionTask {
 
-		protected final Endpoint endpoint;
 		protected final StatementPattern stmt;
-		protected final SourceSelectionExecutorWithLatch control;
-		protected final QueryInfo queryInfo;
 
 		public ParallelCheckTask(Endpoint endpoint, StatementPattern stmt, QueryInfo queryInfo,
 				SourceSelectionExecutorWithLatch control) {
-			this.endpoint = endpoint;
+			super(endpoint, queryInfo, control);
 			this.stmt = stmt;
-			this.queryInfo = queryInfo;
-			this.control = control;
 		}
 
 		@Override
@@ -339,16 +449,80 @@ public class SourceSelection {
 			}
 		}
 
-		@Override
-		public ParallelExecutor<BindingSet> getControl() {
-			return control;
-		}
-
-		@Override
-		public void cancel() {
-			control.latch.countDown();
-			super.cancel();
-		}
 	}
 
+	protected static class ParallelGroupedCheckTask extends ParallelSourceSelectionTask {
+		protected final List<StatementPattern> stmts;
+
+		public ParallelGroupedCheckTask(Endpoint endpoint, List<StatementPattern> stmts, QueryInfo queryInfo,
+				SourceSelectionExecutorWithLatch control) {
+			super(endpoint, queryInfo, control);
+			this.stmts = stmts;
+		}
+
+		@Override
+		protected CloseableIteration<BindingSet> performTaskInternal() throws Exception {
+
+			CloseableIteration<BindingSet> innerResult = null;
+			try {
+				TripleSource t = endpoint.getTripleSource();
+				SourceSelection sourceSelection = control.sourceSelection;
+
+				String preparedGroupedCheck = QueryStringUtilExt.selectQueryStringGroupedSourceSelection(stmts,
+						EmptyBindingSet.getInstance());
+
+				innerResult = t.getStatements(preparedGroupedCheck, EmptyBindingSet.getInstance(),
+						(FilterValueExpr) null, queryInfo);
+				if (!innerResult.hasNext()) {
+					throw new IllegalStateException("Inner result for grouped source selection is empty.");
+				}
+				var sourceSelectionBs = innerResult.next();
+				int stmtId = 0;
+				for (var stmt : stmts) {
+
+					boolean hasResults = ((Literal) sourceSelectionBs.getValue("stmt_" + stmtId++)).booleanValue();
+					sourceSelection.cache.updateInformation(new SubQuery(stmt, queryInfo.getDataset()), endpoint,
+							hasResults);
+
+					if (hasResults) {
+						sourceSelection.addSource(stmt,
+								new StatementSource(endpoint.getId(), StatementSourceType.REMOTE));
+					}
+				}
+
+				return null;
+			} catch (Exception e) {
+				throw new OptimizationException(
+						"Error checking results for endpoint " + endpoint.getId() + ": " + e.getMessage(), e);
+			} finally {
+				if (innerResult != null) {
+					innerResult.close();
+				}
+			}
+
+		}
+
+	}
+
+	static class QueryStringUtilExt extends QueryStringUtil {
+
+		public static String selectQueryStringGroupedSourceSelection(List<StatementPattern> stmts,
+				BindingSet bindings) {
+
+			StringBuilder sb = new StringBuilder();
+			sb.append("SELECT * WHERE { ");
+
+			Set<String> varNames = new HashSet<>();
+			int stmtId = 0;
+			for (var stmt : stmts) {
+				sb.append("BIND(EXISTS { ")
+						.append(constructStatement(stmt, varNames, bindings))
+						.append(" } AS ?stmt_")
+						.append(stmtId++)
+						.append(") ");
+			}
+			sb.append("}");
+			return sb.toString();
+		}
+	}
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/SPARQLServerBaseTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/SPARQLServerBaseTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.monitoring.MonitoringService;
+import org.eclipse.rdf4j.federated.repository.ConfigurableSailRepository;
 import org.eclipse.rdf4j.federated.repository.RepositorySettings;
 import org.eclipse.rdf4j.federated.server.NativeStoreServer;
 import org.eclipse.rdf4j.federated.server.SPARQLEmbeddedServer;
@@ -151,7 +152,7 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 	 * @param i the index of the repository, starting with 1
 	 * @return
 	 */
-	protected static Repository getRepository(int i) {
+	protected static ConfigurableSailRepository getRepository(int i) {
 		return server.getRepository(i);
 	}
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/SourceSelectionPerformanceTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/SourceSelectionPerformanceTest.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.optimizer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.federated.SPARQLBaseTest;
+import org.eclipse.rdf4j.federated.algebra.HolderNode;
+import org.eclipse.rdf4j.federated.algebra.StatementSource;
+import org.eclipse.rdf4j.federated.cache.SourceSelectionCache;
+import org.eclipse.rdf4j.federated.endpoint.Endpoint;
+import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStrategy;
+import org.eclipse.rdf4j.federated.monitoring.MonitoringService;
+import org.eclipse.rdf4j.federated.repository.ConfigurableSailRepository;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.structures.QueryType;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A performance test for source selection
+ *
+ * <p>
+ * Can be executed together with a provided script for better analysis:
+ * </p>
+ *
+ * <p>
+ * Notes:
+ *
+ * - currently requires to manually set SPARQLServerBaseTest.MAX_ENDPOINTS to 20 - requires to remove the "Disabled"
+ * annotation
+ * </p>
+ *
+ * <pre>
+ * mvn -pl tools/federation test -Dtest=SourceSelectionPerformanceTest 2>&1 | python3 tools/federation/src/test/scripts/summarize_benchmark.py
+ * </pre>
+ *
+ * <p>
+ * Example results
+ * </p>
+ *
+ * <pre>
+ * === Source-selection benchmark results (5 measured run(s) + 1 warm-up) ===
++---------+--------------+----------+---------------+-------------------------+
+| Members | Latency (ms) | Patterns | Avg time (ms) | Total endpoint requests |
++---------+--------------+----------+---------------+-------------------------+
+|       5 |            0 |        2 |            13 |                      60 |
+|       5 |            0 |        5 |            16 |                      30 |
+|       5 |            0 |       10 |            19 |                      30 |
+|       5 |            0 |       20 |            19 |                      30 |
+|       5 |           20 |        2 |            28 |                      60 |
+|       5 |           20 |        5 |            29 |                      30 |
+|       5 |           20 |       10 |            31 |                      30 |
+|       5 |           20 |       20 |            32 |                      30 |
+|      10 |            0 |        2 |            28 |                     120 |
+|      10 |            0 |        5 |            28 |                      60 |
+|      10 |            0 |       10 |            31 |                      60 |
+|      10 |            0 |       20 |            30 |                      60 |
+|      10 |           20 |        2 |            28 |                     120 |
+|      10 |           20 |        5 |            30 |                      60 |
+|      10 |           20 |       10 |            30 |                      60 |
+|      10 |           20 |       20 |            35 |                      60 |
+|      20 |            0 |        2 |            30 |                     240 |
+|      20 |            0 |        5 |            30 |                     120 |
+|      20 |            0 |       10 |            30 |                     120 |
+|      20 |            0 |       20 |            32 |                     120 |
+|      20 |           20 |        2 |            53 |                     240 |
+|      20 |           20 |        5 |            30 |                     120 |
+|      20 |           20 |       10 |            31 |                     120 |
+|      20 |           20 |       20 |            35 |                     120 |
++---------+--------------+----------+---------------+-------------------------+
+ * </pre>
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+@Disabled("manual performance test for local execution")
+public class SourceSelectionPerformanceTest extends SPARQLBaseTest {
+
+	/** Set to {@code true} to print benchmark results to stdout. */
+	private static final boolean PRINT_RESULTS = true;
+
+	/** Number of measured runs for computing the average execution time. */
+	private static final int N_BENCHMARK_RUNS = 5;
+
+	private static final String EX_NS = "http://example.org/";
+
+	@Override
+	protected void initFedXConfig() {
+		fedxRule.withConfiguration(c -> c.withEnableMonitoring(true));
+
+		// optionally force ASK queries
+		// fedxRule.withConfiguration(c -> c.withEnableGroupedSourceSelection(false));
+	}
+
+	/**
+	 * Provides {@code (nMembers, latencyMs, nPatterns)} argument triples for
+	 * {@link #benchmarkSourceSelection(int, int, int)}.
+	 *
+	 * <p>
+	 * Each row exercises a different combination of federation size, simulated endpoint latency, and number of
+	 * statement patterns. The {@code nMembers} value must not exceed {@link #N_MEMBERS}, which determines the number of
+	 * repository slots created on the embedded server at start-up.
+	 * </p>
+	 */
+	static Stream<Arguments> sourceSelectionParameters() {
+		return Stream.of(
+				Arguments.of(5, 0, 2),
+				Arguments.of(5, 0, 5),
+				Arguments.of(5, 0, 10),
+				Arguments.of(5, 0, 20),
+				Arguments.of(5, 20, 2),
+				Arguments.of(5, 20, 5),
+				Arguments.of(5, 20, 10),
+				Arguments.of(5, 20, 20),
+				Arguments.of(10, 0, 2),
+				Arguments.of(10, 0, 5),
+				Arguments.of(10, 0, 10),
+				Arguments.of(10, 0, 20),
+				Arguments.of(10, 20, 2),
+				Arguments.of(10, 20, 5),
+				Arguments.of(10, 20, 10),
+				Arguments.of(10, 20, 20),
+				Arguments.of(20, 0, 2),
+				Arguments.of(20, 0, 5),
+				Arguments.of(20, 0, 10),
+				Arguments.of(20, 0, 20),
+				Arguments.of(20, 20, 2),
+				Arguments.of(20, 20, 5),
+				Arguments.of(20, 20, 10),
+				Arguments.of(20, 20, 20)
+		);
+	}
+
+	/**
+	 * Benchmark for {@link SourceSelection#doSourceSelection(List)} over a federation of {@code nMembers} members,
+	 * {@code nPatterns} statement patterns, and a simulated per-request latency of {@code latencyMs} ms.
+	 *
+	 * <p>
+	 * Correctness is validated on the warm-up run: each pattern {@code pred_i} must be matched by exactly
+	 * {@code max(0, nMembers - i)} sources.
+	 * </p>
+	 *
+	 * @param nMembers  number of federation members to use (must be &le; {@value #N_MEMBERS})
+	 * @param latencyMs simulated round-trip latency per endpoint request in milliseconds
+	 * @param nPatterns number of statement patterns to include in each source selection call
+	 */
+	@ParameterizedTest(name = "members={0}, latency={1}ms, patterns={2}")
+	@MethodSource("sourceSelectionParameters")
+	public void benchmarkSourceSelection(int nMembers, int latencyMs, int nPatterns) throws Exception {
+
+		// only execute for sparql endpoints
+		assumeSparqlEndpoint();
+
+		prepareTest(Collections.nCopies(nMembers, "/tests/basic/data_emptyStore.ttl"));
+
+		for (int memberId = 1; memberId <= nMembers; memberId++) {
+			ConfigurableSailRepository memberRepo = getRepository(memberId);
+			populateMemberRepository(memberRepo, nMembers, memberId);
+			if (latencyMs > 0) {
+				memberRepo.setLatencySimulator(() -> {
+					try {
+						Thread.sleep(latencyMs);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new RuntimeException(e);
+					}
+				});
+			} else {
+				memberRepo.setLatencySimulator(null);
+			}
+		}
+
+		FederationContext ctx = federationContext();
+		List<Endpoint> members = new ArrayList<>(ctx.getEndpointManager().getAvailableEndpoints());
+		SourceSelectionCache cache = ctx.getSourceSelectionCache();
+
+		// Invalidate any cache state left over from a previous parameterized invocation
+		cache.invalidate();
+
+		// Warm-up run (not measured): populates cache and validates correctness
+		List<StatementPattern> warmupStmts = createStatementPatterns(nPatterns);
+		SourceSelection warmupSS = new SourceSelection(members, cache, federationContext(), createQueryInfo(ctx));
+		warmupSS.doSourceSelection(warmupStmts);
+		validateCorrectness(warmupStmts, warmupSS, nMembers, nPatterns);
+
+		// Measured runs
+		long totalMs = 0;
+		for (int run = 0; run < N_BENCHMARK_RUNS; run++) {
+
+			cache.invalidate();
+
+			List<StatementPattern> stmts = createStatementPatterns(nPatterns);
+			SourceSelection ss = new SourceSelection(members, cache, federationContext(), createQueryInfo(ctx));
+
+			long start = System.currentTimeMillis();
+			ss.doSourceSelection(stmts);
+			long runMs = System.currentTimeMillis() - start;
+			totalMs += runMs;
+
+			if (PRINT_RESULTS) {
+				System.out.println(
+						"Source selection benchmark [members=" + nMembers + ", latency=" + latencyMs + "ms]"
+								+ " - run " + (run + 1) + "/" + N_BENCHMARK_RUNS + ": " + runMs + " ms");
+			}
+		}
+
+		long avgMs = totalMs / N_BENCHMARK_RUNS;
+		if (PRINT_RESULTS) {
+			System.out.println("Source selection benchmark (" + nMembers + " members, " + nPatterns + " patterns, "
+					+ latencyMs + "ms latency): average execution time over " + N_BENCHMARK_RUNS + " runs = "
+					+ avgMs + " ms");
+		}
+
+		MonitoringService monitoring = (MonitoringService) ctx.getMonitoringService();
+		long totalRequests = monitoring.getAllMonitoringInformation()
+				.stream()
+				.mapToLong(m -> m.getNumberOfRequests())
+				.sum();
+		if (PRINT_RESULTS) {
+			System.out.println("Source selection benchmark (" + nMembers + " members, " + nPatterns + " patterns, "
+					+ latencyMs + "ms latency): total endpoint requests = " + totalRequests);
+		}
+	}
+
+	/**
+	 * Validates source counts: pattern {@code pred_i} (1-indexed) must have exactly {@code max(0, nMembers - i)}
+	 * sources. Patterns with zero expected sources may be absent from {@code stmtToSources} (null entry), which is
+	 * treated as an empty source list.
+	 */
+	private void validateCorrectness(List<StatementPattern> stmts, SourceSelection ss, int nMembers, int nPatterns) {
+		for (int i = 0; i < nPatterns; i++) {
+			int expectedSources = Math.max(0, nMembers - (i + 1));
+			List<StatementSource> sources = ss.stmtToSources.get(stmts.get(i));
+			int actualSources = sources == null ? 0 : sources.size();
+			Assertions.assertEquals(expectedSources, actualSources,
+					"Pattern pred_" + (i + 1) + " should have " + expectedSources + " sources");
+		}
+	}
+
+	/**
+	 * Creates {@code nPatterns} statement patterns, one per predicate {@code ex:pred_1..ex:pred_nPatterns}, with
+	 * unbound subject and object. Each pattern is wrapped in a {@link HolderNode} to satisfy the parent requirement of
+	 * {@link org.eclipse.rdf4j.query.algebra.QueryModelNode#replaceWith}.
+	 *
+	 * @param nPatterns number of statement patterns to create
+	 */
+	private List<StatementPattern> createStatementPatterns(int nPatterns) {
+		List<StatementPattern> stmts = new ArrayList<>();
+		for (int i = 1; i <= nPatterns; i++) {
+			Var predicate = Var.of("pred_" + i, Values.iri(EX_NS, "pred_" + i));
+			StatementPattern sp = new StatementPattern(Var.of("s"), predicate, Var.of("o"));
+			new HolderNode(sp); // artificial parent required by replaceWith()
+			stmts.add(sp);
+		}
+		return stmts;
+	}
+
+	/**
+	 * Creates a fresh {@link QueryInfo} for the current federation context.
+	 */
+	private QueryInfo createQueryInfo(FederationContext ctx) {
+		FederationEvaluationStrategy strategy = ctx.createStrategy(null);
+		return new QueryInfo("SELECT * WHERE { ?s ?p ?o }", null, QueryType.SELECT, 0, false, ctx, strategy, null);
+	}
+
+	/**
+	 * Builds an in-memory repository for federation member {@code memberId}.
+	 *
+	 * <p>
+	 * The repository holds one triple {@code (ex:subject_j, ex:pred_i, ex:object_j)} for each predicate index
+	 * {@code i = 1..(N_MEMBERS - memberId)}.
+	 * </p>
+	 */
+	private void populateMemberRepository(Repository memberRepo, int nMembers, int memberId) {
+		int nPredicates = nMembers - memberId;
+		try (RepositoryConnection conn = memberRepo.getConnection()) {
+			conn.clear();
+			for (int i = 1; i <= nPredicates; i++) {
+				conn.add(
+						Values.iri(EX_NS, "subject_" + memberId),
+						Values.iri(EX_NS, "pred_" + i),
+						Values.iri(EX_NS, "object_" + memberId));
+			}
+		}
+	}
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/performance/FedXPerformanceTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/performance/FedXPerformanceTest.java
@@ -71,7 +71,15 @@ public class FedXPerformanceTest extends SPARQLBaseTest {
 	 */
 	static final String basePackage = "/tests/performance/";
 
+	@Override
+	protected void initFedXConfig() {
+
+		// optionally force ASK queries
+		// fedxRule.withConfiguration(c -> c.withEnableGroupedSourceSelection(false));
+	}
+
 	@Test
+	@Disabled("Activate and run for initial one-time setup")
 	public void setupData() throws Exception {
 
 		var benchmarkFolder = new File("src/test/resources" + basePackage);
@@ -83,12 +91,20 @@ public class FedXPerformanceTest extends SPARQLBaseTest {
 	@Test
 	public void testPerformance() throws Throwable {
 
+		// change this to see the impact of source selection caching
+		// default: cached source selection information
+		final boolean SOURCE_SELECTION_CACHE = false;
+
 		/* prepare endpoints */
 		prepareTest(Arrays.asList(basePackage + "data1.ttl", basePackage + "data2.ttl", basePackage + "data3.ttl",
 				basePackage + "data4.ttl"));
 
 		// warm-up
 		for (String query : queries) {
+			if (!SOURCE_SELECTION_CACHE) {
+				fedxRule.getFederationContext().getSourceSelectionCache().invalidate();
+			}
+
 			long start = System.currentTimeMillis();
 			execute(basePackage + query + ".rq", basePackage + query + ".srx", false, true);
 			long duration = System.currentTimeMillis() - start;
@@ -103,6 +119,11 @@ public class FedXPerformanceTest extends SPARQLBaseTest {
 			Run run = new Run(i);
 			runs.add(run);
 			for (String query : queries) {
+
+				if (!SOURCE_SELECTION_CACHE) {
+					fedxRule.getFederationContext().getSourceSelectionCache().invalidate();
+				}
+
 				SingleQueryRun queryRun = new SingleQueryRun(query);
 				run.addRun(queryRun);
 				long start = System.currentTimeMillis();

--- a/tools/federation/src/test/scripts/summarize_benchmark.py
+++ b/tools/federation/src/test/scripts/summarize_benchmark.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Parses and summarizes the output of SourceSelectionPerformanceTest#benchmarkSourceSelection.
+
+Usage
+-----
+Run the parameterized tests and pipe (or redirect) their stdout into this script:
+
+    mvn -pl tools/federation test -Dtest=SourceSelectionPerformanceTest 2>&1 | python3 tools/federation/src/test/scripts/summarize_benchmark.py
+
+Or point it at a saved log file:
+
+    python3 tools/federation/src/test/scripts/summarize_benchmark.py benchmark.log
+
+The script prints a single table with one row per (members, latency, patterns) combination,
+showing the average execution time and the total number of endpoint requests across all
+measured runs (including the warm-up run).
+"""
+
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+# "Source selection benchmark (5 members, 2 patterns, 0ms latency): average execution time over 5 runs = 38 ms"
+RE_AVG = re.compile(
+    r"Source selection benchmark \((\d+) members, (\d+) patterns, (\d+)ms latency\):"
+    r" average execution time over (\d+) runs = (\d+) ms"
+)
+
+# "Source selection benchmark (5 members, 2 patterns, 0ms latency): total endpoint requests = 60"
+RE_REQ = re.compile(
+    r"Source selection benchmark \((\d+) members, (\d+) patterns, (\d+)ms latency\):"
+    r" total endpoint requests = (\d+)"
+)
+
+# ---------------------------------------------------------------------------
+# Parse
+# ---------------------------------------------------------------------------
+
+def parse(lines):
+    """
+    Returns:
+        averages  : dict  (members, latency, patterns) -> avg_ms
+        requests  : dict  (members, latency, patterns) -> total_requests
+        n_runs    : int   number of measured runs (excluding warm-up), from output
+    """
+    averages = {}
+    requests = {}
+    n_runs   = None
+
+    for line in lines:
+        line = line.rstrip()
+
+        m = RE_AVG.search(line)
+        if m:
+            # groups: (1)=members  (2)=patterns  (3)=latency  (4)=n_runs  (5)=avg_ms
+            # store key as (members, latency, patterns) for consistent unpacking
+            key      = (int(m.group(1)), int(m.group(3)), int(m.group(2)))
+            n_runs   = int(m.group(4))
+            averages[key] = int(m.group(5))
+            continue
+
+        m = RE_REQ.search(line)
+        if m:
+            # groups: (1)=members  (2)=patterns  (3)=latency  (4)=total_requests
+            key = (int(m.group(1)), int(m.group(3)), int(m.group(2)))
+            requests[key] = int(m.group(4))
+            continue
+
+    return averages, requests, n_runs
+
+# ---------------------------------------------------------------------------
+# Format helpers
+# ---------------------------------------------------------------------------
+
+def col_widths(rows, headers):
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(str(cell)))
+    return widths
+
+def print_table(title, headers, rows, align=None):
+    if not rows:
+        return
+    widths = col_widths(rows, headers)
+    align  = align or ["<"] * len(headers)
+    sep    = "+-" + "-+-".join("-" * w for w in widths) + "-+"
+    fmt    = "| " + " | ".join(f"{{:{a}{w}}}" for a, w in zip(align, widths)) + " |"
+
+    print(f"\n{title}")
+    print(sep)
+    print(fmt.format(*headers))
+    print(sep)
+    for row in rows:
+        print(fmt.format(*[str(c) for c in row]))
+    print(sep)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) > 1:
+        print("Parsing benchmark log file …")
+        with open(sys.argv[1], encoding="utf-8") as fh:
+            lines = fh.readlines()
+    else:
+        print("Running benchmark – this may take up to a few minutes …", flush=True)
+        lines = sys.stdin.readlines()
+
+    averages, requests, n_runs = parse(lines)
+
+    if not averages:
+        print("No benchmark results found in input.", file=sys.stderr)
+        sys.exit(1)
+
+    runs_label = f"{n_runs} measured run(s) + 1 warm-up" if n_runs else "? runs + 1 warm-up"
+
+    # --- Table: average execution times + total endpoint requests ---
+    headers = ["Members", "Latency (ms)", "Patterns", "Avg time (ms)", "Total endpoint requests"]
+    rows = [
+        (members, latency, patterns, avg_ms, requests.get((members, latency, patterns), "n/a"))
+        for (members, latency, patterns), avg_ms in sorted(averages.items())
+    ]
+    print_table(
+        f"=== Source-selection benchmark results ({runs_label}) ===",
+        headers, rows,
+        align=[">", ">", ">", ">", ">"],
+    )
+
+    # --- Summary: best / worst ---
+    print("\n=== Summary ===")
+    best  = min(averages.items(), key=lambda kv: kv[1])
+    worst = max(averages.items(), key=lambda kv: kv[1])
+    print(f"  Fastest: members={best[0][0]}, latency={best[0][1]}ms, "
+          f"patterns={best[0][2]}  →  {best[1]} ms avg")
+    print(f"  Slowest: members={worst[0][0]}, latency={worst[0][1]}ms, "
+          f"patterns={worst[0][2]}  →  {worst[1]} ms avg")
+
+    # latency impact: compare latency=0 vs latency>0 for same (members, patterns)
+    zero_lat = {(m, p): v for (m, l, p), v in averages.items() if l == 0}
+    nonz_lat = {(m, p): (l, v) for (m, l, p), v in averages.items() if l > 0}
+    shared   = sorted(set(zero_lat) & set(nonz_lat))
+    if shared:
+        print("\n  Latency overhead (latency=0ms vs latency>0ms):")
+        print(f"    {'Members':>7}  {'Patterns':>8}  {'0ms (ms)':>10}  "
+              f"{'latency>0 (ms)':>14}  {'overhead':>10}")
+        for (m, p) in shared:
+            lat, val = nonz_lat[(m, p)]
+            base     = zero_lat[(m, p)]
+            overhead = val - base
+            print(f"    {m:>7}  {p:>8}  {base:>10}  {val:>14}  {overhead:>+10}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replace the flat per-pattern ASK-query approach with a grouped strategy that batches all statement patterns needing a remote check for the same endpoint into a single SPARQL SELECT using BIND(EXISTS { <pattern> } AS ?stmt_i) expressions. This reduces source-selection round-trips from O(S × M) to O(M), where S = number of statement patterns and M = federation members. Individual ASK queries are still used when ≤2 patterns require a check for a given endpoint, or when the feature is disabled via FedXConfig#withEnableGroupedSourceSelection(false).

Changes:
  - FedXConfig: add enableGroupedSourceSelection flag (default true)
  - SourceSelection: pass FederationContext through constructor; group remote tasks per endpoint; add ParallelGroupedCheckTask and ParallelSourceSelectionTask base class; add QueryStringUtilExt for building grouped SELECT queries
  - FederationEvaluationStrategy: pass federationContext to SourceSelection
  - SPARQLServerBaseTest: tighten getRepository return type to ConfigurableSailRepository
  - Add SourceSelectionPerfomanceTest: parameterised benchmark covering 5/10/20 members, 0/20 ms latency, 2/5/10/20 patterns


GitHub issue resolved: #GH-5813


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change



----

**Benchmark output**


**a) with grouped source selection (new mode)**

```
=== Source-selection benchmark results (5 measured run(s) + 1 warm-up) ===
+---------+--------------+----------+---------------+-------------------------+
| Members | Latency (ms) | Patterns | Avg time (ms) | Total endpoint requests |
+---------+--------------+----------+---------------+-------------------------+
|       5 |            0 |        2 |            13 |                      60 |
|       5 |            0 |        5 |            16 |                      30 |
|       5 |            0 |       10 |            19 |                      30 |
|       5 |            0 |       20 |            19 |                      30 |
|       5 |           20 |        2 |            28 |                      60 |
|       5 |           20 |        5 |            29 |                      30 |
|       5 |           20 |       10 |            31 |                      30 |
|       5 |           20 |       20 |            32 |                      30 |
|      10 |            0 |        2 |            28 |                     120 |
|      10 |            0 |        5 |            28 |                      60 |
|      10 |            0 |       10 |            31 |                      60 |
|      10 |            0 |       20 |            30 |                      60 |
|      10 |           20 |        2 |            28 |                     120 |
|      10 |           20 |        5 |            30 |                      60 |
|      10 |           20 |       10 |            30 |                      60 |
|      10 |           20 |       20 |            35 |                      60 |
|      20 |            0 |        2 |            30 |                     240 |
|      20 |            0 |        5 |            30 |                     120 |
|      20 |            0 |       10 |            30 |                     120 |
|      20 |            0 |       20 |            32 |                     120 |
|      20 |           20 |        2 |            53 |                     240 |
|      20 |           20 |        5 |            30 |                     120 |
|      20 |           20 |       10 |            31 |                     120 |
|      20 |           20 |       20 |            35 |                     120 |
+---------+--------------+----------+---------------+-------------------------+
```

**b) with ASK queries (previous mode)**

```
=== Source-selection benchmark results (5 measured run(s) + 1 warm-up) ===
+---------+--------------+----------+---------------+-------------------------+
| Members | Latency (ms) | Patterns | Avg time (ms) | Total endpoint requests |
+---------+--------------+----------+---------------+-------------------------+
|       5 |            0 |        2 |            13 |                      60 |
|       5 |            0 |        5 |            14 |                     150 |
|       5 |            0 |       10 |            18 |                     300 |
|       5 |            0 |       20 |            23 |                     600 |
|       5 |           20 |        2 |            28 |                      60 |
|       5 |           20 |        5 |            52 |                     150 |
|       5 |           20 |       10 |            78 |                     300 |
|       5 |           20 |       20 |           131 |                     600 |
|      10 |            0 |        2 |            28 |                     120 |
|      10 |            0 |        5 |            55 |                     300 |
|      10 |            0 |       10 |            84 |                     600 |
|      10 |            0 |       20 |           135 |                    1200 |
|      10 |           20 |        2 |            29 |                     120 |
|      10 |           20 |        5 |            80 |                     300 |
|      10 |           20 |       10 |           129 |                     600 |
|      10 |           20 |       20 |           266 |                    1200 |
|      20 |            0 |        2 |            30 |                     240 |
|      20 |            0 |        5 |            79 |                     600 |
|      20 |            0 |       10 |           135 |                    1200 |
|      20 |            0 |       20 |           265 |                    2400 |
|      20 |           20 |        2 |            53 |                     240 |
|      20 |           20 |        5 |           127 |                     600 |
|      20 |           20 |       10 |           257 |                    1200 |
|      20 |           20 |       20 |           520 |                    2400 |
+---------+--------------+----------+---------------+-------------------------+
```

No impact on query execution time