### PR TITLE
GH-5813: improve FedX base unit test to allow configurable endpoints

### DIFF
--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/SPARQLServerBaseTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/SPARQLServerBaseTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +46,7 @@ import org.slf4j.LoggerFactory;
  * @author as
  *
  */
+@TestInstance(Lifecycle.PER_CLASS)
 public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 
 	/**
@@ -54,8 +57,6 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 		REMOTEREPOSITORY,
 		NATIVE
 	}
-
-	protected static final int MAX_ENDPOINTS = 4;
 
 	public static Logger log;
 
@@ -69,8 +70,17 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 
 	private static REPOSITORY_TYPE repositoryType = REPOSITORY_TYPE.SPARQLREPOSITORY;
 
+	/**
+	 * The maximum number of endpoints available and prepared in the server
+	 *
+	 * @return
+	 */
+	protected int getMaxEndpoints() {
+		return 4;
+	}
+
 	@BeforeAll
-	public static void initTest() throws Exception {
+	public void initTest() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 
 		log = LoggerFactory.getLogger(SPARQLServerBaseTest.class);
@@ -91,7 +101,7 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 	}
 
 	@AfterAll
-	public static void afterTest() throws Exception {
+	public void afterTest() throws Exception {
 		if (server != null) {
 			server.shutdown();
 		}
@@ -101,7 +111,7 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 	@BeforeEach
 	public void beforeEachTest() {
 		// reset operations counter and fail after
-		for (int i = 1; i <= MAX_ENDPOINTS; i++) {
+		for (int i = 1; i <= getMaxEndpoints(); i++) {
 			RepositorySettings repoSettings = repoSettings(i);
 			repoSettings.resetOperationsCounter();
 			repoSettings.setFailAfter(-1);
@@ -118,17 +128,19 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 	 *
 	 * @throws Exception
 	 */
-	private static void initializeServer() throws Exception {
+	private void initializeServer() throws Exception {
+
+		int maxEndpoints = getMaxEndpoints();
 
 		// set up the server: the maximal number of endpoints must be known
-		List<String> repositoryIds = new ArrayList<>(MAX_ENDPOINTS);
-		for (int i = 1; i <= MAX_ENDPOINTS; i++) {
+		List<String> repositoryIds = new ArrayList<>();
+		for (int i = 1; i <= maxEndpoints; i++) {
 			repositoryIds.add("endpoint" + i);
 		}
 		File dataDir = new File(tempDir.toFile(), "datadir");
 		server = new SPARQLEmbeddedServer(dataDir, repositoryIds, repositoryType == REPOSITORY_TYPE.REMOTEREPOSITORY);
 
-		server.initialize(MAX_ENDPOINTS);
+		server.initialize(maxEndpoints);
 	}
 
 	/**
@@ -137,11 +149,11 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 	 *
 	 * @throws Exception
 	 */
-	private static void initializeLocalNativeStores() throws Exception {
+	private void initializeLocalNativeStores() throws Exception {
 
 		File dataDir = new File(tempDir.toFile(), "datadir");
 		server = new NativeStoreServer(dataDir);
-		server.initialize(MAX_ENDPOINTS);
+		server.initialize(getMaxEndpoints());
 	}
 
 	/**
@@ -166,7 +178,7 @@ public abstract class SPARQLServerBaseTest extends FedXBaseTest {
 		federationContext().getManager().removeAll();
 
 		// prepare the test endpoints (i.e. load data)
-		if (sparqlEndpointData.size() > MAX_ENDPOINTS) {
+		if (sparqlEndpointData.size() > getMaxEndpoints()) {
 			throw new RuntimeException("MAX_ENDPOINTs to low, " + sparqlEndpointData.size()
 					+ " repositories needed. Adjust configuration");
 		}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/SourceSelectionPerformanceTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/SourceSelectionPerformanceTest.java
@@ -49,8 +49,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * <p>
  * Notes:
  *
- * - currently requires to manually set SPARQLServerBaseTest.MAX_ENDPOINTS to 20 - requires to remove the "Disabled"
- * annotation
+ * requires to remove the "Disabled" annotation
  * </p>
  *
  * <pre>
@@ -111,6 +110,11 @@ public class SourceSelectionPerformanceTest extends SPARQLBaseTest {
 
 		// optionally force ASK queries
 		// fedxRule.withConfiguration(c -> c.withEnableGroupedSourceSelection(false));
+	}
+
+	@Override
+	protected int getMaxEndpoints() {
+		return 20;
 	}
 
 	/**


### PR DESCRIPTION
In Junit 6 the @BeforeAll can also be added to non-static methods - allowing to easily override the max number of endpoints. This mechanism is applied to SourceSelectionPerformanceBenchmarTest


GitHub issue resolved: #5813 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

