### PR TITLE
GH-5828: cleanup deprecated code usages in FedX module

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -17,7 +17,6 @@ import org.eclipse.rdf4j.collection.factory.api.CollectionFactory;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.DistinctIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
-import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.transaction.TransactionSetting;
 import org.eclipse.rdf4j.federated.algebra.PassThroughTupleExpr;
@@ -266,14 +265,7 @@ public class FedXConnection extends AbstractSailConnection {
 		// execute the union in a separate thread
 		federationContext.getManager().getExecutor().execute(union);
 		CollectionFactory cf = federation.getCollectionFactory().get();
-		ExceptionConvertingIteration<Resource, SailException> conv = new ExceptionConvertingIteration<>(union) {
-
-			@Override
-			protected SailException convert(RuntimeException e) {
-				return new SailException(e);
-			}
-		};
-		return new DistinctIteration<Resource>(conv, cf::createSet) {
+		return new DistinctIteration<Resource>(union, cf::createSet) {
 
 			@Override
 			protected void handleClose() {
@@ -305,36 +297,12 @@ public class FedXConnection extends AbstractSailConnection {
 	protected CloseableIteration<? extends Statement> getStatementsInternal(Resource subj, IRI pred,
 			Value obj, boolean includeInferred, Resource... contexts) throws SailException {
 
-		try {
-			Dataset dataset = new SimpleDataset();
-			FederationEvaluationStrategy strategy = federationContext.createStrategy(dataset);
-			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, 0, includeInferred, federationContext, strategy,
-					dataset);
-			federationContext.getMonitoringService().monitorQuery(queryInfo);
-			CloseableIteration<Statement> res = null;
-			try {
-				res = strategy.getStatements(queryInfo, subj, pred, obj, contexts);
-				return new ExceptionConvertingIteration<>(res) {
-					@Override
-					protected SailException convert(RuntimeException e) {
-						return new SailException(e);
-					}
-				};
-			} catch (Throwable t) {
-				if (res != null) {
-					res.close();
-				}
-				throw t;
-			}
-
-		} catch (RuntimeException e) {
-			throw e;
-		} catch (Exception e) {
-			if (e instanceof InterruptedException) {
-				Thread.currentThread().interrupt();
-			}
-			throw new SailException(e);
-		}
+		Dataset dataset = new SimpleDataset();
+		FederationEvaluationStrategy strategy = federationContext.createStrategy(dataset);
+		QueryInfo queryInfo = new QueryInfo(subj, pred, obj, 0, includeInferred, federationContext, strategy,
+				dataset);
+		federationContext.getMonitoringService().monitorQuery(queryInfo);
+		return strategy.getStatements(queryInfo, subj, pred, obj, contexts);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
@@ -13,7 +13,8 @@ package org.eclipse.rdf4j.federated.endpoint;
 import java.io.File;
 import java.io.FileReader;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -86,12 +87,12 @@ public class EndpointFactory {
 	 */
 	public static Endpoint loadSPARQLEndpoint(String endpoint) throws FedXException {
 		try {
-			String id = new URL(endpoint).getHost();
+			String id = new URI(endpoint).toURL().getHost();
 			if (id.equals("localhost")) {
-				id = id + "_" + new URL(endpoint).getPort();
+				id = id + "_" + new URI(endpoint).toURL().getPort();
 			}
 			return loadSPARQLEndpoint("http://" + id, endpoint);
-		} catch (MalformedURLException e) {
+		} catch (URISyntaxException | MalformedURLException e) {
 			throw new FedXException("Malformed URL: " + endpoint);
 		}
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.federated.evaluation;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
-import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.algebra.PrecompiledQueryNode;
@@ -117,16 +116,7 @@ public class SailTripleSource extends TripleSourceBase {
 				repoResult = conn.getStatements(subj, pred, obj,
 						queryInfo.getIncludeInferred(), contexts);
 
-// XXX implementation remark and TODO taken from Sesame
-				// The same variable might have been used multiple times in this
-				// StatementPattern, verify value equality in those cases.
-
-				resultHolder.set(new ExceptionConvertingIteration<>(repoResult) {
-					@Override
-					protected QueryEvaluationException convert(RuntimeException arg0) {
-						return new QueryEvaluationException(arg0);
-					}
-				});
+				resultHolder.set(repoResult);
 			} catch (Throwable t) {
 				if (repoResult != null) {
 					repoResult.close();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
@@ -11,7 +11,6 @@
 package org.eclipse.rdf4j.federated.evaluation;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
@@ -191,15 +190,7 @@ public class SparqlTripleSource extends TripleSourceBase {
 			try {
 				repoResult = conn.getStatements(subj, pred, obj,
 						queryInfo.getIncludeInferred(), contexts);
-				resultHolder.set(new ExceptionConvertingIteration<>(repoResult) {
-					@Override
-					protected QueryEvaluationException convert(RuntimeException ex) {
-						if (ex instanceof QueryEvaluationException) {
-							return (QueryEvaluationException) ex;
-						}
-						return new QueryEvaluationException(ex);
-					}
-				});
+				resultHolder.set(repoResult);
 			} catch (Throwable t) {
 				if (repoResult != null) {
 					repoResult.close();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/FedXPathIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/FedXPathIteration.java
@@ -147,7 +147,7 @@ public class FedXPathIteration extends LookAheadIteration<BindingSet> {
 		case END:
 			return (v, vp) -> ((ValuePair) vp).endValue = v;
 		default:
-			return (v, vp) -> {
+			return (_, _) -> {
 				throw new IllegalStateException("A value is being asked to be set where we never expected one");
 			};
 		}
@@ -166,7 +166,7 @@ public class FedXPathIteration extends LookAheadIteration<BindingSet> {
 		case END:
 			return (vp) -> ((ValuePair) vp).endValue;
 		default:
-			return (vp) -> {
+			return (_) -> {
 				throw new IllegalStateException("A value is being asked to be set where we never expected one");
 			};
 		}
@@ -185,7 +185,7 @@ public class FedXPathIteration extends LookAheadIteration<BindingSet> {
 		case END:
 			return (vp) -> ((ValuePair) vp).endValue != null;
 		default:
-			return (vp) -> {
+			return (_) -> {
 				throw new IllegalStateException("A value is being asked to be set where we never expected one");
 			};
 		}


### PR DESCRIPTION
- converting exception is not required (iterations are fine to propagate runtime exceptions)
- iteration closing is handled abstract class (no need to duplicate)
- use URI.toUrl() replacement in EndpointFactory


GitHub issue resolved: #5828 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

