### PR TITLE
GH-5611 add Java and application server compatibility matrix

### DIFF
--- a/site/content/documentation/programming/setup.md
+++ b/site/content/documentation/programming/setup.md
@@ -7,6 +7,20 @@ autonumbering: true
 This chapter gives you some pointers on how to install the RDF4J libraries and how to initialize your project.
 <!--more-->
 Before you can get started programming with RDF4J, you will need to set up your development environment, download the necessary, libraries, and so on.
+
+## Prerequisites
+
+### Java Version
+
+RDF4J requires a Java runtime environment. The minimum required Java version depends on the RDF4J version you are using:
+
+| RDF4J Version | Minimum Java Version | Jakarta EE / Javax       |
+|---------------|----------------------|--------------------------|
+| 6.x           | Java 25              | Jakarta EE (> EE 10)     |
+| 5.x           | Java 11              | Javax (Java EE)          |
+
+RDF4J 6.0 introduced a migration from the `javax` namespace to the `jakarta` namespace for the affected Jakarta EE (formerly Java EE) APIs, in line with the broader Java ecosystem move to Jakarta EE. If you are upgrading from RDF4J 5.x, update only those imports in your own code that refer to APIs that actually changed namespace; Java SE `javax.*` packages remain unchanged.
+ 
 ## Using Apache Maven
 
 By far the most flexible way to include RDF4J in your project, is to use Maven. Apache Maven is a software management tool that helps you by offering things like library version management and dependency management (which is very useful because it means that once you decide you need a particular RDF4J library, Maven automatically downloads all the libraries that your library of choice requires in turn). For details on how to start using Maven, take a look at the [Apache Maven website](http://maven.apache.org/). If you are familiar with Maven, here are a few pointers to help set up your maven project.

--- a/site/content/documentation/tools/server-workbench.md
+++ b/site/content/documentation/tools/server-workbench.md
@@ -10,12 +10,14 @@ In this chapter, we explain how you can install RDF4J Server (the actual databas
 
 ## Required software
 
-RDF4J Server and RDF4J Workbench requires the following software:
+RDF4J Server and RDF4J Workbench require a Java runtime and a compatible Java Servlet Container. The required versions depend on the RDF4J version you are deploying:
 
-- Java 25 or newer
-- A Java Servlet Container that supports Java Servlet API 3.1 and Java Server Pages (JSP) 2.2, or newer.
+| RDF4J Version | Java Version | Jakarta EE / Javax   | Apache Tomcat | Jetty       |
+|---------------|--------------|----------------------|---------------|-------------|
+| 6.x           | Java 25      | Jakarta EE (> EE 10) | Tomcat 11+    | Jetty 12.1+ |
+| 5.x           | Java 11      | Javax (Java EE)      | Tomcat 9      | Jetty 9     |
 
-We recommend using a recent, stable version of [Apache Tomcat](https://tomcat.apache.org/) (version 9.0) or [Jetty](https://jetty.org) (version 9.4)
+We recommend using a recent, stable version of [Apache Tomcat](https://tomcat.apache.org/) (version 10.0) or [Jetty](https://jetty.org) (version 12.1)
 
 ## Deploying Server and Workbench
 


### PR DESCRIPTION
Document the Java version and Jakarta EE requirements per RDF4J release in both the developer setup guide and the Server/Workbench deployment guide, covering the javax→jakarta namespace change introduced in 6.x.


GitHub issue resolved: #5611 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

