### PR TITLE
GH-5611: upgrade Docker images to Jetty 12/Tomcat 11 with Jakarta EE 11

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -142,8 +142,17 @@ jobs:
 
 
   e2e:
+    name: e2e (${{ matrix.runtime.label }})
     needs: formatting-and-quick-compile
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime:
+          - label: Spring Boot
+            argument: spring-boot
+          - label: Docker Tomcat
+            argument: docker-tomcat
     steps:
       - uses: actions/checkout@v4
       - name: Register JVM thread dump on cancel
@@ -160,9 +169,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Run end-to-end tests of RDF4J Server and Workbench
+      - name: Run end-to-end tests of RDF4J Server and Workbench (${{ matrix.runtime.label }})
         working-directory: ./e2e
-        run: exec ../scripts/ci/run-with-thread-dump.sh ./run.sh
+        run: exec ../scripts/ci/run-with-thread-dump.sh ./run.sh ${{ matrix.runtime.argument }}
 
   frontend-unit-tests:
     needs: formatting-and-quick-compile

--- a/docker/Dockerfile-jetty
+++ b/docker/Dockerfile-jetty
@@ -1,5 +1,5 @@
 # Temp to reduce image size
-FROM ubuntu:jammy AS temp
+FROM ubuntu:noble AS temp
 
 RUN  apt-get clean && apt-get update && apt-get install -y unzip
 
@@ -11,13 +11,13 @@ WORKDIR /tmp
 RUN unzip -q /tmp/rdf4j.zip
 
 # Final workbench
-FROM jetty:9-jdk21-eclipse-temurin
+FROM jetty:12-jdk25-eclipse-temurin
 LABEL org.opencontainers.image.authors="Bart Hanssens (bart.hanssens@bosa.fgov.be)"
 
 USER root
 
 ENV JAVA_OPTIONS="-Xmx2g -Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j -Dorg.eclipse.rdf4j.rio.jsonld_secure_mode=false -Drdf4j.query.breaker.enabled=true"
-ENV JETTY_MODULES="server,bytebufferpool,threadpool,security,servlet,webapp,ext,plus,deploy,annotations,http,jsp,jstl"
+ENV JETTY_MODULES="server,bytebufferpool,threadpool,http,security,ee11-servlet,ee11-webapp,ee11-ext,ee11-plus,ee11-deploy,ee11-annotations,ee11-jsp,ee11-jstl"
 
 COPY --from=temp /tmp/eclipse-rdf4j*/war/*.war /var/lib/jetty/webapps/
 

--- a/docker/Dockerfile-tomcat
+++ b/docker/Dockerfile-tomcat
@@ -1,5 +1,5 @@
 # Temp to reduce image size
-FROM ubuntu:jammy AS temp
+FROM ubuntu:noble AS temp
 
 RUN  apt-get clean && apt-get update && apt-get install -y unzip
 
@@ -11,7 +11,7 @@ WORKDIR /tmp
 RUN unzip -q /tmp/rdf4j.zip
 
 # Final workbench
-FROM tomcat:9-jre25-temurin-jammy
+FROM tomcat:11.0-jdk25-temurin-noble
 MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
 
 RUN apt-get clean && apt-get update && apt-get upgrade -y && apt-get clean

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,6 +1,6 @@
 # End-to-end tests
 
-This directory contains end-to-end tests for the project. The suite now boots the RDF4J Server and Workbench using a Spring Boot wrapper with an embedded Tomcat instance, so Docker is no longer required.
+This directory contains end-to-end tests for the project. The suite can run against either the Spring Boot wrapper with embedded Tomcat or the Docker image that deploys the regular WAR files to Tomcat.
 
 The tests are written using Microsoft Playwright and interact with the server and workbench in a real browser.
 
@@ -11,7 +11,24 @@ Requirements:
  - maven
  - npm
  - npx
+ - docker (for `docker-tomcat`)
 
-The tests can be run using the `run.sh` script. The script builds the Spring Boot runner, launches it in the background, waits until the HTTP endpoints are reachable, and then executes the Playwright test suite.
+The tests can be run using the `run.sh` script. The script builds the selected runtime, waits until the HTTP endpoints are reachable, and then executes the Playwright test suite.
+
+Run against the Spring Boot implementation:
+
+```bash
+./run.sh spring-boot
+```
+
+Run against the Docker/Tomcat image:
+
+```bash
+./run.sh docker-tomcat
+```
+
+The default runtime is `spring-boot`, so `./run.sh` keeps the original local behavior.
+
+If Playwright browsers are already installed locally, set `E2E_SKIP_PLAYWRIGHT_INSTALL=true` to skip the browser installer.
 
 To run the tests interactively use `npx playwright test --ui`

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -10,25 +10,29 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-set -e
+set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+E2E_DIR="${ROOT_DIR}/e2e"
+DOCKER_DIR="${ROOT_DIR}/docker"
+SERVER_RUNTIME="${1:-${E2E_SERVER_RUNTIME:-spring-boot}}"
 SERVER_PID=""
+DOCKER_STARTED="false"
+SPRING_BOOT_DATA_DIR=""
 
-cleanup() {
+stop_spring_boot() {
   if [ -z "${SERVER_PID:-}" ]; then
     return
   fi
 
-  # If the process is already gone, nothing to do
   if ! kill -0 "$SERVER_PID" 2>/dev/null; then
     return
   fi
 
-  echo "Sending SIGINT to server-boot module (pid=$SERVER_PID)"
+  echo "Sending SIGINT to server-boot module (pid=${SERVER_PID})"
   kill -s INT "$SERVER_PID" 2>/dev/null || true
 
-  # Wait for graceful shutdown after SIGINT
-  for i in 1 2 3 4 5 6 7 8 9 10; do
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
     if ! kill -0 "$SERVER_PID" 2>/dev/null; then
       echo "server-boot module stopped gracefully after SIGINT"
       wait "$SERVER_PID" 2>/dev/null || true
@@ -38,12 +42,10 @@ cleanup() {
     sleep 0.5
   done
 
-  # Still alive: send a more aggressive TERM
-  echo "Sending SIGTERM to server-boot module (pid=$SERVER_PID)"
+  echo "Sending SIGTERM to server-boot module (pid=${SERVER_PID})"
   kill "$SERVER_PID" 2>/dev/null || true
 
-  # Wait for graceful shutdown after SIGTERM
-  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
     if ! kill -0 "$SERVER_PID" 2>/dev/null; then
       echo "server-boot module stopped after SIGTERM"
       wait "$SERVER_PID" 2>/dev/null || true
@@ -52,47 +54,145 @@ cleanup() {
     sleep 0.5
   done
 
-  # Still alive after: kill definitively
-  echo "Sending SIGKILL to server-boot module (pid=$SERVER_PID)"
+  echo "Sending SIGKILL to server-boot module (pid=${SERVER_PID})"
   kill -9 "$SERVER_PID" 2>/dev/null || true
   wait "$SERVER_PID" 2>/dev/null || true
 }
 
-trap cleanup EXIT
+stop_docker_tomcat() {
+  if [ "${DOCKER_STARTED}" != "true" ]; then
+    return
+  fi
 
-npm install
+  echo "Stopping Docker/Tomcat RDF4J stack"
+  (cd "$DOCKER_DIR" && APP_SERVER=tomcat docker compose down -v) || true
+}
 
-cd ..
+cleanup() {
+  local status="${1:-$?}"
+  trap - EXIT INT TERM
+  stop_spring_boot
+  stop_docker_tomcat
+  exit "$status"
+}
 
-mvn -q install -Pquick
+usage() {
+  echo "Usage: $0 [spring-boot|docker-tomcat]" >&2
+}
 
-mvn -pl tools/server-boot spring-boot:run &
-SERVER_PID=$!
-# server-boot module will be stopped automatically on script exit (see cleanup trap above).
+install_e2e_dependencies() {
+  cd "$E2E_DIR"
 
-cd e2e
+  if [ ! -d "node_modules" ]; then
+    echo "Installing E2E npm dependencies"
+    npm ci
+  fi
 
-sleep 10
+  if [ "${E2E_SKIP_PLAYWRIGHT_INSTALL:-false}" = "true" ]; then
+    echo "Skipping Playwright browser install"
+  else
+    echo "Installing Playwright browsers"
+    npx playwright install --with-deps
+  fi
+}
 
-if [ ! -d 'node_modules' ]; then
-  echo "npm ci"
-  npm ci
-fi
+wait_for_url() {
+  local label="$1"
+  local url="$2"
 
-npx playwright install --with-deps # install browsers
-npx playwright test
+  printf 'Waiting for %s at %s' "$label" "$url"
+  for _ in $(seq 1 90); do
+    if curl --fail --location --silent --output /dev/null "$url"; then
+      echo ""
+      echo "${label} is ready"
+      return
+    fi
+    ensure_runtime_running
+    printf '.'
+    sleep 1
+  done
 
-status_npx=$?
+  echo ""
+  echo "Timed out waiting for ${label} at ${url}" >&2
+  return 1
+}
 
-cd ..
+ensure_runtime_running() {
+  if [ -n "${SERVER_PID:-}" ] && ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo ""
+    echo "server-boot module exited before RDF4J became ready" >&2
+    wait "$SERVER_PID" 2>/dev/null || true
+    SERVER_PID=""
+    return 1
+  fi
 
-# test for error code
-if [ $status_npx -ne 0 ]; then
-  echo "Error in E2E test"
-  exit $status_npx
-fi
+  if [ "${DOCKER_STARTED}" = "true" ]; then
+    local container_id
+    container_id="$(cd "$DOCKER_DIR" && APP_SERVER=tomcat docker compose ps -q rdf4j 2>/dev/null || true)"
+    if [ -n "$container_id" ] && [ "$(docker inspect -f '{{.State.Running}}' "$container_id" 2>/dev/null || echo false)" != "true" ]; then
+      echo ""
+      echo "Docker/Tomcat container exited before RDF4J became ready" >&2
+      (cd "$DOCKER_DIR" && APP_SERVER=tomcat docker compose logs --tail=200 rdf4j) || true
+      return 1
+    fi
+  fi
+}
 
-echo "E2E test OK"
+wait_for_rdf4j() {
+  wait_for_url "RDF4J Server" "http://localhost:8080/rdf4j-server/"
+  wait_for_url "RDF4J Workbench" "http://localhost:8080/rdf4j-workbench/"
+}
 
-# don't redo the whole build process just for making another docker image
-export SKIP_BUILD="skip"
+start_spring_boot() {
+  echo "Building RDF4J for Spring Boot E2E"
+  (cd "$ROOT_DIR" && mvn install -Pquick)
+
+  SPRING_BOOT_DATA_DIR="${E2E_DATA_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/rdf4j-e2e.XXXXXX")}"
+  echo "Using RDF4J app data directory ${SPRING_BOOT_DATA_DIR}"
+
+  echo "Starting RDF4J Server and Workbench with Spring Boot"
+  (
+    cd "$ROOT_DIR"
+    mvn -pl tools/server-boot spring-boot:run \
+      -Dspring-boot.run.jvmArguments="-Dorg.eclipse.rdf4j.appdata.basedir=${SPRING_BOOT_DATA_DIR}"
+  ) &
+  SERVER_PID=$!
+}
+
+start_docker_tomcat() {
+  echo "Building Docker/Tomcat RDF4J image"
+  (cd "$DOCKER_DIR" && APP_SERVER=tomcat ./build.sh)
+
+  echo "Starting Docker/Tomcat RDF4J container"
+  (cd "$DOCKER_DIR" && APP_SERVER=tomcat docker compose up --force-recreate -d)
+  DOCKER_STARTED="true"
+}
+
+run_playwright() {
+  cd "$E2E_DIR"
+  npx playwright test
+}
+
+trap 'cleanup $?' EXIT
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
+
+case "$SERVER_RUNTIME" in
+  spring-boot)
+    install_e2e_dependencies
+    start_spring_boot
+    ;;
+  docker | docker-tomcat | tomcat)
+    install_e2e_dependencies
+    start_docker_tomcat
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+wait_for_rdf4j
+run_playwright
+
+echo "E2E test OK (${SERVER_RUNTIME})"

--- a/e2e/tests/workbench.spec.js
+++ b/e2e/tests/workbench.spec.js
@@ -82,6 +82,34 @@ function getTrackedRequestIds(requests) {
     return [...new Set(requests.map(request => request.requestId).filter(Boolean))].sort();
 }
 
+const LOADING_EXPLANATION_TEXT = 'Loading explanation...';
+
+async function waitForStableExplanation(page, selector = '#query-explanation') {
+    await page.waitForFunction(({ selector, loadingText }) => {
+        const explanation = document.querySelector(selector);
+        const text = explanation && explanation.textContent.trim();
+        return text && text.length > 0 && text !== loadingText;
+    }, { selector, loadingText: LOADING_EXPLANATION_TEXT });
+
+    return (await page.locator(selector).textContent()).trim();
+}
+
+async function waitForChangedStableExplanation(page, selector, previousExplanation) {
+    await page.waitForFunction(({ selector, loadingText, previousExplanation }) => {
+        const explanation = document.querySelector(selector);
+        const text = explanation && explanation.textContent.trim();
+        return text && text.length > 0 && text !== loadingText && text !== previousExplanation;
+    }, { selector, loadingText: LOADING_EXPLANATION_TEXT, previousExplanation });
+
+    return (await page.locator(selector).textContent()).trim();
+}
+
+async function waitForStableExplanations(page, selectors) {
+    for (const selector of selectors) {
+        await waitForStableExplanation(page, selector);
+    }
+}
+
 test('Create repo', async ({page}) => {
     await page.goto('http://localhost:8080/rdf4j-workbench/');
     page.on('dialog', dialog => {
@@ -225,10 +253,7 @@ test('Query compare mode diffs query and explanation', async ({page}) => {
     });
 
     await page.locator('#explain-trigger').click();
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page);
     await expect(page.locator('#compare-toggle')).toBeVisible();
     await expect.poll(async () => page.evaluate(() => {
         const compareButton = document.getElementById('compare-toggle');
@@ -253,10 +278,7 @@ test('Query compare mode diffs query and explanation', async ({page}) => {
         const compareCode = document.querySelectorAll('.CodeMirror-code')[1];
         return compareCode ? compareCode.textContent.replace(/\s+/g, ' ').trim() : '';
     })).toContain('SELECT * WHERE { ?s ?p ?o } LIMIT 10');
-    await page.waitForFunction(() => {
-        const compareExplanation = document.getElementById('query-explanation-compare');
-        return compareExplanation && compareExplanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page, '#query-explanation-compare');
 
     const collapsedLayout = await page.evaluate(() => {
         const queryForm = document.querySelector('.query-form');
@@ -286,11 +308,7 @@ test('Query compare mode diffs query and explanation', async ({page}) => {
     });
 
     await page.locator('#explain-compare-trigger').click();
-    await page.waitForFunction(() => {
-        const primary = document.getElementById('query-explanation');
-        const compare = document.getElementById('query-explanation-compare');
-        return primary && compare && primary.textContent.trim().length > 0 && compare.textContent.trim().length > 0;
-    });
+    await waitForStableExplanations(page, ['#query-explanation', '#query-explanation-compare']);
 
     await page.locator('#query-diff-trigger').click();
     await expect(page.locator('#query-diff-modal')).toHaveClass(/query-diff-modal--open/);
@@ -318,18 +336,12 @@ test('Explain wait state shows spinner and cancel for primary and compare action
     await page.locator('#explain-trigger').click();
     await expect(page.locator('#explain-trigger-spinner')).toBeVisible();
     await expect(page.locator('#explain-trigger-cancel')).toBeVisible();
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page);
 
     await page.locator('#rerun-explanation').click();
     await expect(page.locator('#rerun-explanation-spinner')).toBeVisible();
     await expect(page.locator('#rerun-explanation-cancel')).toBeVisible();
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page);
 
     await page.locator('#compare-toggle').click();
     await page.waitForFunction(() => document.querySelectorAll('.CodeMirror').length === 2);
@@ -339,20 +351,14 @@ test('Explain wait state shows spinner and cancel for primary and compare action
     await expect(page.locator('#explain-trigger-cancel')).toBeVisible();
     await expect(page.locator('#explain-compare-cancel')).toBeVisible();
     await expect(page.locator('#explain-compare-trigger')).toHaveClass(/query-compare-action--spinning/);
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation-compare');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page, '#query-explanation-compare');
 
     await page.locator('#rerun-explanation').click();
     await expect(page.locator('#rerun-explanation-spinner')).toBeVisible();
     await expect(page.locator('#rerun-explanation-cancel')).toBeVisible();
     await expect(page.locator('#explain-compare-cancel')).toBeVisible();
     await expect(page.locator('#explain-compare-trigger')).toHaveClass(/query-compare-action--spinning/);
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation-compare');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page, '#query-explanation-compare');
 });
 
 test('Primary cancel posts matching request id and stale responses do not repaint', async ({page}) => {
@@ -368,14 +374,7 @@ test('Primary cancel posts matching request id and stale responses do not repain
 
     await typeIntoCodeMirror(page, 0, 'SELECT * WHERE { ?s ?p ?o } LIMIT 10');
     await page.locator('#explain-trigger').click();
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
-
-    const initialExplanation = await page.evaluate(() => {
-        return document.getElementById('query-explanation').textContent.trim();
-    });
+    const initialExplanation = await waitForStableExplanation(page);
 
     const traffic = await trackExplainTraffic(page);
     await page.locator('#explain-format').selectOption('json');
@@ -408,17 +407,12 @@ test('Compare-mode left cancel buttons abort explanation refresh', async ({page}
 
     await typeIntoCodeMirror(page, 0, 'SELECT * WHERE { ?s ?p ?o } LIMIT 10');
     await page.locator('#explain-trigger').click();
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page);
 
     await page.locator('#compare-toggle').click();
     await page.waitForFunction(() => document.querySelectorAll('.CodeMirror').length === 2);
     await typeIntoCodeMirror(page, 1, 'ASK { ?s ?p ?o }');
-    const initialCompareExplanation = await page.evaluate(() => {
-        return document.getElementById('query-explanation-compare').textContent.trim();
-    });
+    const initialCompareExplanation = await waitForStableExplanation(page, '#query-explanation-compare');
 
     const traffic = await trackExplainTraffic(page);
     await page.locator('#explain-trigger').click();
@@ -436,17 +430,9 @@ test('Compare-mode left cancel buttons abort explanation refresh', async ({page}
     })).toBe(initialCompareExplanation);
 
     await page.locator('#explain-compare-trigger').click();
-    await page.waitForFunction(previousExplanation => {
-        const explanation = document.getElementById('query-explanation-compare');
-        const text = explanation && explanation.textContent.trim();
-        return text && text.length > 0
-            && text !== 'Loading explanation...'
-            && text !== previousExplanation;
-    }, initialCompareExplanation);
-
-    const refreshedCompareExplanation = await page.evaluate(() => {
-        return document.getElementById('query-explanation-compare').textContent.trim();
-    });
+    const refreshedCompareExplanation = await waitForChangedStableExplanation(
+        page, '#query-explanation-compare', initialCompareExplanation
+    );
 
     await page.locator('#rerun-explanation').click();
     await expect(page.locator('#rerun-explanation-cancel')).toBeVisible();
@@ -473,14 +459,7 @@ test('Changing explain level implicitly cancels pending explain with matching re
 
     await typeIntoCodeMirror(page, 0, 'SELECT * WHERE { ?s ?p ?o } LIMIT 10');
     await page.locator('#explain-trigger').click();
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
-
-    const initialExplanation = await page.evaluate(() => {
-        return document.getElementById('query-explanation').textContent.trim();
-    });
+    const initialExplanation = await waitForStableExplanation(page);
 
     const traffic = await trackExplainTraffic(page);
     await page.locator('#explain-format').selectOption('json');
@@ -519,10 +498,7 @@ test('Query compare mode keeps primary query on reload without persisting second
     await typeIntoCodeMirror(page, 0, primaryQuery);
 
     await page.locator('#explain-trigger').click();
-    await page.waitForFunction(() => {
-        const explanation = document.getElementById('query-explanation');
-        return explanation && explanation.textContent.trim().length > 0;
-    });
+    await waitForStableExplanation(page);
 
     await page.locator('#compare-toggle').click();
     await page.waitForFunction(() => document.querySelectorAll('.CodeMirror').length === 2);

--- a/site/content/documentation/developer/testing.md
+++ b/site/content/documentation/developer/testing.md
@@ -6,34 +6,85 @@ autonumbering: true
 
 ## Testing the RDF4J Workbench Locally
 
-### Build the project
+The `docker/` directory contains scripts and a Docker Compose setup for building and running RDF4J Server and Workbench locally. All commands below are run from that directory.
 
 ```sh
-mvn -Passembly package
-cd assembly/target
-unzip eclipse-rdf4j-*-sdk.zip
-cd eclipse-rdf4j-*-SNAPSHOT
+cd docker
 ```
 
+### Quick start
 
-### Run the workbench in Docker
+The simplest way to build and start everything in one step:
 
 ```sh
-docker run -d \
-    --name rdf4j \
-    --platform linux/amd64 \
-    --restart unless-stopped \
-    -p 8080:8080 \
-    -v "$(pwd)/war/rdf4j-server.war:/var/lib/jetty/webapps/rdf4j-server.war" \
-    -v "$(pwd)/war/rdf4j-workbench.war:/var/lib/jetty/webapps/rdf4j-workbench.war" \
-    -v rdf4j-data:/var/rdf4j \
-    jetty:12.1-jdk25-alpine \
-    --module=ee10-deploy
+./run.sh
+```
+
+This script will:
+
+1. Run `build.sh` to build the Maven project and produce the SDK ZIP
+2. Copy the ZIP into `ignore/rdf4j.zip` (required by the Dockerfile)
+3. Build the Docker image via `docker compose build`
+4. Start the container with `docker compose up`
+5. Wait until the server is ready and print the Workbench URL
+
+Once ready, the output will confirm:
+
+```
+Workbench is available at http://localhost:8080/rdf4j-workbench
+```
+
+### Choosing the application server
+
+By default `tomcat` is used. To use Jetty instead, set the `APP_SERVER` environment variable before running the scripts:
+
+```sh
+APP_SERVER=jetty ./run.sh
+```
+
+This controls which Dockerfile (`Dockerfile-tomcat` or `Dockerfile-jetty`) and which log volume are used.
+
+### Skipping the Maven build
+
+If you only want to rebuild the Docker image, you can set `SKIP_BUILD` **only if**
+`ignore/rdf4j.zip` already exists in the `docker/` directory (for example, from a previous
+`build.sh` or `run.sh` execution). Skipping the build does not create or refresh that ZIP:
+
+```sh
+SKIP_BUILD=1 ./run.sh
 ```
 
 ### Access
 
-| Application | URL |
-|---|---|
-| RDF4J Server | http://localhost:8080/rdf4j-server |
-| RDF4J Workbench | http://localhost:8080/rdf4j-workbench |
+| Application     | URL                                    |
+|-----------------|----------------------------------------|
+| RDF4J Server    | http://localhost:8080/rdf4j-server     |
+| RDF4J Workbench | http://localhost:8080/rdf4j-workbench  |
+
+### Useful Docker Compose commands
+
+Follow logs in real time:
+
+```sh
+docker compose logs -f
+```
+
+Show all logs:
+
+```sh
+docker compose logs --tail="all"
+```
+
+Stop the container (keep volumes):
+
+```sh
+docker compose stop
+```
+
+### Stopping and cleaning up
+
+To stop the container and remove the image and all volumes:
+
+```sh
+./shutdown.sh
+```

--- a/site/content/documentation/tools/server-workbench.md
+++ b/site/content/documentation/tools/server-workbench.md
@@ -17,6 +17,65 @@ RDF4J Server and RDF4J Workbench requires the following software:
 
 We recommend using a recent, stable version of [Apache Tomcat](https://tomcat.apache.org/) (version 9.0) or [Jetty](https://jetty.org) (version 9.4)
 
+## Running with Docker
+
+The quickest way to get RDF4J Server and Workbench running locally is to use the Docker environment included in the `docker/` directory of the source distribution. It builds the project, packages it into a Docker image, and starts it via Docker Compose.
+
+All commands below are run from that directory:
+
+```sh
+cd docker
+```
+
+### Quick start
+
+```sh
+./run.sh
+```
+
+This script builds the Maven project, assembles the SDK, builds the Docker image, and starts the container. Once ready it prints:
+
+```
+Workbench is available at http://localhost:8080/rdf4j-workbench
+```
+
+### Choosing the application server
+
+By default Apache Tomcat is used. To use Jetty instead, set `APP_SERVER` before running:
+
+```sh
+APP_SERVER=jetty ./run.sh
+```
+
+### Access
+
+| Application     | URL                                   |
+|-----------------|---------------------------------------|
+| RDF4J Server    | http://localhost:8080/rdf4j-server    |
+| RDF4J Workbench | http://localhost:8080/rdf4j-workbench |
+
+### Useful Docker Compose commands
+
+Follow logs in real time:
+
+```sh
+docker compose logs -f
+```
+
+Stop the container (data volumes are preserved):
+
+```sh
+docker compose stop
+```
+
+### Stopping and cleaning up
+
+To stop the container and remove the image and all volumes:
+
+```sh
+./shutdown.sh
+```
+
 ## Deploying Server and Workbench
 
 RDF4J Server is a database management application: it provides HTTP access to RDF4J repositories, exposing them as SPARQL endpoints. RDF4J Server is meant to be accessed by other applications. Apart from some functionality to view the server’s log messages, it doesn’t provide any user oriented functionality. Instead, the user oriented functionality is part of RDF4J Workbench. The Workbench provides a web interface for querying, updating and exploring the repositories of an RDF4J Server.


### PR DESCRIPTION
Update both Dockerfiles to use ubuntu:noble as the build stage base and bump the app server images to jetty:12-jdk25-eclipse-temurin and tomcat:11.0-jdk25-temurin-noble. Fix the Jetty module list so all EE-specific modules use their ee11-* names, required by Jetty 12.

Rewrite the developer testing docs to reflect the docker/run.sh workflow instead of the outdated manual docker run command.

Add a "Running with Docker" section to the Server/Workbench deployment guide covering the same workflow for end users (quick start, app server selection, useful Compose commands, and cleanup)


GitHub issue resolved: #5611 

Also https://github.com/eclipse-rdf4j/rdf4j/issues/5801


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

