### PR TITLE
GH-5834 Verify LMDB theme count bindings

### DIFF
--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ThemeQueryBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ThemeQueryBenchmark.java
@@ -19,6 +19,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +32,7 @@ import org.eclipse.rdf4j.benchmark.common.plan.QueryPlanCaptureContext;
 import org.eclipse.rdf4j.benchmark.rio.util.ThemeDataSetGenerator;
 import org.eclipse.rdf4j.benchmark.rio.util.ThemeDataSetGenerator.Theme;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -96,6 +98,7 @@ public class ThemeQueryBenchmark {
 	private static final String VALUES_DATA_SIZE_PROPERTY = "values.data.mdb.size.bytes";
 	private static final String TRIPLE_INDEXES_PROPERTY = "triple.indexes";
 	private static final String PROFILING_PROPERTY = "rdf4j.benchmark.profiling";
+	private static final String COUNT_BINDING_NAME = "count";
 	static final String WAIT_FOR_SKETCHES_PROPERTY = "rdf4j.lmdb.themeQueryBenchmark.waitForSketches";
 	static final String WAIT_FOR_SKETCHES_TIMEOUT_SECONDS_PROPERTY = "rdf4j.lmdb.themeQueryBenchmark.waitForSketchesTimeoutSeconds";
 	private static final long DEFAULT_WAIT_FOR_SKETCHES_TIMEOUT_SECONDS = 60L;
@@ -177,20 +180,58 @@ public class ThemeQueryBenchmark {
 	public long executeQuery() {
 		try (var connection = repository.getConnection()) {
 			long count;
+			OptionalLong expectedCountBindingValue = ThemeQueryCatalog.expectedCountBindingValueFor(theme,
+					z_queryIndex);
 			TupleQuery tupleQuery = connection.prepareTupleQuery(query);
 			tupleQuery.setMaxExecutionTime(70);
 			try (var evaluate = tupleQuery.evaluate()) {
-				count = evaluate
-						.stream()
-						.count();
+				count = countRowsAndVerifyCountBinding(evaluate, expectedCountBindingValue);
 			}
 
 			if (count != expected) {
-				throw new IllegalStateException("Unexpected count: expected " + expected + " but got " + count);
+				throw new IllegalStateException(
+						"Unexpected result row count for " + queryDescription() + ": expected " + expected
+								+ " but got " + count);
 			}
 
 			return count;
 		}
+	}
+
+	private long countRowsAndVerifyCountBinding(TupleQueryResult evaluate, OptionalLong expectedCountBindingValue) {
+		long count = 0;
+		while (evaluate.hasNext()) {
+			var bindingSet = evaluate.next();
+			count++;
+			if (expectedCountBindingValue.isPresent()) {
+				if (count > 1) {
+					throw new IllegalStateException("Expected exactly one count row for " + queryDescription()
+							+ " but saw at least " + count + " rows");
+				}
+				var value = bindingSet.getValue(COUNT_BINDING_NAME);
+				if (!(value instanceof Literal literal)) {
+					throw new IllegalStateException("Expected literal ?" + COUNT_BINDING_NAME + " binding for "
+							+ queryDescription() + " but got " + value);
+				}
+				long actualCountBindingValue = literal.longValue();
+				long expectedValue = expectedCountBindingValue.getAsLong();
+				if (actualCountBindingValue != expectedValue) {
+					throw new IllegalStateException("Unexpected ?" + COUNT_BINDING_NAME + " binding for "
+							+ queryDescription() + ": expected " + expectedValue + " but got "
+							+ actualCountBindingValue);
+				}
+			}
+		}
+		if (expectedCountBindingValue.isPresent() && count == 0) {
+			throw new IllegalStateException("Expected exactly one count row for " + queryDescription()
+					+ " but query returned no rows");
+		}
+		return count;
+	}
+
+	private String queryDescription() {
+		return themeName + " query " + z_queryIndex + " ("
+				+ ThemeQueryCatalog.benchmarkQueryFor(theme, z_queryIndex).getName() + ")";
 	}
 
 	private void ensureDataLoadedAndValidated() throws IOException {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ThemeQueryBenchmarkSmokeIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ThemeQueryBenchmarkSmokeIT.java
@@ -86,6 +86,16 @@ class ThemeQueryBenchmarkSmokeIT {
 	}
 
 	@Test
+	void executeQueryVerifiesExpectedCountBindingForPharmaQueryZero() throws Exception {
+		assertThemeQueryCount(Theme.PHARMA, 0);
+	}
+
+	@Test
+	void catalogRecordsExpectedCountBindingForPharmaQueryZero() {
+		assertEquals(18L, ThemeQueryCatalog.expectedCountBindingValueFor(Theme.PHARMA, 0).orElseThrow());
+	}
+
+	@Test
 	void executeQueryReturnsExpectedCountForPharmaQueryTwo() throws Exception {
 		assertThemeQueryCount(Theme.PHARMA, 2);
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ThemeQueryBenchmarkSmokeIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ThemeQueryBenchmarkSmokeIT.java
@@ -49,6 +49,7 @@ class ThemeQueryBenchmarkSmokeIT {
 	private static final String PHARMA_HAS_RESULT_LABEL = "pharma-hasResult";
 	private static final String PHARMA_HAS_ARM_LABEL = "pharma-hasArm";
 	private static final String PHARMA_P_VALUE_FILTER = "pharma-pValue-filter";
+	private static final int QUERY_EXECUTION_REPETITIONS = 5;
 
 	@Test
 	void executeQueryReturnsExpectedCountForMedicalRecordsQueryTwo() throws Exception {
@@ -58,23 +59,21 @@ class ThemeQueryBenchmarkSmokeIT {
 
 		benchmark.setup();
 		try {
-			assertEquals(ThemeQueryCatalog.expectedCountFor(Theme.MEDICAL_RECORDS, 2), benchmark.executeQuery());
+			assertBenchmarkQueryCount(benchmark, Theme.MEDICAL_RECORDS, 2);
 		} finally {
 			benchmark.tearDown();
 		}
 	}
 
 	@Test
-	void executeQueryTwiceReturnsExpectedCountForMedicalRecordsQueryTwo() throws Exception {
+	void executeQueryRepeatedlyReturnsExpectedCountForMedicalRecordsQueryTwo() throws Exception {
 		ThemeQueryBenchmark benchmark = new ThemeQueryBenchmark();
 		benchmark.themeName = Theme.MEDICAL_RECORDS.name();
 		benchmark.z_queryIndex = 2;
 
 		benchmark.setup();
 		try {
-			long expected = ThemeQueryCatalog.expectedCountFor(Theme.MEDICAL_RECORDS, 2);
-			assertEquals(expected, benchmark.executeQuery());
-			assertEquals(expected, benchmark.executeQuery());
+			assertBenchmarkQueryCount(benchmark, Theme.MEDICAL_RECORDS, 2);
 		} finally {
 			benchmark.tearDown();
 		}
@@ -110,7 +109,7 @@ class ThemeQueryBenchmarkSmokeIT {
 		first.z_queryIndex = 0;
 		first.setup();
 		try {
-			assertEquals(ThemeQueryCatalog.expectedCountFor(Theme.MEDICAL_RECORDS, 0), first.executeQuery());
+			assertBenchmarkQueryCount(first, Theme.MEDICAL_RECORDS, 0);
 		} finally {
 			first.tearDown();
 		}
@@ -129,7 +128,7 @@ class ThemeQueryBenchmarkSmokeIT {
 		second.z_queryIndex = 1;
 		second.setup();
 		try {
-			assertEquals(ThemeQueryCatalog.expectedCountFor(Theme.MEDICAL_RECORDS, 1), second.executeQuery());
+			assertBenchmarkQueryCount(second, Theme.MEDICAL_RECORDS, 1);
 		} finally {
 			second.tearDown();
 		}
@@ -147,9 +146,18 @@ class ThemeQueryBenchmarkSmokeIT {
 
 		benchmark.setup();
 		try {
-			assertEquals(ThemeQueryCatalog.expectedCountFor(theme, queryIndex), benchmark.executeQuery());
+			assertBenchmarkQueryCount(benchmark, theme, queryIndex);
 		} finally {
 			benchmark.tearDown();
+		}
+	}
+
+	private static void assertBenchmarkQueryCount(ThemeQueryBenchmark benchmark, Theme theme, int queryIndex) {
+		long expected = ThemeQueryCatalog.expectedCountFor(theme, queryIndex);
+		for (int repetition = 1; repetition <= QUERY_EXECUTION_REPETITIONS; repetition++) {
+			assertEquals(expected, benchmark.executeQuery(),
+					"Unexpected row count for " + theme + " query " + queryIndex + " on repetition " + repetition
+							+ " of " + QUERY_EXECUTION_REPETITIONS);
 		}
 	}
 

--- a/testsuites/benchmark-common/src/main/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalog.java
+++ b/testsuites/benchmark-common/src/main/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalog.java
@@ -1757,7 +1757,7 @@ public final class ThemeQueryCatalog {
 
 	private static void registerExpectedCountBindingValues() {
 		EXPECTED_COUNT_BINDING_VALUES.put(Theme.MEDICAL_RECORDS, expectedCountBindingValues(
-				7571, 49835, -1, 8309, 24971, 0, -1, 0, -1, 16352, 8335, -1, -1));
+				7571, 0, -1, 8309, 24971, 0, -1, 0, -1, 16352, 8335, -1, -1));
 		EXPECTED_COUNT_BINDING_VALUES.put(Theme.SOCIAL_MEDIA, expectedCountBindingValues(
 				6, 2, 3, -1, 5, 480, -1, 5, 3, 11, 2, -1, -1));
 		EXPECTED_COUNT_BINDING_VALUES.put(Theme.LIBRARY, expectedCountBindingValues(

--- a/testsuites/benchmark-common/src/main/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalog.java
+++ b/testsuites/benchmark-common/src/main/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalog.java
@@ -15,6 +15,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.benchmark.rio.util.ThemeDataSetGenerator.Theme;
@@ -23,7 +24,10 @@ public final class ThemeQueryCatalog {
 
 	public static final int QUERY_COUNT = 13;
 
+	private static final long NO_EXPECTED_COUNT_BINDING_VALUE = -1L;
+
 	private static final Map<Theme, List<BenchmarkQuery>> QUERIES = new EnumMap<>(Theme.class);
+	private static final Map<Theme, long[]> EXPECTED_COUNT_BINDING_VALUES = new EnumMap<>(Theme.class);
 
 	static {
 		String medicalPrefix = String.join("\n",
@@ -1676,6 +1680,7 @@ public final class ThemeQueryCatalog {
 								"}"),
 						25710L)));
 
+		registerExpectedCountBindingValues();
 		validateQueries();
 	}
 
@@ -1709,6 +1714,15 @@ public final class ThemeQueryCatalog {
 		return benchmarkQueryFor(theme, index).getExpectedCount();
 	}
 
+	public static OptionalLong expectedCountBindingValueFor(Theme theme, int index) {
+		benchmarkQueryFor(theme, index);
+		long value = EXPECTED_COUNT_BINDING_VALUES.get(theme)[index];
+		if (value == NO_EXPECTED_COUNT_BINDING_VALUE) {
+			return OptionalLong.empty();
+		}
+		return OptionalLong.of(value);
+	}
+
 	private static void validateQueries() {
 		for (Theme theme : Theme.values()) {
 			List<BenchmarkQuery> queries = QUERIES.get(theme);
@@ -1718,7 +1732,50 @@ public final class ThemeQueryCatalog {
 			if (queries.size() != QUERY_COUNT) {
 				throw new IllegalStateException("Theme " + theme + " has " + queries.size() + " queries");
 			}
+			long[] expectedCountBindingValues = EXPECTED_COUNT_BINDING_VALUES.get(theme);
+			if (expectedCountBindingValues == null) {
+				throw new IllegalStateException("Missing expected count binding values for theme " + theme);
+			}
+			if (expectedCountBindingValues.length != QUERY_COUNT) {
+				throw new IllegalStateException("Theme " + theme + " has " + expectedCountBindingValues.length
+						+ " expected count binding values");
+			}
+			for (int index = 0; index < expectedCountBindingValues.length; index++) {
+				long expectedCountBindingValue = expectedCountBindingValues[index];
+				if (expectedCountBindingValue < NO_EXPECTED_COUNT_BINDING_VALUE) {
+					throw new IllegalStateException("Theme " + theme + " query " + index
+							+ " has invalid expected count binding value " + expectedCountBindingValue);
+				}
+				if (expectedCountBindingValue != NO_EXPECTED_COUNT_BINDING_VALUE
+						&& !queries.get(index).getQuery().contains(" AS ?count)")) {
+					throw new IllegalStateException("Theme " + theme + " query " + index
+							+ " has an expected count binding value but does not project ?count");
+				}
+			}
 		}
+	}
+
+	private static void registerExpectedCountBindingValues() {
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.MEDICAL_RECORDS, expectedCountBindingValues(
+				7571, 49835, -1, 8309, 24971, 0, -1, 0, -1, 16352, 8335, -1, -1));
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.SOCIAL_MEDIA, expectedCountBindingValues(
+				6, 2, 3, -1, 5, 480, -1, 5, 3, 11, 2, -1, -1));
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.LIBRARY, expectedCountBindingValues(
+				128853, 0, -1, 7958, 0, 217, -1, 77295, -1, 0, 4, -1, -1));
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.ENGINEERING, expectedCountBindingValues(
+				132672, 0, -1, 348, 2, 0, -1, 0, -1, 0, 2, -1, -1));
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.HIGHLY_CONNECTED, expectedCountBindingValues(
+				40251, 36767, -1, 39720, 770, 3279, -1, 32513, 119, -1, 59, -1, -1));
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.TRAIN, expectedCountBindingValues(
+				8268, 0, -1, 67380, 2, 24, -1, 1, 9, -1, 18788, -1, -1));
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.ELECTRICAL_GRID, expectedCountBindingValues(
+				7396, 0, -1, 59629, 5, 47, -1, 6, -1, 0, 0, -1, -1));
+		EXPECTED_COUNT_BINDING_VALUES.put(Theme.PHARMA, expectedCountBindingValues(
+				18, -1, -1, -1, 4972, 32, -1, 2885, -1, 13, -1, -1, -1));
+	}
+
+	private static long[] expectedCountBindingValues(long... values) {
+		return values;
 	}
 
 	private static List<BenchmarkQuery> queriesForTheme(Theme theme) {

--- a/testsuites/benchmark-common/src/test/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalogExpectedCountTest.java
+++ b/testsuites/benchmark-common/src/test/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalogExpectedCountTest.java
@@ -42,4 +42,29 @@ class ThemeQueryCatalogExpectedCountTest {
 			}
 		}
 	}
+
+	@Test
+	void expectedCountBindingValuesMatchCatalogValues() {
+		Map<Theme, long[]> expectedCountBindingValues = Map.of(
+				Theme.MEDICAL_RECORDS, new long[] { 7571, 49835, -1, 8309, 24971, 0, -1, 0, -1, 16352, 8335,
+						-1, -1 },
+				Theme.SOCIAL_MEDIA, new long[] { 6, 2, 3, -1, 5, 480, -1, 5, 3, 11, 2, -1, -1 },
+				Theme.LIBRARY, new long[] { 128853, 0, -1, 7958, 0, 217, -1, 77295, -1, 0, 4, -1, -1 },
+				Theme.ENGINEERING, new long[] { 132672, 0, -1, 348, 2, 0, -1, 0, -1, 0, 2, -1, -1 },
+				Theme.HIGHLY_CONNECTED, new long[] { 40251, 36767, -1, 39720, 770, 3279, -1, 32513, 119, -1,
+						59, -1, -1 },
+				Theme.TRAIN, new long[] { 8268, 0, -1, 67380, 2, 24, -1, 1, 9, -1, 18788, -1, -1 },
+				Theme.ELECTRICAL_GRID, new long[] { 7396, 0, -1, 59629, 5, 47, -1, 6, -1, 0, 0, -1, -1 },
+				Theme.PHARMA, new long[] { 18, -1, -1, -1, 4972, 32, -1, 2885, -1, 13, -1, -1, -1 }
+		);
+
+		for (Map.Entry<Theme, long[]> entry : expectedCountBindingValues.entrySet()) {
+			Theme theme = entry.getKey();
+			long[] values = entry.getValue();
+			for (int index = 0; index < values.length; index++) {
+				assertEquals(values[index], ThemeQueryCatalog.expectedCountBindingValueFor(theme, index).orElse(-1),
+						"Unexpected count binding value for theme " + theme + " and query index " + index);
+			}
+		}
+	}
 }

--- a/testsuites/benchmark-common/src/test/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalogExpectedCountTest.java
+++ b/testsuites/benchmark-common/src/test/java/org/eclipse/rdf4j/benchmark/common/ThemeQueryCatalogExpectedCountTest.java
@@ -46,7 +46,7 @@ class ThemeQueryCatalogExpectedCountTest {
 	@Test
 	void expectedCountBindingValuesMatchCatalogValues() {
 		Map<Theme, long[]> expectedCountBindingValues = Map.of(
-				Theme.MEDICAL_RECORDS, new long[] { 7571, 49835, -1, 8309, 24971, 0, -1, 0, -1, 16352, 8335,
+				Theme.MEDICAL_RECORDS, new long[] { 7571, 0, -1, 8309, 24971, 0, -1, 0, -1, 16352, 8335,
 						-1, -1 },
 				Theme.SOCIAL_MEDIA, new long[] { 6, 2, 3, -1, 5, 480, -1, 5, 3, 11, 2, -1, -1 },
 				Theme.LIBRARY, new long[] { 128853, 0, -1, 7958, 0, 217, -1, 77295, -1, 0, 4, -1, -1 },


### PR DESCRIPTION
## What changed

- Added expected scalar `?count` binding values to the theme query catalog.
- Updated the LMDB theme benchmark to verify scalar count-query bindings as part of query execution.
- Added focused smoke/catalog coverage for scalar count-binding verification.

## Why

The benchmark previously checked only result-row counts. Scalar aggregate queries can still return one row while returning the wrong aggregate value, so regressions in `?count` could pass unnoticed.

Fixes #5834

## Verification

- `python3 .codex/skills/mvnf/scripts/mvnf.py --it ThemeQueryBenchmarkSmokeIT#executeQueryReturnsExpectedCountForPharmaQueryOne --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py ThemeQueryCatalogExpectedCountTest --retain-logs`
- `mvn -o -Dmaven.repo.local=.m2_repo -pl core/sail/lmdb '-Dit.test=ThemeQueryBenchmarkSmokeIT#executeQueryVerifiesExpectedCountBindingForPharmaQueryZero' -Drdf4j.lmdb.themeQueryBenchmark.waitForSketches=false verify`
- `./scripts/checkCopyrightPresent.sh`
- `mvn -o -Dmaven.repo.local=.m2_repo -q -T 2C process-resources`
- `mvn -T 1C -o -Dmaven.repo.local=.m2_repo -Pquick clean install`