### PR TITLE
GH-5843: fix NativeStore BTree corruption recovery

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TripleStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TripleStore.java
@@ -383,10 +383,10 @@ class TripleStore implements Closeable {
 				logger.error("Failed to restore from uncompleted commit", e);
 				throw e;
 			} catch (RuntimeException e) {
-				logger.error("BTree corruption detected during commit recovery, attempting rollback", e);
+				logger.error("Commit recovery failed with runtime exception, attempting rollback", e);
 				try {
 					rollback();
-					logger.warn("Rolled back corrupt commit; data from that transaction is lost");
+					logger.warn("Rolled back failed commit recovery; data from that transaction is lost");
 				} catch (IOException rollbackEx) {
 					e.addSuppressed(rollbackEx);
 					throw new IOException("Crash recovery failed: commit and rollback both failed", e);

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TripleStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TripleStore.java
@@ -382,6 +382,15 @@ class TripleStore implements Closeable {
 			} catch (IOException e) {
 				logger.error("Failed to restore from uncompleted commit", e);
 				throw e;
+			} catch (RuntimeException e) {
+				logger.error("BTree corruption detected during commit recovery, attempting rollback", e);
+				try {
+					rollback();
+					logger.warn("Rolled back corrupt commit; data from that transaction is lost");
+				} catch (IOException rollbackEx) {
+					e.addSuppressed(rollbackEx);
+					throw new IOException("Crash recovery failed: commit and rollback both failed", e);
+				}
 			}
 			break;
 		case ROLLING_BACK:

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
@@ -12,8 +12,10 @@ package org.eclipse.rdf4j.sail.nativerdf;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
+import java.io.RandomAccessFile;
 
 import org.eclipse.rdf4j.sail.nativerdf.TxnStatusFile.TxnStatus;
 import org.eclipse.rdf4j.sail.nativerdf.btree.RecordIterator;
@@ -48,6 +50,83 @@ public class TripleStoreRecoveryTest {
 		} finally {
 			tripleStore.close();
 		}
+	}
+
+	/**
+	 * Reproduces a crash-recovery failure where a BTree file is structurally corrupt: a non-leaf node's left child is
+	 * an empty leaf. This violates the B-Tree invariant and causes {@link IllegalArgumentException} to be thrown from
+	 * {@code BTree.removeLargestValueFromTree} during crash recovery, making the store permanently unreadable.
+	 * <p>
+	 * The test simulates the exact scenario from the production stack trace:
+	 *
+	 * <pre>
+	 * IllegalArgumentException: Trying to remove largest value from an empty node in ...triples-spoc.dat
+	 *   at BTree.removeLargestValueFromTree
+	 *   at BTree.removeFromTree
+	 *   at BTree.remove
+	 *   at TripleStore.commit
+	 *   at TripleStore.processUncompletedTransaction
+	 *   at TripleStore.&lt;init&gt;
+	 * </pre>
+	 */
+	@Test
+	public void testCommitRecoveryWithBTreeCorruption() throws Exception {
+		// TripleStore uses blockSize=2048, RECORD_LENGTH=17, slotSize=21.
+		// branchFactor = 1 + (2048-8)/21 = 98; a node holds up to 97 values.
+		// Inserting 98 triples in ascending order fills the leaf root (97 values) and
+		// triggers a split on the 98th: the value at medianIdx=49 (triple 50) becomes
+		// the root's sole value; node 1 (left child) holds triples 1-49.
+		final int blockSize = 2048;
+		final int slotSize = 4 + TripleStore.RECORD_LENGTH;
+		final int branchFactor = 1 + (blockSize - 8) / slotSize; // 98
+		final int medianId = branchFactor / 2 + 1; // 50 — the triple stored in the root node
+
+		// Step 1: Populate the TripleStore with enough triples to create a 2-level BTree
+		TripleStore tripleStore = new TripleStore(dataDir, "spoc");
+		try {
+			tripleStore.startTransaction();
+			for (int i = 1; i <= branchFactor + 2; i++) {
+				tripleStore.storeTriple(i, i, i, i);
+			}
+			tripleStore.commit();
+		} finally {
+			tripleStore.close();
+		}
+
+		// Step 2: Mark the median triple (the value stored in the non-leaf root node)
+		// for removal inside a transaction, but do not commit. This sets REMOVED_FLAG
+		// on that triple in the BTree file while leaving txn status as ACTIVE.
+		tripleStore = new TripleStore(dataDir, "spoc");
+		try {
+			tripleStore.startTransaction();
+			tripleStore.removeTriplesByContext(medianId, medianId, medianId, medianId, true);
+		} finally {
+			tripleStore.close();
+		}
+
+		// Step 3: Simulate disk corruption — zero out the valueCount of node 1
+		// (the root's left child, at file offset blockSize * nodeId = 2048).
+		// This creates an empty leaf, violating the B-Tree structural invariant.
+		File btreeFile = new File(dataDir, "triples-spoc.dat");
+		try (RandomAccessFile raf = new RandomAccessFile(btreeFile, "rw")) {
+			raf.seek(blockSize); // nodeID2offset(1) = blockSize * 1
+			raf.writeInt(0); // set valueCount = 0
+		}
+
+		// Step 4: Simulate a crash that occurred mid-commit by forcing txn status to COMMITTING
+		TxnStatusFile txnStatusFile = new TxnStatusFile(dataDir);
+		try {
+			txnStatusFile.setTxnStatus(TxnStatus.COMMITTING, false);
+		} finally {
+			txnStatusFile.close();
+		}
+
+		// Step 5: Re-opening triggers crash recovery:
+		// processUncompletedTransaction(COMMITTING) → commit()
+		// → btree.iterateAll() finds triple medianId with REMOVED_FLAG
+		// → btree.remove(triple) → removeFromTree finds it in root (non-leaf)
+		// → removeLargestValueFromTree(empty left child) → IllegalArgumentException
+		assertThrows(IllegalArgumentException.class, () -> new TripleStore(dataDir, "spoc").close());
 	}
 
 	@Test

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.sail.nativerdf;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.RandomAccessFile;
@@ -122,11 +121,17 @@ public class TripleStoreRecoveryTest {
 		}
 
 		// Step 5: Re-opening triggers crash recovery:
-		// processUncompletedTransaction(COMMITTING) → commit()
-		// → btree.iterateAll() finds triple medianId with REMOVED_FLAG
-		// → btree.remove(triple) → removeFromTree finds it in root (non-leaf)
-		// → removeLargestValueFromTree(empty left child) → IllegalArgumentException
-		assertThrows(IllegalArgumentException.class, () -> new TripleStore(dataDir, "spoc").close());
+		// processUncompletedTransaction(COMMITTING) → commit() throws IllegalArgumentException
+		// → fallback rollback() clears the REMOVED_FLAG → store opens successfully
+		tripleStore = new TripleStore(dataDir, "spoc");
+		try {
+			try (RecordIterator iter = tripleStore.getTriples(-1, -1, -1, -1)) {
+				// store must be readable after recovery; exact content is best-effort
+				assertNotNull(iter);
+			}
+		} finally {
+			tripleStore.close();
+		}
 	}
 
 	@Test

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -84,7 +85,7 @@ public class TripleStoreRecoveryTest {
 		TripleStore tripleStore = new TripleStore(dataDir, "spoc");
 		try {
 			tripleStore.startTransaction();
-			for (int i = 1; i <= branchFactor + 2; i++) {
+			for (int i = 1; i <= branchFactor; i++) {
 				tripleStore.storeTriple(i, i, i, i);
 			}
 			tripleStore.commit();
@@ -98,7 +99,8 @@ public class TripleStoreRecoveryTest {
 		tripleStore = new TripleStore(dataDir, "spoc");
 		try {
 			tripleStore.startTransaction();
-			tripleStore.removeTriplesByContext(medianId, medianId, medianId, medianId, true);
+			assertEquals(Long.valueOf(1L),
+					tripleStore.removeTriplesByContext(medianId, medianId, medianId, medianId, true).get(medianId));
 		} finally {
 			tripleStore.close();
 		}
@@ -127,7 +129,7 @@ public class TripleStoreRecoveryTest {
 		try {
 			try (RecordIterator iter = tripleStore.getTriples(-1, -1, -1, -1)) {
 				// store must be readable after recovery; exact content is best-effort
-				assertNotNull(iter);
+				assertNotNull(iter.next());
 			}
 		} finally {
 			tripleStore.close();


### PR DESCRIPTION
GitHub issue resolved: #5843

See #5843 for detailed write-up

**Commit 1 GH-5843: add regression test for BTree corruption crash-recovery failure**

Adds testCommitRecoveryWithBTreeCorruption to TripleStoreRecoveryTest,
reproducing the scenario where a crash leaves a non-leaf BTree node with
an empty leaf child. On reopen,
processUncompletedTransaction(COMMITTING) calls commit(), which calls
btree.remove() on the root-level triple, which recurses into the empty
child via removeLargestValueFromTree and throws IllegalArgumentException
— making the store permanently unreadable.

The test simulates the exact production stack trace by: building a
2-level BTree, marking the root's separator value for removal, zeroing
the left child's valueCount on disk to mimic a partial-flush crash, and
forcing txn status to COMMITTING. It asserts that reopening throws
IllegalArgumentException, confirming the bug is reproducible before any
fix is applied.



**Commit 2: GH-5843: recover from BTree corruption during crash recovery**

processUncompletedTransaction only caught IOException from commit(), so
an IllegalArgumentException thrown by BTree.removeLargestValueFromTree
(when a non-leaf node's child is an empty leaf due to a partial-flush
crash) propagated through the TripleStore constructor and left the store
permanently unreadable.

Add a RuntimeException catch that falls back to rollback(), keeping the
store accessible at the cost of losing the uncommitted transaction. If
rollback also fails, both exceptions are surfaced via addSuppressed.

Update the regression test to assert the store opens and is readable
after recovery instead of asserting the exception.




----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

