### PR TITLE
GH-5849 Remove obsolete TurtleStarWriterFactory reference and incorrect triple term comparison logic in literal-only comparison methods

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtil.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtil.java
@@ -201,13 +201,7 @@ public class QueryEvaluationUtil {
 		if (l != null && l.isLiteral() && r != null && r.isLiteral()) {
 			return doCompareLiteralsLT((Literal) l, (Literal) r, strict);
 		}
-		if (l != null && l.isTripleTerm() && r != null && r.isTripleTerm()) {
-			TripleTerm leftTerm = (TripleTerm) l;
-			TripleTerm rightTerm = (TripleTerm) r;
-			return compareLT(leftTerm.getSubject(), rightTerm.getSubject(), strict) &&
-					compareLT(leftTerm.getPredicate(), rightTerm.getPredicate(), strict) &&
-					compareLT(leftTerm.getObject(), rightTerm.getObject(), strict);
-		}
+
 		throw NOT_COMPATIBLE_AND_ORDERED_EXCEPTION;
 	}
 
@@ -227,13 +221,7 @@ public class QueryEvaluationUtil {
 		if (l != null && l.isLiteral() && r != null && r.isLiteral()) {
 			return doCompareLiteralsLE((Literal) l, (Literal) r, strict);
 		}
-		if (l != null && l.isTripleTerm() && r != null && r.isTripleTerm()) {
-			TripleTerm leftTerm = (TripleTerm) l;
-			TripleTerm rightTerm = (TripleTerm) r;
-			return compareLE(leftTerm.getSubject(), rightTerm.getSubject(), strict) &&
-					compareLE(leftTerm.getPredicate(), rightTerm.getPredicate(), strict) &&
-					compareLE(leftTerm.getObject(), rightTerm.getObject(), strict);
-		}
+
 		throw NOT_COMPATIBLE_AND_ORDERED_EXCEPTION;
 	}
 
@@ -253,13 +241,7 @@ public class QueryEvaluationUtil {
 		if (l != null && l.isLiteral() && r != null && r.isLiteral()) {
 			return doCompareLiteralsGT((Literal) l, (Literal) r, strict);
 		}
-		if (l != null && l.isTripleTerm() && r != null && r.isTripleTerm()) {
-			TripleTerm leftTerm = (TripleTerm) l;
-			TripleTerm rightTerm = (TripleTerm) r;
-			return compareGT(leftTerm.getSubject(), rightTerm.getSubject(), strict) &&
-					compareGT(leftTerm.getPredicate(), rightTerm.getPredicate(), strict) &&
-					compareGT(leftTerm.getObject(), rightTerm.getObject(), strict);
-		}
+
 		throw NOT_COMPATIBLE_AND_ORDERED_EXCEPTION;
 	}
 
@@ -279,13 +261,7 @@ public class QueryEvaluationUtil {
 		if (l != null && l.isLiteral() && r != null && r.isLiteral()) {
 			return doCompareLiteralsGE((Literal) l, (Literal) r, strict);
 		}
-		if (l != null && l.isTripleTerm() && r != null && r.isTripleTerm()) {
-			TripleTerm leftTerm = (TripleTerm) l;
-			TripleTerm rightTerm = (TripleTerm) r;
-			return compareGE(leftTerm.getSubject(), rightTerm.getSubject(), strict) &&
-					compareGE(leftTerm.getPredicate(), rightTerm.getPredicate(), strict) &&
-					compareGE(leftTerm.getObject(), rightTerm.getObject(), strict);
-		}
+
 		throw NOT_COMPATIBLE_AND_ORDERED_EXCEPTION;
 	}
 

--- a/core/rio/turtle/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
+++ b/core/rio/turtle/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
@@ -1,2 +1,1 @@
 org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory
-org.eclipse.rdf4j.rio.turtlestar.TurtleStarWriterFactory


### PR DESCRIPTION
GitHub issue resolved: #5327

Remove obsolete TurtleStarWriterFactory reference and incorrect triple term comparison logic in literal-only comparison methods in QueryEvaluationUtil.

- Remove TurtleStarWriterFactory from META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory as TurtleStar is superseded by standard Turtle with native RDF-star support
- Remove triple term comparison blocks from compareLT, compareLE, compareGT and compareGE in QueryEvaluationUtil as these methods are explicitly designed for literal comparisons only and triple terms support equality comparison only

1.  My pull request is self-contained
2.  I've applied code formatting
3.  I've squashed my commits where necessary
4.  every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

Note on tests: No tests were added for these changes as the removed code was unreachable dead code — the triple term comparison blocks in these literal-only methods could never be correctly triggered, and the TurtleStarWriterFactory removal is a service registration cleanup with no behavioral logic to test.

