### PR TITLE
GH-5852 Added support for directive serialization style in turtle wri…

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleWriterSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleWriterSettings.java
@@ -37,6 +37,19 @@ public class TurtleWriterSettings {
 			"org.eclipse.rdf4j.rio.turtle.abbreviate_numbers", "Abbreviate numbers", Boolean.TRUE);
 
 	/**
+	 * Boolean setting for Turtle/Trig writers to determine whether they should use RDF style directives: '@prefix',
+	 * '@base' and '@version' if set to false, or SPARQL style directives: 'PREFIX', 'BASE' and 'VERSION' if set to
+	 * true.
+	 * <p>
+	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.use_sparql_style_directives}.
+	 */
+	public static final BooleanRioSetting USE_SPARQL_STYLE_DIRECTIVES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.use_sparql_style_directives",
+			"Use SPARQL style directives BASE, PREFIX and VERSION.", Boolean.FALSE);
+
+	/**
 	 * Private default constructor.
 	 */
 	private TurtleWriterSettings() {

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
@@ -40,11 +40,6 @@ public class N3Writer implements RDFWriter, CharSink {
 
 	private final TurtleWriter ttlWriter;
 
-	/**
-	 * A collection of configuration options for this writer.
-	 */
-	private WriterConfig writerConfig = new WriterConfig();
-
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
@@ -103,13 +98,13 @@ public class N3Writer implements RDFWriter, CharSink {
 
 	@Override
 	public RDFWriter setWriterConfig(WriterConfig config) {
-		this.writerConfig = config;
+		ttlWriter.setWriterConfig(config);
 		return this;
 	}
 
 	@Override
 	public WriterConfig getWriterConfig() {
-		return writerConfig;
+		return ttlWriter.getWriterConfig();
 	}
 
 	@Override

--- a/core/rio/n3/src/test/java/org/eclipse/rdf4j/rio/n3/N3WriterTest.java
+++ b/core/rio/n3/src/test/java/org/eclipse/rdf4j/rio/n3/N3WriterTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.n3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.DynamicModelFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.TurtleWriterSettings;
+import org.junit.jupiter.api.Test;
+
+public class N3WriterTest {
+
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	@Test
+	public void testRDFStyleDirectivesPrintedByDefault() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.N3,
+				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, false));
+		assertEquals("@base <http://example.com/base/> .\n" +
+				"@prefix ex: <http://example.com/prefix/> .\n" +
+				"@version \"1.2\" .\n" +
+				"_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 </p> \"literal\" )>> .\n",
+				stringWriter.toString());
+	}
+
+	@Test
+	public void testSPARQLStyleDirectivesPrintedUponConfiguration() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		WriterConfig writerConfig = new WriterConfig();
+		writerConfig.set(BasicWriterSettings.PRETTY_PRINT, false);
+		writerConfig.set(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES, true);
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.N3, writerConfig);
+		assertEquals("BASE <http://example.com/base/>\n" +
+				"PREFIX ex: <http://example.com/prefix/>\n" +
+				"VERSION \"1.2\"\n" +
+				"_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 </p> \"literal\" )>> .\n",
+				stringWriter.toString());
+	}
+}

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/AbstractTriGWriterTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/AbstractTriGWriterTest.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.rio.trig;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringWriter;
+import java.net.URISyntaxException;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
@@ -45,7 +46,8 @@ public abstract class AbstractTriGWriterTest extends RDFWriterTest {
 				BasicWriterSettings.PRETTY_PRINT,
 				BasicWriterSettings.INLINE_BLANK_NODES,
 				BasicWriterSettings.BASE_DIRECTIVE,
-				TurtleWriterSettings.ABBREVIATE_NUMBERS
+				TurtleWriterSettings.ABBREVIATE_NUMBERS,
+				TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES
 		};
 	}
 
@@ -66,7 +68,7 @@ public abstract class AbstractTriGWriterTest extends RDFWriterTest {
 		Rio.write(model, stringWriter, RDFFormat.TRIG,
 				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, true));
 
-		assertTrue(stringWriter.toString().startsWith("VERSION \"1.2\"\n"));
+		assertTrue(stringWriter.toString().startsWith("@version \"1.2\" .\n"));
 	}
 
 	@Test
@@ -79,7 +81,7 @@ public abstract class AbstractTriGWriterTest extends RDFWriterTest {
 		Rio.write(model, stringWriter, RDFFormat.TRIG,
 				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, true));
 
-		assertTrue(stringWriter.toString().startsWith("VERSION \"1.2\"\n"));
+		assertTrue(stringWriter.toString().startsWith("@version \"1.2\" .\n"));
 	}
 
 	@Test
@@ -92,7 +94,7 @@ public abstract class AbstractTriGWriterTest extends RDFWriterTest {
 		StringWriter stringWriter = new StringWriter();
 		Rio.write(model, stringWriter, RDFFormat.TRIG);
 
-		assertTrue(stringWriter.toString().startsWith("VERSION \"1.2\"\n"));
+		assertTrue(stringWriter.toString().startsWith("@version \"1.2\" .\n"));
 	}
 
 	@Test
@@ -103,6 +105,40 @@ public abstract class AbstractTriGWriterTest extends RDFWriterTest {
 		StringWriter stringWriter = new StringWriter();
 		Rio.write(model, stringWriter, RDFFormat.TRIG);
 
-		assertTrue(stringWriter.toString().startsWith("VERSION \"1.2\"\n"));
+		assertTrue(stringWriter.toString().startsWith("@version \"1.2\" .\n"));
 	}
+
+	@Test
+	public void testRDFStyleDirectivesPrintedByDefault() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.TURTLE);
+		assertTrue(stringWriter.toString()
+				.startsWith("@base <http://example.com/base/> .\n" +
+						"@prefix ex: <http://example.com/prefix/> .\n" +
+						"@version \"1.2\" .\n"));
+	}
+
+	@Test
+	public void testSPARQLStyleDirectivesPrintedUponConfiguration() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.TURTLE,
+				new WriterConfig().set(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES, true));
+		assertTrue(stringWriter.toString()
+				.startsWith("BASE <http://example.com/base/>\n" +
+						"PREFIX ex: <http://example.com/prefix/>\n" +
+						"VERSION \"1.2\"\n"));
+	}
+
 }

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -161,6 +161,7 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 		settings.add(BasicWriterSettings.PRETTY_PRINT);
 		settings.add(BasicWriterSettings.INLINE_BLANK_NODES);
 		settings.add(TurtleWriterSettings.ABBREVIATE_NUMBERS);
+		settings.add(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES);
 		return settings;
 	}
 
@@ -456,18 +457,34 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 	}
 
 	protected void writeBase(String baseURI) throws IOException {
-		writer.write("@base <");
-		StringUtil.simpleEscapeIRI(baseURI, writer, false);
-		writer.write("> .");
+		if (getWriterConfig().get(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES)) {
+			writer.write("BASE <");
+			StringUtil.simpleEscapeIRI(baseURI, writer, false);
+			// SPARQL directive style doesn't end with .
+			writer.write(">");
+		} else {
+			writer.write("@base <");
+			StringUtil.simpleEscapeIRI(baseURI, writer, false);
+			writer.write("> .");
+		}
 		writer.writeEOL();
 	}
 
 	protected void writeNamespace(String prefix, String name) throws IOException {
-		writer.write("@prefix ");
-		writer.write(prefix);
-		writer.write(": <");
-		StringUtil.simpleEscapeIRI(name, writer, false);
-		writer.write("> .");
+		if (getWriterConfig().get(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES)) {
+			writer.write("PREFIX ");
+			writer.write(prefix);
+			writer.write(": <");
+			StringUtil.simpleEscapeIRI(name, writer, false);
+			// SPARQL directive style doesn't end with .
+			writer.write(">");
+		} else {
+			writer.write("@prefix ");
+			writer.write(prefix);
+			writer.write(": <");
+			StringUtil.simpleEscapeIRI(name, writer, false);
+			writer.write("> .");
+		}
 		writer.writeEOL();
 	}
 
@@ -494,7 +511,13 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 	@Override
 	protected void writeVersionAnnouncement() throws RDFHandlerException {
 		try {
-			writer.write("VERSION \"1.2\"");
+			if (getWriterConfig().get(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES)) {
+				writer.write("VERSION \"1.2\"");
+				// SPARQL directive style doesn't end with .
+			} else {
+				writer.write("@version \"1.2\"");
+				writer.write(" .");
+			}
 			writer.writeEOL();
 		} catch (IOException e) {
 			throw new RDFHandlerException(e);

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterSettings.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterSettings.java
@@ -38,6 +38,19 @@ public class TurtleWriterSettings {
 			"org.eclipse.rdf4j.rio.turtle.abbreviate_numbers", "Abbreviate numbers", Boolean.TRUE);
 
 	/**
+	 * Boolean setting for Turtle/Trig writers to determine whether they should use RDF style directives: '@prefix',
+	 * '@base' and '@version' if set to false, or SPARQL style directives: 'PREFIX', 'BASE' and 'VERSION' if set to
+	 * true.
+	 * <p>
+	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.use_sparql_style_directives}.
+	 */
+	public static final BooleanRioSetting USE_SPARQL_STYLE_DIRECTIVES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.use_sparql_style_directives",
+			"Use SPARQL style directives BASE, PREFIX and VERSION.", Boolean.FALSE);
+
+	/**
 	 * Private default constructor.
 	 */
 	private TurtleWriterSettings() {
@@ -45,6 +58,8 @@ public class TurtleWriterSettings {
 
 	static {
 		assert ABBREVIATE_NUMBERS.equals(org.eclipse.rdf4j.rio.helpers.TurtleWriterSettings.ABBREVIATE_NUMBERS);
+		assert USE_SPARQL_STYLE_DIRECTIVES
+				.equals(org.eclipse.rdf4j.rio.helpers.TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES);
 	}
 
 }

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/AbstractTurtleWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/AbstractTurtleWriterTest.java
@@ -36,7 +36,8 @@ public abstract class AbstractTurtleWriterTest extends RDFWriterTest {
 				BasicWriterSettings.PRETTY_PRINT,
 				BasicWriterSettings.INLINE_BLANK_NODES,
 				BasicWriterSettings.BASE_DIRECTIVE,
-				TurtleWriterSettings.ABBREVIATE_NUMBERS
+				TurtleWriterSettings.ABBREVIATE_NUMBERS,
+				TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES
 		};
 	}
 

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.net.URISyntaxException;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
@@ -159,7 +160,7 @@ public class TurtlePrettyWriterTest extends AbstractTurtleWriterTest {
 		Rio.write(model, stringWriter, RDFFormat.TURTLE,
 				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, true));
 
-		assertEquals("VERSION \"1.2\"\n\n"
+		assertEquals("@version \"1.2\" .\n\n"
 				+ "<http://example.com/s> <http://example.com/p> \"o\" .\n\n"
 				+ "_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 <http://example.com/p> \"literal\" )>> .\n",
 				stringWriter.toString());
@@ -175,9 +176,48 @@ public class TurtlePrettyWriterTest extends AbstractTurtleWriterTest {
 		Rio.write(model, stringWriter, RDFFormat.TURTLE,
 				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, true));
 
-		assertEquals("VERSION \"1.2\"\n\n"
+		assertEquals("@version \"1.2\" .\n\n"
 				+ "<http://example.com/s> <http://example.com/p> \"o\" .\n\n"
 				+ "_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt> \"literal\"@en--ltr .\n",
+				stringWriter.toString());
+	}
+
+	@Test
+	public void testRDFStyleDirectivesPrintedByDefault() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.TURTLE,
+				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, true));
+		assertEquals("@base <http://example.com/base/> .\n" +
+				"@prefix ex: <http://example.com/prefix/> .\n" +
+				"@version \"1.2\" .\n\n" +
+				"_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 </p> \"literal\" )>> .\n",
+				stringWriter.toString());
+	}
+
+	@Test
+	public void testSPARQLStyleDirectivesPrintedUponConfiguration() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		WriterConfig writerConfig = new WriterConfig();
+		writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
+		writerConfig.set(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES, true);
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.TURTLE, writerConfig);
+		assertEquals("BASE <http://example.com/base/>\n" +
+				"PREFIX ex: <http://example.com/prefix/>\n" +
+				"VERSION \"1.2\"\n\n" +
+				"_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 </p> \"literal\" )>> .\n",
 				stringWriter.toString());
 	}
 }

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URISyntaxException;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -833,7 +834,7 @@ public class TurtleWriterTest extends AbstractTurtleWriterTest {
 		Rio.write(model, stringWriter, RDFFormat.TURTLE,
 				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, false));
 
-		assertEquals("VERSION \"1.2\"\n"
+		assertEquals("@version \"1.2\" .\n"
 				+ "_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 <http://example.com/p> \"literal\" )>> .\n",
 				stringWriter.toString());
 	}
@@ -846,7 +847,7 @@ public class TurtleWriterTest extends AbstractTurtleWriterTest {
 		Rio.write(model, stringWriter, RDFFormat.TURTLE,
 				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, false));
 
-		assertEquals("VERSION \"1.2\"\n"
+		assertEquals("@version \"1.2\" .\n"
 				+ "_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt> \"literal\"@en--ltr .\n",
 				stringWriter.toString());
 	}
@@ -860,9 +861,48 @@ public class TurtleWriterTest extends AbstractTurtleWriterTest {
 		StringWriter stringWriter = new StringWriter();
 		Rio.write(model, stringWriter, RDFFormat.TURTLE,
 				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, false));
-		assertEquals("VERSION \"1.2\"\n"
+		assertEquals("@version \"1.2\" .\n"
 				+ "_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 <http://example.com/p> \"literal\" )>>;\n"
 				+ "<http://www.w3.org/1999/02/22-rdf-syntax-ns#Alt> \"literal\"@en--ltr .\n",
+				stringWriter.toString());
+	}
+
+	@Test
+	public void testRDFStyleDirectivesPrintedByDefault() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.TURTLE,
+				new WriterConfig().set(BasicWriterSettings.PRETTY_PRINT, false));
+		assertEquals("@base <http://example.com/base/> .\n" +
+				"@prefix ex: <http://example.com/prefix/> .\n" +
+				"@version \"1.2\" .\n" +
+				"_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 </p> \"literal\" )>> .\n",
+				stringWriter.toString());
+	}
+
+	@Test
+	public void testSPARQLStyleDirectivesPrintedUponConfiguration() throws URISyntaxException {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace("ex", "http://example.com/prefix/");
+		// Triple term in order to trigger version 1.2 print
+		model.add(vf.createBNode("b"), RDF.REIFIES, vf.createTripleTerm(vf.createBNode("b2"),
+				vf.createIRI("http://example.com/p"), vf.createLiteral("literal")));
+		StringWriter stringWriter = new StringWriter();
+
+		WriterConfig writerConfig = new WriterConfig();
+		writerConfig.set(BasicWriterSettings.PRETTY_PRINT, false);
+		writerConfig.set(TurtleWriterSettings.USE_SPARQL_STYLE_DIRECTIVES, true);
+
+		Rio.write(model, stringWriter, "http://example.com/base/", RDFFormat.TURTLE, writerConfig);
+		assertEquals("BASE <http://example.com/base/>\n" +
+				"PREFIX ex: <http://example.com/prefix/>\n" +
+				"VERSION \"1.2\"\n" +
+				"_:b <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> <<( _:b2 </p> \"literal\" )>> .\n",
 				stringWriter.toString());
 	}
 }


### PR DESCRIPTION
…ters


GitHub issue resolved: #5852

Briefly describe the changes proposed in this PR:

Added a Turtle writer setting to configure the directive style. 

Setting the USE_SPARQL_STYLE_DIRECTIVES corresponds to using: `VERSION, PREFIX, BASE` and no terminating dot '.'. By default the property is set to False and the corresponding style is: `@version, @prefix, @base` where the statement is terminated by a dot. 

The affected writers are Turtle, Trig and N3. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ v] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [v ] I've added tests for the changes I made
 - [v ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ v] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [v ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

