### PR TITLE
GH-5860: unit test for memory store SPARQL regression with BIND + fix

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/QueryJoinOptimizer.java
@@ -35,6 +35,8 @@ import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
@@ -546,7 +548,7 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 
 			List<TupleExpr> extensions = List.of();
 			for (TupleExpr expr : expressions) {
-				if (TupleExprs.containsExtension(expr)) {
+				if (joinArgContainsExtension(expr)) {
 					if (extensions.isEmpty()) {
 						extensions = List.of(expr);
 					} else {
@@ -558,6 +560,24 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 				}
 			}
 			return extensions;
+		}
+
+		/**
+		 * Returns true if the join arg contains an Extension (BIND clause) that contributes bindings to the current
+		 * join scope. Unlike {@link TupleExprs#containsExtension}, this also looks through Filter and Join wrappers
+		 * that a pre-pass filter optimizer may have introduced around Extension-containing subtrees.
+		 */
+		private static boolean joinArgContainsExtension(TupleExpr expr) {
+			if (expr instanceof Extension) {
+				return true;
+			}
+			if (expr instanceof Filter filter) {
+				return joinArgContainsExtension(filter.getArg());
+			}
+			if (expr instanceof Join join) {
+				return joinArgContainsExtension(join.getLeftArg()) || joinArgContainsExtension(join.getRightArg());
+			}
+			return false;
 		}
 
 		/**

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySparqlBindTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySparqlBindTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import java.io.StringReader;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MemorySparqlBindTest {
+
+	@Test
+	public void testBind() throws Exception {
+
+		String data = """
+								@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+				@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+				@prefix schema: <https://schema.org/> .
+				@prefix ex: <http://www.example.com/resource/> .
+
+
+				ex:CompanyA a schema:Organization ;
+				    schema:name "Company A" .
+
+				ex:Alice a schema:Person ;
+				    schema:name "Alice Smith";
+				    schema:memberOf ex:CompanyA ;
+				    schema:affiliation ex:CompanyA .
+
+				ex:Bob a schema:Person ;
+				    schema:name "Bob Jones";
+				    schema:memberOf ex:CompanyA ;
+				    schema:affiliation ex:CompanyA .
+
+
+				ex:Paper2 a schema:CreativeWork ;
+				    schema:name "A Benchmark Suite for Distributed Systems" ;
+				    schema:citation ex:Paper3, ex:Paper4 ;
+				    schema:author ex:Alice, ex:Carol, ex:Bob, ex:Dave ;
+				    schema:sourceOrganization ex:UniversityA, ex:CompanyA .
+
+				ex:Paper3 a schema:CreativeWork ;
+				    schema:name "Optimization Techniques for Distributed Systems" ;
+				    schema:citation ex:Paper5 .
+								""";
+
+		String testQuery = """
+				SELECT DISTINCT ?node0 ?prop1 ?node1 ?prop2 ?node2 ?prop3 ?node3
+				WHERE {
+				  BIND(<http://www.example.com/resource/Alice> as ?node0)
+				  BIND(<http://www.example.com/resource/Bob> as ?node3)
+
+
+				  { ?node0 ?prop1 ?node1 . FILTER(ISIRI(?node1))  }
+				  { ?node1 ?prop2 ?node2 } UNION { ?node2 ?prop2 ?node1 }
+				  { ?node2 ?prop3 ?node3 } UNION { ?node3 ?prop3 ?node2 }
+
+
+				  # avoid cycles
+				  FILTER(?node1 != ?node0)
+				  FILTER(?node2 != ?node0)
+				  FILTER(?node2 != ?node1)
+				  FILTER(?node3 != ?node0)
+				  FILTER(?node3 != ?node1)
+				  FILTER(?node3 != ?node2)
+				} LIMIT 100
+				                """;
+
+		Repository repository = new SailRepository(new MemoryStore());
+
+		try (var conn = repository.getConnection()) {
+
+			// load test data
+			try (var reader = new StringReader(data)) {
+				conn.add(reader, RDFFormat.TRIG);
+			}
+
+			// query
+			var tq = conn.prepareTupleQuery(testQuery);
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(Set.of(Values.iri("http://www.example.com/resource/Bob")),
+					res.stream().map(bs -> bs.getValue("node3")).collect(Collectors.toSet()));
+
+			// the expected result is two paths
+			Assertions.assertEquals(2, res.size());
+		}
+
+		repository.shutDown();
+	}
+
+}


### PR DESCRIPTION
The following minimized test data shows a regression in the RDF4J memory store (likely similarly in the NativeStore)

Fix is included in commit 2:

GH-5720 Fix QueryJoinOptimizer failing to detect BIND Extension

The FilterOptimizer pre-pass introduced in GH-5720 relocates filters
before QueryJoinOptimizer runs. For filters whose variables span both a
BIND-provided variable and a variable from another join arg, this
produces a join arg of the form Filter(cond, Join(Extension, ...)).

TupleExprs.containsExtension() stops traversal at Join boundaries, so
getExtensionTupleExprs() failed to recognise such a join arg as
Extension-carrying. With no priorityArgs, the BIND-bound variables were
unknown during join cost estimation, causing wrong join ordering: BIND
bindings ended up buried inside Union branches instead of being
evaluated outermost, leading to incorrect query results.

Fix by replacing the TupleExprs.containsExtension() call in
getExtensionTupleExprs() with a new joinArgContainsExtension() helper
that traverses through Filter and Join wrappers to locate an Extension,
stopping only at Union, LeftJoin, and other scope-changing nodes where
Extension bindings do not propagate freely.



GitHub issue resolved: #5860 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

