### PR TITLE
GH-5828: refine FedXConnection interface contract for exceptions

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -297,12 +297,19 @@ public class FedXConnection extends AbstractSailConnection {
 	protected CloseableIteration<? extends Statement> getStatementsInternal(Resource subj, IRI pred,
 			Value obj, boolean includeInferred, Resource... contexts) throws SailException {
 
-		Dataset dataset = new SimpleDataset();
-		FederationEvaluationStrategy strategy = federationContext.createStrategy(dataset);
-		QueryInfo queryInfo = new QueryInfo(subj, pred, obj, 0, includeInferred, federationContext, strategy,
-				dataset);
-		federationContext.getMonitoringService().monitorQuery(queryInfo);
-		return strategy.getStatements(queryInfo, subj, pred, obj, contexts);
+		try {
+			Dataset dataset = new SimpleDataset();
+			FederationEvaluationStrategy strategy = federationContext.createStrategy(dataset);
+			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, 0, includeInferred, federationContext, strategy,
+					dataset);
+			federationContext.getMonitoringService().monitorQuery(queryInfo);
+			return strategy.getStatements(queryInfo, subj, pred, obj, contexts);
+		} catch (Exception e) {
+			if (e instanceof SailException se) {
+				throw se;
+			}
+			throw new SailException(e);
+		}
 	}
 
 	@Override
@@ -316,9 +323,10 @@ public class FedXConnection extends AbstractSailConnection {
 			federationContext.getMonitoringService().monitorQuery(queryInfo);
 			return strategy.hasStatements(queryInfo, subj, pred, obj, contexts);
 
-		} catch (RuntimeException e) {
-			throw e;
 		} catch (Exception e) {
+			if (e instanceof SailException se) {
+				throw se;
+			}
 			if (e instanceof InterruptedException) {
 				Thread.currentThread().interrupt();
 			}
@@ -330,7 +338,10 @@ public class FedXConnection extends AbstractSailConnection {
 	protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
 		try {
 			getWriteStrategyInternal().addStatement(subj, pred, obj, contexts);
-		} catch (RepositoryException e) {
+		} catch (Exception e) {
+			if (e instanceof SailException se) {
+				throw se;
+			}
 			throw new SailException(e);
 		}
 	}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
@@ -86,19 +86,19 @@ public class WriteTest extends SPARQLBaseTest {
 
 		Assertions.assertEquals(false, fedxRule.getRepository().isWritable());
 
-		Assertions.assertThrows(UnsupportedOperationException.class, () -> {
-			Statement st = simpleStatement();
-			try (RepositoryConnection conn = fedxRule.getRepository().getConnection()) {
-				try {
-					conn.add(st);
-				} catch (RuntimeException e) {
-					// rollback to avoid a stack trace in the output
-					conn.rollback();
-					throw e;
-				}
-			}
-		});
+		Statement st = simpleStatement();
+		try (RepositoryConnection conn = fedxRule.getRepository().getConnection()) {
+			try {
+				conn.add(st);
+			} catch (RepositoryException e) {
+				// rollback to avoid a stack trace in the output
+				conn.rollback();
 
+				Assertions.assertTrue(e.getMessage()
+						.contains(
+								"java.lang.UnsupportedOperationException: Writing not supported to a federation: the federation is readonly."));
+			}
+		}
 	}
 
 	@Test


### PR DESCRIPTION
- make sure to throw exceptions as SailException (to be properly handled in upstream callers)


GitHub issue resolved: #5828 
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

