### PR TITLE
GH-5849: remove left-over mentioning of TriGStarWriterFactory

### DIFF
--- a/core/rio/trig/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
+++ b/core/rio/trig/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
@@ -1,2 +1,1 @@
 org.eclipse.rdf4j.rio.trig.TriGWriterFactory
-org.eclipse.rdf4j.rio.trigstar.TriGStarWriterFactory


### PR DESCRIPTION
GitHub issue resolved: #5849 


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

