### PR TITLE
GH-5865 Fix Statements conversion method names 

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
@@ -832,7 +832,7 @@ public class Models {
 	 */
 	@Experimental
 	public static void convertRDF12ReificationToRDF11(ValueFactory vf, Model model, Consumer<Statement> consumer) {
-		model.forEach(st -> Statements.convertRDF12ReificationToRDF11(vf, st, consumer));
+		model.forEach(st -> Statements.convertRDF12ToStandardReification(vf, st, consumer));
 	}
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
@@ -293,8 +293,8 @@ public class Statements {
 	 * @param consumer the {@link Consumer} function for the produced statements.
 	 */
 	@Experimental
-	public static void convertRDF12ReificationToRDF11(Statement st, Consumer<Statement> consumer) {
-		convertRDF12ReificationToRDF11(SimpleValueFactory.getInstance(), st, consumer);
+	public static void convertRDF12ToStandardReification(Statement st, Consumer<Statement> consumer) {
+		convertRDF12ToStandardReification(SimpleValueFactory.getInstance(), st, consumer);
 	}
 
 	/**
@@ -309,7 +309,7 @@ public class Statements {
 	 * @param consumer the {@link Consumer} function for the produced statements.
 	 */
 	@Experimental
-	public static void convertRDF12ReificationToRDF11(ValueFactory vf, Statement st, Consumer<Statement> consumer) {
+	public static void convertRDF12ToStandardReification(ValueFactory vf, Statement st, Consumer<Statement> consumer) {
 		Resource subject = st.getSubject();
 		IRI predicate = st.getPredicate();
 		Value object = st.getObject();

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
@@ -91,12 +91,12 @@ public class StatementsTest {
 		Model reifiedModel = ModelReificationTestHelper.createRDF11ReificationModel();
 
 		Model convertedModel1 = new LinkedHashModel();
-		rdfStarModel.forEach((s) -> Statements.convertRDF12ReificationToRDF11(s, convertedModel1::add));
+		rdfStarModel.forEach((s) -> Statements.convertRDF12ToStandardReification(s, convertedModel1::add));
 		assertTrue("RDF 1.2 conversion to reification with implicit VF",
 				Models.isomorphic(reifiedModel, convertedModel1));
 
 		Model convertedModel2 = new LinkedHashModel();
-		rdfStarModel.forEach((s) -> Statements.convertRDF12ReificationToRDF11(vf, s, convertedModel2::add));
+		rdfStarModel.forEach((s) -> Statements.convertRDF12ToStandardReification(vf, s, convertedModel2::add));
 		assertTrue("RDF 1.2 conversion to reification with explicit VF",
 				Models.isomorphic(reifiedModel, convertedModel2));
 	}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
@@ -250,7 +250,7 @@ public abstract class AbstractRDFWriter implements RDFWriter, Sink {
 	}
 
 	private void handleStatementConvertTripleTerms(Statement st) {
-		Statements.convertRDF12ReificationToRDF11(st, this::consumeStatement);
+		Statements.convertRDF12ToStandardReification(st, this::consumeStatement);
 	}
 
 	private void handleStatementEncodeTripleTerms(Statement st) {


### PR DESCRIPTION
GitHub issue resolved: #GH-5865

Briefly describe the changes proposed in this PR:

Statements conversion method names should be changed to convertRDF12ToStandardReification to reflect their current behaviour. Allows to provide other conversion mechanism according to the new spec, which will convert from RDF12 to RDF 12 using the new basic encoding algorithm. [RDF 1.2 interoperability](https://www.w3.org/TR/rdf12-interop/)

----
 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

