### PR TITLE
GH-5868 Disable LMDB sketches by default

### DIFF
--- a/core/sail/lmdb/pom.xml
+++ b/core/sail/lmdb/pom.xml
@@ -211,6 +211,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit-pioneer</groupId>
+			<artifactId>junit-pioneer</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-queryrender</artifactId>
 			<version>${project.version}</version>

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
@@ -71,8 +71,6 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 	 */
 	static final int VERSION = 2;
 
-	private static final long SKETCH_BASED_JOIN_ESTIMATOR_MIN_MAX_HEAP_BYTES = 2L * 1024 * 1024 * 1024;
-
 	/**
 	 * Specifies which triple indexes this lmdb store must use.
 	 */
@@ -478,7 +476,7 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 		return shouldUseSketchBasedJoinEstimator(Runtime.getRuntime().maxMemory());
 	}
 
-	boolean shouldUseSketchBasedJoinEstimator(long maxMemoryBytes) {
+	boolean shouldUseSketchBasedJoinEstimator(long ignoredMaxMemoryBytes) {
 		if (explicitEvalStratFactory != null) {
 			return false;
 		}
@@ -488,7 +486,7 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 			return sketchEstimatorEnabled;
 		}
 
-		return maxMemoryBytes >= SKETCH_BASED_JOIN_ESTIMATOR_MIN_MAX_HEAP_BYTES;
+		return false;
 	}
 
 	private boolean isSketchEstimatorReadyNonBlocking() {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbEvaluationStatisticsMemoizationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbEvaluationStatisticsMemoizationTest.java
@@ -404,7 +404,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void usesSketchEstimatorForLeftJoinCardinalityWhenReady() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-leftjoin").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -436,7 +436,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void usesSketchEstimatorForFilterWrappedStatementPatternsWhenReady() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-filter-wrapped-join").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -481,7 +481,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void usesSketchEstimatorForFilterCardinalityWhenReady() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-filter-cardinality").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -512,7 +512,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void optimizedPlanDumpShowsCurrentPlannerEstimatesForNodes() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-plan-estimate-dump").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -555,7 +555,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void optimizedPlanDumpAnnotatesCompleteTupleExprCosting() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-plan-complete-cost-dump").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -607,7 +607,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void leftJoinNodeReceivesCurrentRowsAndSubtreeWork() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-plan-leftjoin-cost").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -632,7 +632,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void unionNodeReceivesSummedRowsAndWork() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-plan-union-cost").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -658,7 +658,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void groupNodeUsesDistinctGroupEstimateOrSyntheticUpperBound() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-plan-group-cost").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -718,7 +718,9 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void samplesPatternLocalFilterPassRatioWhenLearnedStatsUnavailable() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-sampled-filter").toFile();
-		LmdbStoreConfig config = new LmdbStoreConfig().setOptimizerSamplingMaxMillis(100L);
+		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
+				.setOptimizerSamplingMaxMillis(100L);
 		SailRepository repository = new SailRepository(new LmdbStore(dataDir, config));
 		try {
 			loadData(repository);
@@ -749,7 +751,9 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void samplesZeroHitPatternLocalFilterPassRatioWhenLearnedStatsUnavailable() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-zero-sampled-filter").toFile();
-		LmdbStoreConfig config = new LmdbStoreConfig().setOptimizerSamplingMaxMillis(100L);
+		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
+				.setOptimizerSamplingMaxMillis(100L);
 		SailRepository repository = new SailRepository(new LmdbStore(dataDir, config));
 		try {
 			loadNameData(repository, 300);
@@ -783,7 +787,9 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void optimizerSamplingCanBeDisabledForUnlearnedFilters() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-sampling-disabled").toFile();
-		LmdbStoreConfig config = new LmdbStoreConfig().setOptimizerSamplingEnabled(false);
+		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
+				.setOptimizerSamplingEnabled(false);
 		SailRepository repository = new SailRepository(new LmdbStore(dataDir, config));
 		try {
 			loadData(repository);
@@ -810,6 +816,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	void optimizerVotesUnlearnedFilterForBackgroundSamplingWhenForegroundSamplingDisabled() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-background-vote").toFile();
 		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
 				.setOptimizerSamplingEnabled(false)
 				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 		SailRepository repository = new SailRepository(new LmdbStore(dataDir, config));
@@ -851,6 +858,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 			throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-medical-background-vote").toFile();
 		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
 				.setOptimizerSamplingEnabled(false)
 				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 		SailRepository repository = new SailRepository(new LmdbStore(dataDir, config));
@@ -940,6 +948,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	void backgroundRawSamplingDisabledPreventsQueueingAndSampling() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-background-disabled").toFile();
 		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
 				.setOptimizerSamplingEnabled(false)
 				.setBackgroundRawSamplingEnabled(false)
 				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
@@ -972,6 +981,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	void backgroundCycleSamplesQueuedFilterWhenForegroundSamplingDisabled() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-background-cycle").toFile();
 		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
 				.setOptimizerSamplingEnabled(false)
 				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 		SailRepository repository = new SailRepository(new LmdbStore(dataDir, config));
@@ -1010,6 +1020,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	void repeatedOptimizerNeedPromotesBackgroundSamplingRequestToFront() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-background-promotion").toFile();
 		LmdbStoreConfig config = new LmdbStoreConfig()
+				.setSketchEstimatorEnabled(true)
 				.setOptimizerSamplingEnabled(false)
 				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 		SailRepository repository = new SailRepository(new LmdbStore(dataDir, config));
@@ -1109,7 +1120,7 @@ class LmdbEvaluationStatisticsMemoizationTest {
 	@Test
 	void recordsLearnedFilterPassRatioForExternalBoundPatternLocalFilter() throws Exception {
 		File dataDir = Files.createTempDirectory("lmdb-eval-stats-learned-filter").toFile();
-		SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig()));
+		SailRepository repository = new SailRepository(new LmdbStore(dataDir, sketchEnabledConfig()));
 		try {
 			loadData(repository);
 
@@ -1179,6 +1190,10 @@ class LmdbEvaluationStatisticsMemoizationTest {
 					.explain(Explanation.Level.Optimized);
 			return explanation.toString();
 		}
+	}
+
+	private static LmdbStoreConfig sketchEnabledConfig() {
+		return new LmdbStoreConfig().setSketchEstimatorEnabled(true);
 	}
 
 	private static void rebuildSketchesAndAwaitLmdbOptimizer(LmdbStore sail, LmdbSailStore backingStore)

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbIndexAwareJoinOrderPlanningTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbIndexAwareJoinOrderPlanningTest.java
@@ -107,7 +107,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 
 	@Test
 	void optimizedElectricalGridQueryKeepsFeedsBeforeNameInGeneratorBranch(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -141,7 +141,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 
 	@Test
 	void optimizedPlanIncludesLmdbPlannedIndexMetrics(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -169,7 +169,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 
 	@Test
 	void unboundLocalFilterDoesNotReducePhysicalAccessWork(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -200,7 +200,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 	@Test
 	void plannerStartsElectricalQ2WithFilteredSubstationNameWhenOnlyPredicatePrefixIsAvailable(@TempDir File dataDir)
 			throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -233,7 +233,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 
 	@Test
 	void plannerAcceptsGeneralSegmentShapesAndReportsAdditiveWork(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc,posc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc,posc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -270,7 +270,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 
 	@Test
 	void optimizedSocialMediaQ4StartsWithUSideRestrictionBeforeFollowsProbe(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -321,7 +321,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 
 	@Test
 	void predicateOnlyAccessIsCostedAsPrefixScan(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -351,7 +351,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 
 	@Test
 	void directLookupChainFromFiniteUserTuplesDoesNotExpandEstimate(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -398,7 +398,7 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 	}
 
 	private static PlannedBranch planGeneratorBranch(File dataDir, String indexes) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig(indexes);
+		LmdbStoreConfig config = sketchEnabledConfig(indexes);
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -445,6 +445,10 @@ class LmdbIndexAwareJoinOrderPlanningTest {
 				.contains("costModel=lmdb"),
 				"Expected LMDB physical refinement diagnostics: "
 						+ attempt.getPlan().get().getSummaryStringMetrics());
+	}
+
+	private static LmdbStoreConfig sketchEnabledConfig(String indexes) {
+		return new LmdbStoreConfig(indexes).setSketchEstimatorEnabled(true);
 	}
 
 	private static void assertEstimatedWorkMatchesStepSum(JoinOrderPlanner.JoinOrderPlan plan) {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimizerPipelineTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimizerPipelineTest.java
@@ -91,7 +91,7 @@ class LmdbOptimizerPipelineTest {
 	@Test
 	void automaticLmdbStoreSwitchesToLmdbEvaluationStrategyFactoryAfterSketchesAreReady(@TempDir File dataDir)
 			throws Exception {
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			addSingleStatement(store, "urn:ready");
@@ -118,7 +118,7 @@ class LmdbOptimizerPipelineTest {
 
 	@Test
 	void longLivedConnectionsChooseCurrentAutomaticFactoryPerQueryCreation(@TempDir File dataDir) throws Exception {
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try (NotifyingSailConnection connection = store.getConnection()) {
 			EvaluationStrategyFactory factory = capturedEvaluationStrategyFactory(connection);
@@ -140,7 +140,7 @@ class LmdbOptimizerPipelineTest {
 	@Test
 	void automaticFactoryPreservesConfiguredPipelineAfterSketchesBecomeReady(@TempDir File dataDir) throws Exception {
 		QueryOptimizerPipeline customPipeline = List::of;
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.getEvaluationStrategyFactory().setOptimizerPipeline(customPipeline);
 		store.init();
 		try {
@@ -373,6 +373,10 @@ class LmdbOptimizerPipelineTest {
 				store.shutDown();
 			}
 		}
+	}
+
+	private static LmdbStoreConfig sketchEnabledConfig(String tripleIndexes) {
+		return new LmdbStoreConfig(tripleIndexes).setSketchEstimatorEnabled(true);
 	}
 
 	private static final class ProcessResult {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreCloseTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreCloseTest.java
@@ -35,7 +35,9 @@ class LmdbSailStoreCloseTest {
 
 	@Test
 	void closeDrainsRunningScheduledPersistBeforeClosingEstimator(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc").setBackgroundRawSamplingMaxMillisPerCycle(0L);
+		LmdbStoreConfig config = new LmdbStoreConfig("spoc")
+				.setSketchEstimatorEnabled(true)
+				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 		LmdbStore store = new LmdbStore(dataDir, config);
 		store.init();
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreEstimatorPersistenceTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreEstimatorPersistenceTest.java
@@ -98,7 +98,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 
 	@Test
 	void storeConfigIsPassedToSketchEstimator(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc");
 		invokeConfig(config, "setSketchEstimatorSubjectBucketCount", int.class, 64);
 		invokeConfig(config, "setSketchEstimatorPredicateBucketCount", int.class, 16);
 		invokeConfig(config, "setSketchEstimatorObjectBucketCount", int.class, 32);
@@ -127,7 +127,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:p");
 		var o = vf.createIRI("urn:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			try (NotifyingSailConnection conn = store.getConnection()) {
@@ -144,7 +144,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		assertTrue(estimatorStore(dataDir).isDirectory(), "Expected estimator directory after shutdown");
 		assertTrue(estimatorMetadata(dataDir).isFile(), "Expected estimator metadata after shutdown");
 
-		LmdbStore reopened = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore reopened = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		reopened.init();
 		try {
 			LmdbSailStore backingStore = reopened.getBackingStore();
@@ -172,7 +172,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:default-store:p");
 		var o = vf.createIRI("urn:default-store:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			SketchBasedJoinEstimator estimator = store.getBackingStore().getSketchBasedJoinEstimator();
@@ -198,7 +198,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 	void closeWritesFilterSelectivitySidecarAndReloadsItAfterRestart(@TempDir File dataDir) throws Exception {
 		Filter learnedFilter = firstFilter(LEARNED_FILTER_QUERY);
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		SailRepository repository = new SailRepository(store);
 		repository.init();
 		double learnedPassRatioBeforeShutdown;
@@ -218,7 +218,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		assertTrue(new File(dataDir, FILTER_SNAPSHOT_FILE).isFile(),
 				"Expected filter selectivity sidecar after LMDB shutdown");
 
-		LmdbStore reopened = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore reopened = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		reopened.init();
 		try {
 			assertTrue(reopened.awaitSketchesReady(10, TimeUnit.SECONDS));
@@ -234,7 +234,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 	void closeWritesSampledFilterSelectivitySidecarAndReloadsItAfterRestart(@TempDir File dataDir)
 			throws Exception {
 		Filter sampledFilter = firstFilter(SAMPLED_FILTER_QUERY);
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc")
+		LmdbStoreConfig config = sketchEnabledConfig("spoc")
 				.setOptimizerSamplingEnabled(false)
 				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 
@@ -262,7 +262,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		assertTrue(new File(dataDir, FILTER_SNAPSHOT_FILE).isFile(),
 				"Expected filter selectivity sidecar after LMDB shutdown");
 
-		LmdbStoreConfig reopenedConfig = new LmdbStoreConfig("spoc")
+		LmdbStoreConfig reopenedConfig = sketchEnabledConfig("spoc")
 				.setOptimizerSamplingEnabled(false)
 				.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 		LmdbStore reopened = new LmdbStore(dataDir, reopenedConfig);
@@ -284,7 +284,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 	void ignoresFilterSelectivitySidecarWhenEstimatorSnapshotRevisionChanges(@TempDir File dataDir) throws Exception {
 		Filter learnedFilter = firstFilter(LEARNED_FILTER_QUERY);
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		SailRepository repository = new SailRepository(store);
 		repository.init();
 		try {
@@ -298,7 +298,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		FileTime originalTimestamp = Files.getLastModifiedTime(metadata);
 		Files.setLastModifiedTime(metadata, FileTime.fromMillis(originalTimestamp.toMillis() + 5_000L));
 
-		LmdbStore reopened = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore reopened = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		reopened.init();
 		try {
 			EvaluationStatistics statistics = reopened.getBackingStore().getEvaluationStatistics();
@@ -316,7 +316,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:p");
 		var o = vf.createIRI("urn:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			LmdbSailStore backingStore = store.getBackingStore();
@@ -342,7 +342,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		assertFalse(new File(dataDir, SNAPSHOT_FILE + ".sketches").exists(),
 				"Directory store must not write legacy sketch sidecars");
 
-		LmdbStore reopened = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore reopened = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		reopened.init();
 		try {
 			SketchBasedJoinEstimator estimator = reopened.getBackingStore().getSketchBasedJoinEstimator();
@@ -364,7 +364,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var o2 = vf.createIRI("urn:restart:o2");
 		var c1 = vf.createIRI("urn:restart:c1");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			try (NotifyingSailConnection conn = store.getConnection()) {
@@ -380,7 +380,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 			store.shutDown();
 		}
 
-		LmdbStore reopened = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore reopened = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		reopened.init();
 		try {
 			SketchBasedJoinEstimator estimator = reopened.getBackingStore().getSketchBasedJoinEstimator();
@@ -420,7 +420,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var o2 = vf.createIRI("urn:cycle:o2");
 		var c1 = vf.createIRI("urn:cycle:c1");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		SailRepository repository = new SailRepository(store);
 
 		repository.init();
@@ -476,7 +476,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:rc:p");
 		var o = vf.createIRI("urn:rc:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			LmdbSailStore backingStore = store.getBackingStore();
@@ -508,7 +508,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 					vf.createIRI("urn:direct-estimator:o:" + i)));
 		}
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			LmdbSailStore backingStore = store.getBackingStore();
@@ -542,7 +542,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:p");
 		var o = vf.createIRI("urn:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			LmdbSailStore backingStore = store.getBackingStore();
@@ -573,7 +573,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:rollback:p");
 		var o = vf.createIRI("urn:rollback:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			LmdbSailStore backingStore = store.getBackingStore();
@@ -619,7 +619,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:read-committed-rollback:p");
 		var o = vf.createIRI("urn:read-committed-rollback:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			LmdbSailStore backingStore = store.getBackingStore();
@@ -681,7 +681,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		var p = vf.createIRI("urn:notready:p");
 		var o = vf.createIRI("urn:notready:o");
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		SailRepository repository = new SailRepository(store);
 		repository.init();
 		try {
@@ -734,7 +734,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 				() -> withEstimatorProperty("memoryMonitorEstimatedOperationBytes", "1",
 						() -> withEstimatorProperty("incrementalQueueEstimatedStatementBytes",
 								Long.toString(Long.MAX_VALUE / 2), () -> {
-									LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+									LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 									store.init();
 									try {
 										LmdbSailStore backingStore = store.getBackingStore();
@@ -781,7 +781,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 
 		writeLegacySnapshot(dataDir.toPath().resolve(SNAPSHOT_FILE));
 
-		LmdbStore store = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore store = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		store.init();
 		try {
 			try (NotifyingSailConnection conn = store.getConnection()) {
@@ -794,7 +794,7 @@ class LmdbSailStoreEstimatorPersistenceTest {
 			store.shutDown();
 		}
 
-		LmdbStore reopened = new LmdbStore(dataDir, new LmdbStoreConfig("spoc"));
+		LmdbStore reopened = new LmdbStore(dataDir, sketchEnabledConfig("spoc"));
 		reopened.init();
 		try {
 			try (NotifyingSailConnection conn = reopened.getConnection()) {
@@ -804,6 +804,10 @@ class LmdbSailStoreEstimatorPersistenceTest {
 		} finally {
 			reopened.shutDown();
 		}
+	}
+
+	private static LmdbStoreConfig sketchEnabledConfig(String tripleIndexes) {
+		return new LmdbStoreConfig(tripleIndexes).setSketchEstimatorEnabled(true);
 	}
 
 	private static Object invokeConfig(LmdbStoreConfig config, String methodName, Class<?> parameterType, Object value)

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreTest.java
@@ -415,7 +415,7 @@ public class LmdbSailStoreTest {
 
 	@Test
 	void approveAllBulkFailureDiscardsNonIsolatedEstimatorUpdates() throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,posc");
+		LmdbStoreConfig config = new LmdbStoreConfig("spoc,posc").setSketchEstimatorEnabled(true);
 		setBulkOperationSize(config, 2);
 		LmdbStore sail = new LmdbStore(new File(dataDir, "bulk-failure-estimator"), config);
 		sail.init();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSketchAwareFilterPlacementIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSketchAwareFilterPlacementIT.java
@@ -16,6 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.nio.file.Files;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -61,8 +65,9 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.repository.util.RDFInserter;
 import org.eclipse.rdf4j.sail.lmdb.benchmark.BenchmarkJoinEstimatorSupport;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.RetryingTest;
 
 class LmdbSketchAwareFilterPlacementIT {
 
@@ -88,14 +93,23 @@ class LmdbSketchAwareFilterPlacementIT {
 	private static final String GRID_TRANSFORMER_TYPE_LABEL = "transformer-type";
 	private static final int CRITERIA_RETRY_ATTEMPTS = 10;
 	private static final int TEST_RERUN_ATTEMPTS = 10;
-	private static final long RETRY_PAUSE_MILLIS = TimeUnit.SECONDS.toMillis(1L);
+	private static final int FULL_ATTEMPTS_PER_INVOCATION = 1;
+	private static final int TEST_RERUN_TIMEOUT_MINUTES = 3;
+	private static final int RETRY_PAUSE_MILLIS = 1_000;
 
-	@Test
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@RetryingTest(maxAttempts = TEST_RERUN_ATTEMPTS, suspendForMs = RETRY_PAUSE_MILLIS)
+	@Timeout(value = TEST_RERUN_TIMEOUT_MINUTES, unit = TimeUnit.MINUTES)
+	private @interface RetriedWithinTimeout {
+	}
+
+	@RetriedWithinTimeout
 	void optimizedQueryPushesBranchNameFilterOntoLocalPatternWhenSketchesReady(@TempDir File dataDir)
 			throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"optimizedQueryPushesBranchNameFilterOntoLocalPatternWhenSketchesReady", attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -148,11 +162,11 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void filterCardinalityUsesLocalFilterSelectivityWithoutSketchesReady(@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"filterCardinalityUsesLocalFilterSelectivityWithoutSketchesReady", attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -189,11 +203,11 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void learnedTemplateStatsApplyWhenExactFilterKeyMisses(@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir, "learnedTemplateStatsApplyWhenExactFilterKeyMisses",
 				attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -228,10 +242,10 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void bindingWindowFilterKeepsIncomingValuesBindings(@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir, "bindingWindowFilterKeepsIncomingValuesBindings", attemptDir -> {
-			LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+			LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 			SailRepository repository = new SailRepository(store);
 			repository.init();
 
@@ -260,11 +274,11 @@ class LmdbSketchAwareFilterPlacementIT {
 		});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void prefixConditionedLocalFilterFeedbackDoesNotPoisonUnconditionalStats(@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"prefixConditionedLocalFilterFeedbackDoesNotPoisonUnconditionalStats", attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -302,11 +316,11 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void nonLocalEqualityFilterReceivesHeuristicPassRatio(@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir, "nonLocalEqualityFilterReceivesHeuristicPassRatio",
 				attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -336,11 +350,11 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void socialMediaQ3KeepsPairwiseInequalityOnBindingAssignmentWindow(@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"socialMediaQ3KeepsPairwiseInequalityOnBindingAssignmentWindow", attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -366,10 +380,10 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void deferredFilterUnlockAddsWorkAndShrinksRows(@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir, "deferredFilterUnlockAddsWorkAndShrinksRows", attemptDir -> {
-			LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+			LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 			SailRepository repository = new SailRepository(store);
 			repository.init();
 
@@ -419,13 +433,13 @@ class LmdbSketchAwareFilterPlacementIT {
 		});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void optimizedMedicalRecordsQ2MovesRecordedOnFilterBeforeOtherMandatoryPatternsWithoutSketchesReady(
 			@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"optimizedMedicalRecordsQ2MovesRecordedOnFilterBeforeOtherMandatoryPatternsWithoutSketchesReady",
 				attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -473,13 +487,13 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void optimizedMedicalRecordsQ2MovesRecordedOnFilterBeforeOtherMandatoryPatternsInThemeDataset(
 			@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"optimizedMedicalRecordsQ2MovesRecordedOnFilterBeforeOtherMandatoryPatternsInThemeDataset",
 				attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -508,13 +522,14 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void backgroundRawSamplingMovesMedicalRecordedOnFilterBeforeOtherMandatoryPatternsWhenForegroundSamplingDisabled(
 			@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"backgroundRawSamplingMovesMedicalRecordedOnFilterBeforeOtherMandatoryPatternsWhenForegroundSamplingDisabled",
 				attemptDir -> {
 					LmdbStoreConfig config = new LmdbStoreConfig()
+							.setSketchEstimatorEnabled(true)
 							.setOptimizerSamplingEnabled(false)
 							.setBackgroundRawSamplingMaxMillisPerCycle(0L);
 					LmdbStore store = new LmdbStore(attemptDir, config);
@@ -564,13 +579,17 @@ class LmdbSketchAwareFilterPlacementIT {
 		});
 	}
 
-	@Test
+	private static LmdbStoreConfig sketchEnabledConfig() {
+		return new LmdbStoreConfig().setSketchEstimatorEnabled(true);
+	}
+
+	@RetriedWithinTimeout
 	void optimizedElectricalGridQ2MovesSubstationNameFilterBeforeTransformerScanInThemeDataset(
 			@TempDir File dataDir) throws Exception {
 		assertTestPassesWithinAttempts(dataDir,
 				"optimizedElectricalGridQ2MovesSubstationNameFilterBeforeTransformerScanInThemeDataset",
 				attemptDir -> {
-					LmdbStore store = new LmdbStore(attemptDir, new LmdbStoreConfig());
+					LmdbStore store = new LmdbStore(attemptDir, sketchEnabledConfig());
 					SailRepository repository = new SailRepository(store);
 					repository.init();
 
@@ -602,7 +621,7 @@ class LmdbSketchAwareFilterPlacementIT {
 				});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void deferredFilterPlacementPreservesAcceptedFactorOrder() throws Exception {
 		assertTestPassesWithinAttempts("deferredFilterPlacementPreservesAcceptedFactorOrder", () -> {
 			StatementPattern forward = new StatementPattern(Var.of("anchor"),
@@ -621,7 +640,7 @@ class LmdbSketchAwareFilterPlacementIT {
 		});
 	}
 
-	@Test
+	@RetriedWithinTimeout
 	void deferredFiniteBindingWindowKeepsModeSensitiveDurationFilter() throws Exception {
 		assertTestPassesWithinAttempts("deferredFiniteBindingWindowKeepsModeSensitiveDurationFilter", () -> {
 			BindingSetAssignment left = bindingAssignment("left", VF.createLiteral("P1D", XSD.DAYTIMEDURATION));
@@ -650,7 +669,7 @@ class LmdbSketchAwareFilterPlacementIT {
 	private static void assertTestPassesWithinAttempts(File dataDir, String testName, TestAttempt testAttempt)
 			throws Exception {
 		Throwable lastFailure = null;
-		for (int attempt = 1; attempt <= TEST_RERUN_ATTEMPTS; attempt++) {
+		for (int attempt = 1; attempt <= FULL_ATTEMPTS_PER_INVOCATION; attempt++) {
 			File attemptDir = new File(dataDir, "attempt-" + attempt);
 			Files.createDirectories(attemptDir.toPath());
 			try {
@@ -665,13 +684,13 @@ class LmdbSketchAwareFilterPlacementIT {
 				lastFailure = e;
 			}
 		}
-		failAfterRetries("Test \"" + testName + "\" did not pass within " + TEST_RERUN_ATTEMPTS
+		failAfterRetries("Test \"" + testName + "\" did not pass within " + FULL_ATTEMPTS_PER_INVOCATION
 				+ " full attempts", lastFailure);
 	}
 
 	private static void assertTestPassesWithinAttempts(String testName, TestBody testBody) throws Exception {
 		Throwable lastFailure = null;
-		for (int attempt = 1; attempt <= TEST_RERUN_ATTEMPTS; attempt++) {
+		for (int attempt = 1; attempt <= FULL_ATTEMPTS_PER_INVOCATION; attempt++) {
 			try {
 				testBody.run();
 				return;
@@ -684,7 +703,7 @@ class LmdbSketchAwareFilterPlacementIT {
 				lastFailure = e;
 			}
 		}
-		failAfterRetries("Test \"" + testName + "\" did not pass within " + TEST_RERUN_ATTEMPTS
+		failAfterRetries("Test \"" + testName + "\" did not pass within " + FULL_ATTEMPTS_PER_INVOCATION
 				+ " full attempts", lastFailure);
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreSketchEstimatorConfigTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreSketchEstimatorConfigTest.java
@@ -72,11 +72,11 @@ class LmdbStoreSketchEstimatorConfigTest {
 	}
 
 	@Test
-	void unsetSketchEstimatorEnabledKeepsHeapThreshold() {
+	void unsetSketchEstimatorEnabledDefaultsToDisabled() {
 		LmdbStore store = new LmdbStore(new LmdbStoreConfig());
 
 		assertThat(store.shouldUseSketchBasedJoinEstimator(SKETCH_ESTIMATOR_MIN_HEAP_BYTES - 1)).isFalse();
-		assertThat(store.shouldUseSketchBasedJoinEstimator(SKETCH_ESTIMATOR_MIN_HEAP_BYTES)).isTrue();
+		assertThat(store.shouldUseSketchBasedJoinEstimator(SKETCH_ESTIMATOR_MIN_HEAP_BYTES)).isFalse();
 	}
 
 	@Test
@@ -95,7 +95,7 @@ class LmdbStoreSketchEstimatorConfigTest {
 
 	@Test
 	void sketchEstimatorThrottleConfigIsAppliedToBackingEstimator(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig();
+		LmdbStoreConfig config = new LmdbStoreConfig().setSketchEstimatorEnabled(true);
 		invokeLongSetter(config, "setSketchEstimatorThrottleEveryN", 7L);
 		invokeLongSetter(config, "setSketchEstimatorThrottleMillis", 11L);
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/SketchEstimatorThemeJoinAccuracyIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/SketchEstimatorThemeJoinAccuracyIT.java
@@ -71,7 +71,7 @@ class SketchEstimatorThemeJoinAccuracyIT {
 
 	@Test
 	void estimatorMatchesManualJoinAcrossAllThemes(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -144,7 +144,7 @@ class SketchEstimatorThemeJoinAccuracyIT {
 
 	@Test
 	void plannerPrefersSelectiveChainEndForPathologicalLmdbJoin(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LmdbStore store = new LmdbStore(dataDir, config);
 		SailRepository repository = new SailRepository(store);
 		repository.init();
@@ -197,7 +197,7 @@ class SketchEstimatorThemeJoinAccuracyIT {
 
 	@Test
 	void estimatorDoesNotZeroLibraryLocatedAtNameJoinAfterReload(@TempDir File dataDir) throws Exception {
-		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		LmdbStoreConfig config = sketchEnabledConfig("spoc,ospc,psoc");
 		LibraryJoinLoadResult loadResult = loadLibraryThemeIntoDefaultContext(dataDir, config);
 		assertTrue(loadResult.persisted(),
 				"Expected explicit persist after library-theme load to produce a reloadable snapshot");
@@ -303,6 +303,10 @@ class SketchEstimatorThemeJoinAccuracyIT {
 		System.out.println("Direct counts leftStatements=" + leftStatements + ", leftDistinctSubjects="
 				+ leftSubjects.size() + ", rightStatements=" + rightStatements + ", rightDistinctSubjects="
 				+ rightSubjects.size());
+	}
+
+	private static LmdbStoreConfig sketchEnabledConfig(String indexes) {
+		return new LmdbStoreConfig(indexes).setSketchEstimatorEnabled(true);
 	}
 
 	private static double estimateScenarioJoin(SketchBasedJoinEstimator estimator, JoinScenario scenario) {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/BenchmarkJoinEstimatorSupportLowHeapTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/BenchmarkJoinEstimatorSupportLowHeapTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 class BenchmarkJoinEstimatorSupportLowHeapTest {
 
 	@Test
-	void lowHeapAwaitEstimatorReadySkipsMissingHeapGatedEstimator(@TempDir File dataDir) throws Exception {
+	void awaitEstimatorReadySkipsDisabledEstimator(@TempDir File dataDir) throws Exception {
 		ProcessResult result = runLowHeapProbe(dataDir);
 
 		assertEquals(0, result.exitCode, result.output);
@@ -66,7 +66,7 @@ class BenchmarkJoinEstimatorSupportLowHeapTest {
 
 		public static void main(String[] args) throws Exception {
 			File dataDir = new File(args[0]);
-			LmdbStore store = new LmdbStore(dataDir, ConfigUtil.createConfig());
+			LmdbStore store = new LmdbStore(dataDir, ConfigUtil.createConfig().setSketchEstimatorEnabled(false));
 			SailRepository repository = new SailRepository(store);
 			repository.init();
 			try {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ConfigUtil.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ConfigUtil.java
@@ -34,6 +34,7 @@ final class ConfigUtil {
 
 	private static LmdbStoreConfig createConfig(String tripleIndexes) {
 		LmdbStoreConfig config = new LmdbStoreConfig(tripleIndexes);
+		config.setSketchEstimatorEnabled(true);
 		config.setForceSync(false);
 		config.setValueDBSize(1_073_741_824L); // 1 GiB
 		config.setTripleDBSize(config.getValueDBSize());

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 		<guava.version>32.1.3-jre</guava.version>
 		<jmhVersion>1.37</jmhVersion>
 		<junit.version>6.0.2</junit.version>
+		<junit-pioneer.version>2.3.0</junit-pioneer.version>
 		<mockito.version>5.21.0</mockito.version>
 		<mockserver.version>5.15.0</mockserver.version>
 		<assertj.version>3.27.7</assertj.version>
@@ -756,6 +757,25 @@
 				<version>${junit.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit-pioneer</groupId>
+				<artifactId>junit-pioneer</artifactId>
+				<version>${junit-pioneer.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-params</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.junit.platform</groupId>
+						<artifactId>junit-platform-launcher</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>

--- a/site/content/documentation/programming/lmdb-store.md
+++ b/site/content/documentation/programming/lmdb-store.md
@@ -109,19 +109,31 @@ config.setForceSync(true);
 config.setAutoGrow(false);
 // persist value hash codes across restarts, disabled by default
 config.setValueHashCacheEnabled(true);
+// enable sketch-based join estimation, disabled by default
+config.setSketchEstimatorEnabled(true);
 // set maximum size of value db to 1 GiB
 
 config.setValueDBSize(1_073_741_824L);
 // set maximum size of triple db to 1 GiB
 config.setTripleDBSize(1_073_741_824L);
 
-Repository repo = new SailRepository(new LmdbStore(dataDir), config);
+Repository repo = new SailRepository(new LmdbStore(dataDir, config));
 ```
 
 The optional value hash cache stores precomputed `Value.hashCode()` results in `hashes.dat`. It is disabled by default.
 When enabled, LMDB writes a `hashes.dat.integrity` sidecar on clean shutdown and only trusts the cache again on the
 next startup if that integrity metadata validates. Invalid or stale hash cache files are discarded automatically and
 the store falls back to recomputing hashes lazily.
+
+Sketch-based join estimation is disabled by default. To enable it, set
+`LmdbStoreConfig.setSketchEstimatorEnabled(true)` when creating the store. Repository configuration files can enable it
+with `http://rdf4j.org/config/sail/lmdb#sketchEstimatorEnabled` set to `true`.
+
+```turtle
+@prefix lmdb: <http://rdf4j.org/config/sail/lmdb#> .
+
+[] lmdb:sketchEstimatorEnabled true .
+```
 
 ## Required storage space, RAM size and disk performance
 You can expect a footprint of around 120 - 130 bytes per quad when using the LMDB store


### PR DESCRIPTION
## Summary

- Disable the LMDB sketch-based join estimator unless sketchEstimatorEnabled is explicitly set.
- Update LMDB documentation with Java and repository-config opt-in examples.
- Make sketch-dependent LMDB tests and benchmarks opt in explicitly, and add JUnit Pioneer retry support for the brittle filter-placement IT.

## Test Plan

- mvn -o -Dmaven.repo.local=.m2_repo -pl core/sail/lmdb -Dtest=LmdbStoreSketchEstimatorConfigTest#unsetSketchEstimatorEnabledDefaultsToDisabled -DskipITs verify
- mvn -o -Dmaven.repo.local=.m2_repo -pl core/sail/lmdb -Dtest=NoSuchTest -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=LmdbSketchAwareFilterPlacementIT verify
- mvn -o -Dmaven.repo.local=.m2_repo -pl core/sail/lmdb -Dtest=NoSuchTest -Dsurefire.failIfNoSpecifiedTests=false -Dit.test=SketchEstimatorThemeJoinAccuracyIT verify
- mvn -o -Dmaven.repo.local=.m2_repo -pl core/sail/lmdb -DskipITs verify
- mvn -o -Dmaven.repo.local=.m2_repo -T 2C process-resources
- git diff --check

Fixes #5868