### PR TITLE
GH-5870: add basic RDF 1.2 support to FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -537,9 +537,9 @@ public class FedXConfig {
 	}
 
 	/**
-	 * Whether the support for RDF 1.2 triple term evaluation is enabled not
+	 * Whether the support for RDF 1.2 triple term evaluation is enabled or not
 	 *
-	 * @return
+	 * @return whether triple ref support is enabled
 	 */
 	public boolean isEnableTripleRefSupport() {
 		return this.enableTripleRefSupport;
@@ -551,7 +551,7 @@ public class FedXConfig {
 	 *
 	 * @param flag to enable RDF 1.2 triple term support.
 	 * @return the current config
-	 * @see #getEn
+	 * @see #isEnableTripleRefSupport()
 	 */
 	public FedXConfig withEnableTripleRefSupport(boolean flag) {
 		this.enableTripleRefSupport = flag;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -60,6 +60,11 @@ public class FedXConfig {
 
 	private boolean enableGroupedSourceSelection = true;
 
+	/**
+	 * Enable support for RDF 1.2 triple term queries
+	 */
+	private boolean enableTripleRefSupport = false;
+
 	private String sourceSelectionCacheSpec = null;
 
 	private SourceSelectionCacheFactory sourceSelectionCacheFactory = null;
@@ -530,4 +535,27 @@ public class FedXConfig {
 		this.enableGroupedSourceSelection = flag;
 		return this;
 	}
+
+	/**
+	 * Whether the support for RDF 1.2 triple term evaluation is enabled not
+	 *
+	 * @return
+	 */
+	public boolean isEnableTripleRefSupport() {
+		return this.enableTripleRefSupport;
+	}
+
+	/**
+	 * Enable or disable the support for RDF 1.2 triple term evaluation
+	 *
+	 *
+	 * @param flag to enable RDF 1.2 triple term support.
+	 * @return the current config
+	 * @see #getEn
+	 */
+	public FedXConfig withEnableTripleRefSupport(boolean flag) {
+		this.enableTripleRefSupport = flag;
+		return this;
+	}
+
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
@@ -78,6 +78,10 @@ public abstract class FedXStatementPattern extends StatementPattern
 		}
 	}
 
+	public void addStatementSource(StatementSource statementSource) {
+		statementSources.add(statementSource);
+	}
+
 	@Override
 	public <X extends Exception> void visit(QueryModelVisitor<X> visitor)
 			throws X {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
@@ -50,10 +50,6 @@ public class StatementSourcePattern extends FedXStatementPattern {
 		this.federationContext = queryInfo.getFederationContext();
 	}
 
-	public void addStatementSource(StatementSource statementSource) {
-		statementSources.add(statementSource);
-	}
-
 	@Override
 	public CloseableIteration<BindingSet> evaluate(BindingSet bindings)
 			throws QueryEvaluationException {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefJoinGroup.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefJoinGroup.java
@@ -1,0 +1,110 @@
+package org.eclipse.rdf4j.federated.algebra;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
+import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.QueryModelVisitor;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+
+/**
+ * A join group around a {@link TripleRefStatementPattern}: besides the {@link TripleRefStatementPattern} it contains
+ * the list of {@link StatementPattern} sharing the same subject (typically a blank node).
+ *
+ * {@link TripleRefJoinGroup} are exclusive to a single {@link StatementSource}.
+ */
+public class TripleRefJoinGroup extends AbstractQueryModelNode implements FedXTupleExpr {
+
+	private static final long serialVersionUID = 3505148693453950138L;
+
+	private final TripleRefStatementPattern tripleRef;
+	private final List<StatementPattern> stmts;
+	private final StatementSource statementSource;
+	private final QueryInfo queryInfo;
+
+	private Set<String> assuredBindingNames;
+	private List<String> freeVars;
+
+	public TripleRefJoinGroup(TripleRefStatementPattern tripleRef, List<StatementPattern> stmts,
+			StatementSource statementSource, QueryInfo queryInfo) {
+		super();
+		this.tripleRef = tripleRef;
+		this.stmts = stmts;
+		this.statementSource = statementSource;
+		this.queryInfo = queryInfo;
+	}
+
+	@Override
+	public Set<String> getBindingNames() {
+		return getAssuredBindingNames();
+	}
+
+	@Override
+	public Set<String> getAssuredBindingNames() {
+		if (assuredBindingNames == null) {
+			assuredBindingNames = new HashSet<>();
+			assuredBindingNames.addAll(tripleRef.getAssuredBindingNames());
+			stmts.forEach(st -> assuredBindingNames.addAll(st.getAssuredBindingNames()));
+		}
+		return assuredBindingNames;
+	}
+
+	public StatementSource getSource() {
+		return statementSource;
+	}
+
+	@Override
+	public <X extends Exception> void visit(QueryModelVisitor<X> visitor) throws X {
+		visitor.meetOther(this);
+	}
+
+	@Override
+	public <X extends Exception> void visitChildren(QueryModelVisitor<X> visitor) throws X {
+
+		statementSource.visit(visitor);
+
+		tripleRef.visit(visitor);
+
+		for (var stmt : stmts) {
+			stmt.visit(visitor);
+		}
+	}
+
+	@Override
+	public void replaceChildNode(QueryModelNode current, QueryModelNode replacement) {
+		throw new UnsupportedOperationException();
+
+	}
+
+	@Override
+	public List<String> getFreeVars() {
+		if (freeVars == null) {
+			Set<String> freeVarsSet = new HashSet<>();
+			freeVarsSet.addAll(tripleRef.getFreeVars());
+			for (var st : stmts) {
+				if (st instanceof VariableExpr e) {
+					freeVarsSet.addAll(e.getFreeVars());
+				} else {
+					freeVarsSet.addAll(QueryAlgebraUtil.getFreeVars(st));
+				}
+			}
+			freeVars = new ArrayList<String>(freeVarsSet);
+		}
+		return freeVars;
+	}
+
+	@Override
+	public QueryInfo getQueryInfo() {
+		return queryInfo;
+	}
+
+	@Override
+	public TripleRefJoinGroup clone() {
+		return (TripleRefJoinGroup) super.clone();
+	}
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefJoinGroup.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefJoinGroup.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
 package org.eclipse.rdf4j.federated.algebra;
 
 import java.util.ArrayList;
@@ -16,7 +26,8 @@ import org.eclipse.rdf4j.query.algebra.StatementPattern;
  * A join group around a {@link TripleRefStatementPattern}: besides the {@link TripleRefStatementPattern} it contains
  * the list of {@link StatementPattern} sharing the same subject (typically a blank node).
  *
- * {@link TripleRefJoinGroup} are exclusive to a single {@link StatementSource}.
+ * {@link TripleRefJoinGroup} can be associated to multiple {@link StatementSource}s, where on each it gets executed in
+ * a single expression.
  */
 public class TripleRefJoinGroup extends AbstractQueryModelNode implements FedXTupleExpr {
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefJoinGroup.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefJoinGroup.java
@@ -24,18 +24,18 @@ public class TripleRefJoinGroup extends AbstractQueryModelNode implements FedXTu
 
 	private final TripleRefStatementPattern tripleRef;
 	private final List<StatementPattern> stmts;
-	private final StatementSource statementSource;
+	private final List<StatementSource> statementSources;
 	private final QueryInfo queryInfo;
 
 	private Set<String> assuredBindingNames;
 	private List<String> freeVars;
 
 	public TripleRefJoinGroup(TripleRefStatementPattern tripleRef, List<StatementPattern> stmts,
-			StatementSource statementSource, QueryInfo queryInfo) {
+			List<StatementSource> statementSources, QueryInfo queryInfo) {
 		super();
 		this.tripleRef = tripleRef;
 		this.stmts = stmts;
-		this.statementSource = statementSource;
+		this.statementSources = statementSources;
 		this.queryInfo = queryInfo;
 	}
 
@@ -54,8 +54,16 @@ public class TripleRefJoinGroup extends AbstractQueryModelNode implements FedXTu
 		return assuredBindingNames;
 	}
 
-	public StatementSource getSource() {
-		return statementSource;
+	public List<StatementSource> getStatementSources() {
+		return statementSources;
+	}
+
+	public TripleRefStatementPattern getTripleRefStatementPattern() {
+		return this.tripleRef;
+	}
+
+	public List<StatementPattern> getStatementPatterns() {
+		return this.stmts;
 	}
 
 	@Override
@@ -66,7 +74,9 @@ public class TripleRefJoinGroup extends AbstractQueryModelNode implements FedXTu
 	@Override
 	public <X extends Exception> void visitChildren(QueryModelVisitor<X> visitor) throws X {
 
-		statementSource.visit(visitor);
+		for (var source : statementSources) {
+			source.visit(visitor);
+		}
 
 		tripleRef.visit(visitor);
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
@@ -10,28 +10,47 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.algebra;
 
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.federated.endpoint.Endpoint;
+import org.eclipse.rdf4j.federated.evaluation.TripleSource;
+import org.eclipse.rdf4j.federated.evaluation.iterator.InsertBindingsIteration;
+import org.eclipse.rdf4j.federated.evaluation.iterator.SingleBindingSetIteration;
+import org.eclipse.rdf4j.federated.evaluation.union.ParallelPreparedUnionTask;
+import org.eclipse.rdf4j.federated.evaluation.union.ParallelUnionTask;
+import org.eclipse.rdf4j.federated.evaluation.union.WorkerUnionBase;
+import org.eclipse.rdf4j.federated.exception.IllegalQueryException;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.QueryModelVisitor;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TripleRef;
+import org.eclipse.rdf4j.repository.RepositoryException;
 
 /**
  * A {@link FedXStatementPattern} representing a {@link StatementPattern} together with a {@link TripleRef}, i.e. a
- * SPARQL / RDF 1.2 expression.
+ * SPARQL / RDF 1.2 triple term expression.
  */
 public class TripleRefStatementPattern extends FedXStatementPattern {
 
 	private static final long serialVersionUID = 841877125206379474L;
 	protected final TripleRef tripleRef;
+	protected final FederationContext federationContext;
+
+	private Set<String> assuredBindingNames;
 
 	public TripleRefStatementPattern(StatementPattern node, TripleRef tripleRef, QueryInfo queryInfo) {
 		super(node, queryInfo);
 		this.tripleRef = tripleRef;
+		this.federationContext = queryInfo.getFederationContext();
 		refineFreeVars();
 	}
 
@@ -58,14 +77,45 @@ public class TripleRefStatementPattern extends FedXStatementPattern {
 			freeVars.add(tripleRef.getPredicateVar().getName());
 		}
 
-		// triple ref predicate
+		// triple ref object
 		if (tripleRef.getObjectVar().getValue() == null) {
 			freeVars.add(tripleRef.getObjectVar().getName());
 		}
 	}
 
-	public List<StatementSource> getStatementSources() {
-		return statementSources;
+	@Override
+	public Set<String> getAssuredBindingNames() {
+		Set<String> assuredBindingNames = this.assuredBindingNames;
+		if (assuredBindingNames == null) {
+			// take assured binding names as defined for StatementPattern
+			assuredBindingNames = new HashSet<>();
+
+			if (!getSubjectVar().hasValue()) {
+				assuredBindingNames.add(getSubjectVar().getName());
+			}
+			if (!getPredicateVar().hasValue()) {
+				assuredBindingNames.add(getPredicateVar().getName());
+			}
+			if (getContextVar() != null && !getContextVar().hasValue()) {
+				assuredBindingNames.add(getContextVar().getName());
+			}
+
+			// Note: ; the statement's object var is an internal join id
+
+			// include triple term component variables
+			if (!tripleRef.getSubjectVar().hasValue()) {
+				assuredBindingNames.add(tripleRef.getSubjectVar().getName());
+			}
+			if (!tripleRef.getPredicateVar().hasValue()) {
+				assuredBindingNames.add(tripleRef.getPredicateVar().getName());
+			}
+			if (!tripleRef.getObjectVar().hasValue()) {
+				assuredBindingNames.add(tripleRef.getObjectVar().getName());
+			}
+
+			this.assuredBindingNames = assuredBindingNames;
+		}
+		return assuredBindingNames;
 	}
 
 	public TripleRef getTripleRef() {
@@ -82,8 +132,87 @@ public class TripleRefStatementPattern extends FedXStatementPattern {
 
 	@Override
 	public CloseableIteration<BindingSet> evaluate(BindingSet bindings) throws QueryEvaluationException {
-		// TODO Auto-generated method stub
-		return null;
+
+		WorkerUnionBase<BindingSet> union = null;
+		try {
+
+			AtomicBoolean isEvaluated = new AtomicBoolean(false); // is filter evaluated in prepared query
+			String preparedQuery = null; // used for some triple sources
+			union = federationContext.getManager().createWorkerUnion(queryInfo);
+
+			for (StatementSource source : statementSources) {
+
+				Endpoint ownedEndpoint = queryInfo.getFederationContext()
+						.getEndpointManager()
+						.getEndpoint(source.getEndpointID());
+				TripleSource t = ownedEndpoint.getTripleSource();
+
+				if (t.usePreparedQuery(this, queryInfo)) {
+
+					// queryString needs to be constructed only once for a given bindingset
+					if (preparedQuery == null) {
+						try {
+							preparedQuery = QueryStringUtil.selectQueryString(this, bindings, filterExpr, isEvaluated,
+									queryInfo.getDataset());
+						} catch (IllegalQueryException e1) {
+							/* all vars are bound, this must be handled as a check query, can occur in joins */
+							CloseableIteration<BindingSet> res = handleStatementSourcePatternCheck(
+									bindings);
+							if (boundFilters != null && !(res instanceof EmptyIteration)) {
+								res = new InsertBindingsIteration(res, boundFilters);
+							}
+							return res;
+						}
+					}
+
+					union.addTask(new ParallelPreparedUnionTask(union, preparedQuery, ownedEndpoint, bindings,
+							(isEvaluated.get() ? null : filterExpr), queryInfo));
+
+				} else {
+					union.addTask(new ParallelUnionTask(union, this, ownedEndpoint, bindings, filterExpr, queryInfo));
+				}
+
+			}
+
+			union.run(); // execute the union in this thread
+
+			if (boundFilters != null) {
+				// make sure to insert any values from FILTER expressions that are directly
+				// bound in this expression
+				return new InsertBindingsIteration(union, boundFilters);
+			} else {
+				return union;
+			}
+
+		} catch (RepositoryException | MalformedQueryException e) {
+			if (union != null) {
+				union.close();
+			}
+			throw new QueryEvaluationException(e);
+		} catch (Throwable t) {
+			if (union != null) {
+				union.close();
+			}
+			throw t;
+		}
+	}
+
+	protected CloseableIteration<BindingSet> handleStatementSourcePatternCheck(
+			BindingSet bindings) throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+
+		// if at least one source has statements, we can return this binding set as result
+
+		for (StatementSource source : statementSources) {
+			Endpoint ownedEndpoint = queryInfo.getFederationContext()
+					.getEndpointManager()
+					.getEndpoint(source.getEndpointID());
+			TripleSource t = ownedEndpoint.getTripleSource();
+			if (t.hasStatements(this, bindings, queryInfo, queryInfo.getDataset())) {
+				return new SingleBindingSetIteration(bindings);
+			}
+		}
+
+		return new EmptyIteration<>();
 	}
 
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.algebra;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.QueryModelVisitor;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TripleRef;
+
+/**
+ * A {@link FedXStatementPattern} representing a {@link StatementPattern} together with a {@link TripleRef}, i.e. a
+ * SPARQL / RDF 1.2 expression.
+ */
+public class TripleRefStatementPattern extends FedXStatementPattern {
+
+	private static final long serialVersionUID = 841877125206379474L;
+	protected final TripleRef tripleRef;
+
+	public TripleRefStatementPattern(StatementPattern node, TripleRef tripleRef, QueryInfo queryInfo) {
+		super(node, queryInfo);
+		this.tripleRef = tripleRef;
+		refineFreeVars();
+	}
+
+	protected void refineFreeVars() {
+		freeVars.clear();
+
+		// main statement subject
+		if (getSubjectVar().getValue() == null) {
+			freeVars.add(getSubjectVar().getName());
+		}
+
+		// main statement predicate
+		if (getPredicateVar().getValue() == null) {
+			freeVars.add(getPredicateVar().getName());
+		}
+
+		// triple ref subject
+		if (tripleRef.getSubjectVar().getValue() == null) {
+			freeVars.add(tripleRef.getSubjectVar().getName());
+		}
+
+		// triple ref predicate
+		if (tripleRef.getPredicateVar().getValue() == null) {
+			freeVars.add(tripleRef.getPredicateVar().getName());
+		}
+
+		// triple ref predicate
+		if (tripleRef.getObjectVar().getValue() == null) {
+			freeVars.add(tripleRef.getObjectVar().getName());
+		}
+	}
+
+	public TripleRef getTripleRef() {
+		return tripleRef;
+	}
+
+	@Override
+	public <X extends Exception> void visitChildren(QueryModelVisitor<X> visitor) throws X {
+
+		super.visitChildren(visitor);
+
+		tripleRef.visit(visitor);
+	}
+
+	@Override
+	public CloseableIteration<BindingSet> evaluate(BindingSet bindings) throws QueryEvaluationException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.algebra;
 
+import java.util.List;
+
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -62,11 +64,8 @@ public class TripleRefStatementPattern extends FedXStatementPattern {
 		}
 	}
 
-	public StatementSource getStatementSource() {
-		if (statementSources.size() != 1) {
-			throw new IllegalStateException("Invalid state in source selection of triple ref statement pattern");
-		}
-		return statementSources.get(0);
+	public List<StatementSource> getStatementSources() {
+		return statementSources;
 	}
 
 	public TripleRef getTripleRef() {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/TripleRefStatementPattern.java
@@ -62,6 +62,13 @@ public class TripleRefStatementPattern extends FedXStatementPattern {
 		}
 	}
 
+	public StatementSource getStatementSource() {
+		if (statementSources.size() != 1) {
+			throw new IllegalStateException("Invalid state in source selection of triple ref statement pattern");
+		}
+		return statementSources.get(0);
+	}
+
 	public TripleRef getTripleRef() {
 		return tripleRef;
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategy.java
@@ -83,6 +83,7 @@ import org.eclipse.rdf4j.federated.optimizer.LimitOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.ServiceOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.SourceSelection;
 import org.eclipse.rdf4j.federated.optimizer.StatementGroupAndJoinOptimizer;
+import org.eclipse.rdf4j.federated.optimizer.TripleRefJoinOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.UnionOptimizer;
 import org.eclipse.rdf4j.federated.structures.FedXDataset;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
@@ -259,6 +260,10 @@ public class FederationEvaluationStrategy extends StrictEvaluationStrategy {
 		}
 
 		optimizeExclusiveExpressions(query, queryInfo, info);
+		
+		// optimize triple ref
+		// TODO conditionally
+		new TripleRefJoinOptimizer(queryInfo).optimize(query);
 
 		// optimize statement groups and join order
 		optimizeJoinOrder(query, queryInfo, info);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategy.java
@@ -49,6 +49,7 @@ import org.eclipse.rdf4j.federated.algebra.StatementSource;
 import org.eclipse.rdf4j.federated.algebra.StatementSource.StatementSourceType;
 import org.eclipse.rdf4j.federated.algebra.StatementSourcePattern;
 import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
+import org.eclipse.rdf4j.federated.algebra.TripleRefJoinGroup;
 import org.eclipse.rdf4j.federated.cache.CacheUtils;
 import org.eclipse.rdf4j.federated.cache.SourceSelectionCache;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
@@ -260,10 +261,11 @@ public class FederationEvaluationStrategy extends StrictEvaluationStrategy {
 		}
 
 		optimizeExclusiveExpressions(query, queryInfo, info);
-		
+
 		// optimize triple ref
-		// TODO conditionally
-		new TripleRefJoinOptimizer(queryInfo).optimize(query);
+		if (info.hasTripleRefExpr()) {
+			new TripleRefJoinOptimizer(queryInfo).optimize(query);
+		}
 
 		// optimize statement groups and join order
 		optimizeJoinOrder(query, queryInfo, info);
@@ -493,6 +495,10 @@ public class FederationEvaluationStrategy extends StrictEvaluationStrategy {
 			return evaluateService((FedXService) expr, bindings);
 		}
 
+		if (expr instanceof TripleRefJoinGroup tripleRefJoin) {
+			return evaluateTripleRefJoinGroup(tripleRefJoin, bindings);
+		}
+
 		if (expr instanceof FedXArbitraryLengthPath) {
 			return evaluateArbitrayLengthPath((FedXArbitraryLengthPath) expr, bindings);
 		}
@@ -544,6 +550,10 @@ public class FederationEvaluationStrategy extends StrictEvaluationStrategy {
 		}
 
 		if (expr instanceof FedXService) {
+			return QueryEvaluationStep.minimal(this, expr);
+		}
+
+		if (expr instanceof TripleRefJoinGroup) {
 			return QueryEvaluationStep.minimal(this, expr);
 		}
 
@@ -1164,6 +1174,29 @@ public class FederationEvaluationStrategy extends StrictEvaluationStrategy {
 			} else {
 				result = new BindLeftJoinIteration(result, bindings);
 			}
+
+			return result;
+		} catch (Throwable t) {
+			if (result != null) {
+				result.close();
+			}
+			if (t instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+			}
+			throw ExceptionUtil.toQueryEvaluationException(t);
+		}
+	}
+
+	public CloseableIteration<BindingSet> evaluateTripleRefJoinGroup(TripleRefJoinGroup tripleRefJoinGroup,
+			BindingSet bindings) {
+
+		String preparedQuery = QueryStringUtil.selectQueryStringTripleRefJoinGroup(tripleRefJoinGroup, bindings,
+				tripleRefJoinGroup.getQueryInfo().getDataset());
+
+		CloseableIteration<BindingSet> result = null;
+		try {
+			result = evaluateAtStatementSources(preparedQuery, tripleRefJoinGroup.getStatementSources(),
+					tripleRefJoinGroup.getQueryInfo());
 
 			return result;
 		} catch (Throwable t) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.federated.algebra.FedXArbitraryLengthPath;
 import org.eclipse.rdf4j.federated.algebra.FedXLeftJoin;
 import org.eclipse.rdf4j.federated.algebra.FederatedDescribeOperator;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
+import org.eclipse.rdf4j.federated.algebra.TripleRefStatementPattern;
 import org.eclipse.rdf4j.federated.exception.OptimizationException;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
@@ -26,6 +27,7 @@ import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
 import org.eclipse.rdf4j.query.algebra.Projection;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.Slice;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
@@ -128,8 +130,16 @@ public class GenericInfoOptimizer extends AbstractSimpleQueryModelVisitor<Optimi
 		/*
 		 * Optimization task:
 		 *
-		 * Collect all join arguments recursively and create the NJoin structure for easier join order optimization
+		 * - Replace joins with a TripleRef to FedXTripleTermStatementPattern (recursively) - Collect all join arguments
+		 * recursively and create the NJoin structure for easier join order optimization
 		 */
+
+		var newNode = OptimizerUtil.flattenTripleRefJoins(node, queryInfo);
+		if (!(newNode instanceof Join)) {
+			node.replaceWith(newNode);
+			newNode.visit(this);
+			return;
+		}
 
 		NJoin newJoin = OptimizerUtil.flattenJoin(node, queryInfo);
 		newJoin.visitChildren(this);
@@ -187,6 +197,16 @@ public class GenericInfoOptimizer extends AbstractSimpleQueryModelVisitor<Optimi
 		newNode.visitChildren(this);
 
 		node.replaceWith(newNode);
+	}
+
+	@Override
+	public void meetOther(QueryModelNode node) throws OptimizationException {
+
+		if (node instanceof TripleRefStatementPattern st) {
+			this.stmts.add(st);
+		}
+
+		super.meetOther(node);
 	}
 
 	public boolean hasService() {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
@@ -135,7 +135,7 @@ public class GenericInfoOptimizer extends AbstractSimpleQueryModelVisitor<Optimi
 		/*
 		 * Optimization task:
 		 *
-		 * - Replace joins with a TripleRef to FedXTripleTermStatementPattern (recursively) - Collect all join arguments
+		 * - Replace joins with a TripleRef to TripleRefStatementPattern (recursively) - Collect all join arguments
 		 * recursively and create the NJoin structure for easier join order optimization
 		 */
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
@@ -50,6 +50,7 @@ public class GenericInfoOptimizer extends AbstractSimpleQueryModelVisitor<Optimi
 	protected boolean hasFilter = false;
 	protected boolean hasUnion = false;
 	protected boolean hasPathExpr = false;
+	protected boolean hasTripleRefExpr = false;
 	protected List<Service> services = null;
 	protected long limit = -1; // set to a positive number if the main query has a limit
 	protected List<StatementPattern> stmts = new ArrayList<>();
@@ -70,6 +71,10 @@ public class GenericInfoOptimizer extends AbstractSimpleQueryModelVisitor<Optimi
 
 	public boolean hasUnion() {
 		return hasUnion;
+	}
+
+	public boolean hasTripleRefExpr() {
+		return hasTripleRefExpr;
 	}
 
 	public boolean hasPathExpression() {
@@ -134,11 +139,14 @@ public class GenericInfoOptimizer extends AbstractSimpleQueryModelVisitor<Optimi
 		 * recursively and create the NJoin structure for easier join order optimization
 		 */
 
-		var newNode = OptimizerUtil.flattenTripleRefJoins(node, queryInfo);
-		if (!(newNode instanceof Join)) {
-			node.replaceWith(newNode);
-			newNode.visit(this);
-			return;
+		// conditionally based on config support RDF 1.2 triple terms
+		if (queryInfo.getFederationContext().getConfig().isEnableTripleRefSupport()) {
+			var newNode = OptimizerUtil.flattenTripleRefJoins(node, queryInfo);
+			if (!(newNode instanceof Join)) {
+				node.replaceWith(newNode);
+				newNode.visit(this);
+				return;
+			}
 		}
 
 		NJoin newJoin = OptimizerUtil.flattenJoin(node, queryInfo);
@@ -203,6 +211,7 @@ public class GenericInfoOptimizer extends AbstractSimpleQueryModelVisitor<Optimi
 	public void meetOther(QueryModelNode node) throws OptimizationException {
 
 		if (node instanceof TripleRefStatementPattern st) {
+			hasTripleRefExpr = true;
 			this.stmts.add(st);
 		}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/OptimizerUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/OptimizerUtil.java
@@ -14,8 +14,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.rdf4j.federated.algebra.NJoin;
+import org.eclipse.rdf4j.federated.algebra.TripleRefStatementPattern;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TripleRef;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 
 public class OptimizerUtil {
@@ -47,5 +50,30 @@ public class OptimizerUtil {
 		} else {
 			joinArgs.add(node);
 		}
+	}
+
+	public static TupleExpr flattenTripleRefJoins(Join join, QueryInfo queryInfo) {
+		// recursion
+		if (join.getLeftArg()instanceof Join nestedJoin) {
+			join.setLeftArg(flattenTripleRefJoins(nestedJoin, queryInfo));
+		}
+		if (join.getRightArg()instanceof Join nestedJoin) {
+			join.setRightArg(flattenTripleRefJoins(nestedJoin, queryInfo));
+		}
+
+		// handle own node
+		if (join.getLeftArg()instanceof TripleRef tr && join.getRightArg()instanceof StatementPattern stmt) {
+
+			TupleExpr newExpr = new TripleRefStatementPattern(stmt, tr, queryInfo);
+			return newExpr;
+		}
+		if (join.getRightArg()instanceof TripleRef tr && join.getLeftArg()instanceof StatementPattern stmt) {
+
+			TupleExpr newExpr = new TripleRefStatementPattern(stmt, tr, queryInfo);
+			return newExpr;
+		}
+
+		// leave actual join untouched
+		return join;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
@@ -25,6 +25,7 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.algebra.EmptyStatementPattern;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
+import org.eclipse.rdf4j.federated.algebra.FedXStatementPattern;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.algebra.StatementSource;
 import org.eclipse.rdf4j.federated.algebra.StatementSource.StatementSourceType;
@@ -193,13 +194,18 @@ public class SourceSelection {
 			// otherwise: No resource seems to provide results
 
 			if (sources.size() > 1) {
-				StatementSourcePattern stmtNode = new StatementSourcePattern(stmt, queryInfo);
+				var stmtNode = stmt instanceof FedXStatementPattern ? (FedXStatementPattern) stmt
+						: new StatementSourcePattern(stmt, queryInfo);
 				for (StatementSource s : sources) {
 					stmtNode.addStatementSource(s);
 				}
 				stmt.replaceWith(stmtNode);
 			} else if (sources.size() == 1) {
-				stmt.replaceWith(new ExclusiveStatement(stmt, sources.get(0), queryInfo));
+				if (stmt instanceof FedXStatementPattern fstmt) {
+					fstmt.addStatementSource(sources.get(0));
+				} else {
+					stmt.replaceWith(new ExclusiveStatement(stmt, sources.get(0), queryInfo));
+				}
 			} else {
 				if (log.isDebugEnabled()) {
 					log.debug("Statement " + QueryStringUtil.toString(stmt)

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/TripleRefJoinOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/TripleRefJoinOptimizer.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
 package org.eclipse.rdf4j.federated.optimizer;
 
 import java.util.ArrayList;
@@ -85,6 +95,10 @@ public class TripleRefJoinOptimizer extends AbstractSimpleQueryModelVisitor<Opti
 			node.replaceWith(args.get(0));
 			return;
 		}
+
+		// exchange the node
+		NJoin newNode = new NJoin(args, queryInfo);
+		node.replaceWith(newNode);
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/TripleRefJoinOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/TripleRefJoinOptimizer.java
@@ -1,0 +1,153 @@
+package org.eclipse.rdf4j.federated.optimizer;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.rdf4j.federated.algebra.EmptyNJoin;
+import org.eclipse.rdf4j.federated.algebra.NJoin;
+import org.eclipse.rdf4j.federated.algebra.StatementSource;
+import org.eclipse.rdf4j.federated.algebra.TripleRefJoinGroup;
+import org.eclipse.rdf4j.federated.algebra.TripleRefStatementPattern;
+import org.eclipse.rdf4j.federated.exception.OptimizationException;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.Service;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractSimpleQueryModelVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Optimizer that groups {@link TripleRefStatementPattern} nodes with co-located {@link StatementPattern} nodes into
+ * {@link TripleRefJoinGroup} instances, enabling efficient federated evaluation of RDF 1.2 reification patterns.
+ *
+ * <p>
+ * The optimizer visits every {@link NJoin} in the query tree (depth-first) and looks for pairs of a
+ * {@link TripleRefStatementPattern} and one or more plain {@link StatementPattern}s that share the same unbound subject
+ * variable. Matched patterns are collapsed into a single {@link TripleRefJoinGroup} that can be sent as one request to
+ * the owning endpoint.
+ * </p>
+ *
+ * @author Andreas Schwarte
+ * @see TripleRefJoinGroup
+ * @see TripleRefStatementPattern
+ */
+public class TripleRefJoinOptimizer extends AbstractSimpleQueryModelVisitor<OptimizationException>
+		implements FedXOptimizer {
+
+	private static final Logger log = LoggerFactory.getLogger(TripleRefJoinOptimizer.class);
+
+	protected final QueryInfo queryInfo;
+
+
+	public TripleRefJoinOptimizer(QueryInfo queryInfo) {
+		super(true);
+		this.queryInfo = queryInfo;
+	}
+
+	@Override
+	public void optimize(TupleExpr tupleExpr) {
+		tupleExpr.visit(this);
+	}
+
+	@Override
+	public void meet(Service tupleExpr) {
+		// stop traversal
+	}
+
+	@Override
+	public void meetOther(QueryModelNode node) {
+		if (node instanceof NJoin) {
+			super.meetOther(node); // depth first
+			meetNJoin((NJoin) node);
+		} else {
+			super.meetOther(node);
+		}
+	}
+
+	protected void meetNJoin(NJoin node) {
+
+		List<TupleExpr> args = node.getArgs();
+
+		// form groups
+		args = formGroups(args);
+
+		if (args.isEmpty()) {
+			node.replaceWith(new EmptyNJoin(node, queryInfo));
+			return;
+		}
+
+		// if the join args could be reduced to just one, e.g. ExclusiveGroup
+		// we can safely replace the join node
+		if (args.size() == 1) {
+			log.debug("Join arguments could be reduced to a single argument, replacing join node.");
+			node.replaceWith(args.get(0));
+			return;
+		}
+	}
+
+	/**
+	 * Group {@link TripleRefStatementPattern} and {@link StatementPattern} having the same subject variable into a
+	 * {@link TripleRefJoinGroup}.
+	 *
+	 * <p>
+	 * <b>Assumption:</b> a shared unbound subject variable is treated as a sufficient co-location signal. In RDF 1.2
+	 * reification patterns the subject linking the outer statement to its triple term is typically a blank node that is
+	 * local to a single dataset (and therefore to a single endpoint). No additional source-exclusivity check is
+	 * performed.
+	 * </p>
+	 *
+	 * @param originalArgs the join arguments to group
+	 * @return the new (potentially grouped) join arguments. If empty, the join will not produce any results.
+	 */
+	protected List<TupleExpr> formGroups(List<TupleExpr> originalArgs) {
+
+		LinkedList<TupleExpr> newArgs = new LinkedList<>();
+		LinkedList<TupleExpr> argsCopy = new LinkedList<>(originalArgs);
+
+		for (TupleExpr te : originalArgs) {
+
+			if (!(te instanceof TripleRefStatementPattern tref)) {
+				continue;
+			}
+
+			if (tref.getSubjectVar().hasValue()) {
+				continue;
+			}
+
+			// guard: skip if already claimed by a group formed in an earlier iteration
+			if (!argsCopy.contains(tref)) {
+				continue;
+			}
+
+			String varName = tref.getSubjectVar().getName();
+			// TODO support multiple sources
+			StatementSource trefSource = tref.getStatementSource();
+
+			List<StatementPattern> group = new ArrayList<>();
+			// find StatementPatterns (but not further TripleRefStatementPatterns) sharing the subject variable
+			for (TupleExpr te2 : argsCopy) {
+				if (te2 instanceof StatementPattern st
+						&& !(te2 instanceof TripleRefStatementPattern)
+						&& !st.getSubjectVar().hasValue()
+						&& st.getSubjectVar().getName().equals(varName)) {
+					group.add(st);
+				}
+			}
+
+			if (!group.isEmpty()) {
+				TripleRefJoinGroup trGroup = new TripleRefJoinGroup(tref, group, trefSource, queryInfo);
+				argsCopy.remove(tref);
+				argsCopy.removeAll(group);
+				newArgs.add(trGroup);
+			}
+		}
+
+		// add remaining
+		newArgs.addAll(argsCopy);
+
+		return newArgs;
+	}
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/TripleRefJoinOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/TripleRefJoinOptimizer.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * The optimizer visits every {@link NJoin} in the query tree (depth-first) and looks for pairs of a
  * {@link TripleRefStatementPattern} and one or more plain {@link StatementPattern}s that share the same unbound subject
  * variable. Matched patterns are collapsed into a single {@link TripleRefJoinGroup} that can be sent as one request to
- * the owning endpoint.
+ * the owning endpoints.
  * </p>
  *
  * @author Andreas Schwarte
@@ -40,7 +40,6 @@ public class TripleRefJoinOptimizer extends AbstractSimpleQueryModelVisitor<Opti
 	private static final Logger log = LoggerFactory.getLogger(TripleRefJoinOptimizer.class);
 
 	protected final QueryInfo queryInfo;
-
 
 	public TripleRefJoinOptimizer(QueryInfo queryInfo) {
 		super(true);
@@ -123,8 +122,7 @@ public class TripleRefJoinOptimizer extends AbstractSimpleQueryModelVisitor<Opti
 			}
 
 			String varName = tref.getSubjectVar().getName();
-			// TODO support multiple sources
-			StatementSource trefSource = tref.getStatementSource();
+			List<StatementSource> trefSources = tref.getStatementSources();
 
 			List<StatementPattern> group = new ArrayList<>();
 			// find StatementPatterns (but not further TripleRefStatementPatterns) sharing the subject variable
@@ -138,7 +136,7 @@ public class TripleRefJoinOptimizer extends AbstractSimpleQueryModelVisitor<Opti
 			}
 
 			if (!group.isEmpty()) {
-				TripleRefJoinGroup trGroup = new TripleRefJoinGroup(tref, group, trefSource, queryInfo);
+				TripleRefJoinGroup trGroup = new TripleRefJoinGroup(tref, group, trefSources, queryInfo);
 				argsCopy.remove(tref);
 				argsCopy.removeAll(group);
 				newArgs.add(trGroup);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExprRenderer;
 import org.eclipse.rdf4j.federated.algebra.FedXStatementPattern;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
+import org.eclipse.rdf4j.federated.algebra.TripleRefStatementPattern;
 import org.eclipse.rdf4j.federated.evaluation.iterator.BoundJoinVALUESConversionIteration;
 import org.eclipse.rdf4j.federated.exception.IllegalQueryException;
 import org.eclipse.rdf4j.model.BNode;
@@ -40,6 +41,7 @@ import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.StatementPattern.Scope;
+import org.eclipse.rdf4j.query.algebra.TripleRef;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.slf4j.Logger;
@@ -641,7 +643,7 @@ public class QueryStringUtil {
 		}
 		sb = appendVar(sb, stmt.getSubjectVar(), varNames, bindings).append(" ");
 		sb = appendVar(sb, stmt.getPredicateVar(), varNames, bindings).append(" ");
-		sb = appendVar(sb, stmt.getObjectVar(), varNames, bindings).append(" . ");
+		appendStmtObjectOrTripleRef(sb, stmt, varNames, bindings);
 
 		if (stmt.getScope().equals(Scope.NAMED_CONTEXTS)) {
 			sb.append("} ");
@@ -706,6 +708,29 @@ public class QueryStringUtil {
 		sb.append(" FILTER (?o_").append(_varID).append(" = ").append(objValue).append(" )");
 
 		return sb.toString();
+	}
+
+	protected static StringBuilder appendStmtObjectOrTripleRef(StringBuilder sb, StatementPattern stmt,
+			Set<String> varNames, BindingSet bindings) {
+
+		if (stmt instanceof TripleRefStatementPattern tstmt) {
+			appendTripleRef(sb, tstmt.getTripleRef(), varNames, bindings);
+		} else {
+			sb = appendVar(sb, stmt.getObjectVar(), varNames, bindings).append(" . ");
+		}
+
+		return sb;
+	}
+
+	protected static StringBuilder appendTripleRef(StringBuilder sb, TripleRef tripleRef, Set<String> varNames,
+			BindingSet bindings) {
+
+		sb.append("<<( ");
+		appendVar(sb, tripleRef.getSubjectVar(), varNames, bindings);
+		appendVar(sb, tripleRef.getPredicateVar(), varNames, bindings);
+		appendVar(sb, tripleRef.getObjectVar(), varNames, bindings);
+		sb.append(" )>> ");
+		return sb;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExprRenderer;
 import org.eclipse.rdf4j.federated.algebra.FedXStatementPattern;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
+import org.eclipse.rdf4j.federated.algebra.TripleRefJoinGroup;
 import org.eclipse.rdf4j.federated.algebra.TripleRefStatementPattern;
 import org.eclipse.rdf4j.federated.evaluation.iterator.BoundJoinVALUESConversionIteration;
 import org.eclipse.rdf4j.federated.exception.IllegalQueryException;
@@ -472,6 +473,34 @@ public class QueryStringUtil {
 		return res.toString();
 	}
 
+	public static String selectQueryStringTripleRefJoinGroup(TripleRefJoinGroup tripleRefJoinGroup, BindingSet bindings,
+			Dataset dataset) {
+
+		Set<String> varNames = new HashSet<>();
+
+		StringBuilder body = new StringBuilder();
+		body.append(constructStatement(tripleRefJoinGroup.getTripleRefStatementPattern(), varNames, bindings));
+		for (var stmt : tripleRefJoinGroup.getStatementPatterns()) {
+			body.append(constructStatement(stmt, varNames, bindings));
+		}
+
+		StringBuilder res = new StringBuilder();
+
+		res.append("SELECT ");
+
+		for (String var : varNames) {
+			res.append(" ?").append(var);
+		}
+
+		res.append(" ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE {");
+
+		res.append(body).append(" }");
+
+		return res.toString();
+	}
+
 	protected static String constructInnerUnion(StatementPattern stmt, int outerID, Set<String> varNames,
 			List<BindingSet> bindings) {
 
@@ -726,10 +755,10 @@ public class QueryStringUtil {
 			BindingSet bindings) {
 
 		sb.append("<<( ");
-		appendVar(sb, tripleRef.getSubjectVar(), varNames, bindings);
-		appendVar(sb, tripleRef.getPredicateVar(), varNames, bindings);
-		appendVar(sb, tripleRef.getObjectVar(), varNames, bindings);
-		sb.append(" )>> ");
+		appendVar(sb, tripleRef.getSubjectVar(), varNames, bindings).append(" ");
+		appendVar(sb, tripleRef.getPredicateVar(), varNames, bindings).append(" ");
+		appendVar(sb, tripleRef.getObjectVar(), varNames, bindings).append(" ");
+		sb.append(" )>> . ");
 		return sb;
 	}
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
@@ -146,6 +146,11 @@ public abstract class FedXBaseTest {
 
 		actualQueryPlan = actualQueryPlan.replaceAll("sparql_localhost:[0-9]+_repositories_", "");
 		actualQueryPlan = actualQueryPlan.replace("remote_", "");
+
+		// comparison of anon bnode variables
+		expectedQueryPlan = expectedQueryPlan.replaceAll("name=_anon_.*,", "name=_anon_");
+		actualQueryPlan = actualQueryPlan.replaceAll("name=_anon_.*,", "name=_anon_");
+
 		Assertions.assertEquals(expectedQueryPlan, actualQueryPlan);
 	}
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
@@ -148,8 +148,8 @@ public abstract class FedXBaseTest {
 		actualQueryPlan = actualQueryPlan.replace("remote_", "");
 
 		// comparison of anon bnode variables
-		expectedQueryPlan = expectedQueryPlan.replaceAll("name=_anon_.*,", "name=_anon_");
-		actualQueryPlan = actualQueryPlan.replaceAll("name=_anon_.*,", "name=_anon_");
+		expectedQueryPlan = expectedQueryPlan.replaceAll("name=_anon_[^,]*,", "name=_anon_");
+		actualQueryPlan = actualQueryPlan.replaceAll("name=_anon_[^,]*,", "name=_anon_");
 
 		Assertions.assertEquals(expectedQueryPlan, actualQueryPlan);
 	}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/RDF12Tests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/RDF12Tests.java
@@ -114,6 +114,32 @@ public class RDF12Tests extends SPARQLBaseTest {
 			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
 		}
 	}
+	
+	@Test
+	public void testRetrieval_sparql1_2_join_multiSource() throws Exception {
+		
+		fedxRule.enableDebug();
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"""
+							PREFIX ex:    <http://www.example.org/>
+							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+							SELECT * WHERE {
+							   ?node rdf:reifies <<( ex:bob ex:jobTitle ?jobTitle )>> ;
+							      ex:accordingTo ?title .
+							}
+							""");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(1, res.size());
+			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
+		}
+	}
 
 	// real federated queries
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/RDF12Tests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/RDF12Tests.java
@@ -19,9 +19,24 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.TripleTerm;
 import org.eclipse.rdf4j.model.util.Values;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class RDF12Tests extends SPARQLBaseTest {
+
+	// TODO add comparison for query plans
+
+	@BeforeEach
+	public void assumeSparql() {
+		assumeSparqlEndpoint();
+	}
+
+	@Override
+	protected void initFedXConfig() {
+		super.initFedXConfig();
+
+		fedxRule.withConfiguration(config -> config.withEnableTripleRefSupport(true));
+	}
 
 	@Test
 	public void testRetrieval_openVar() throws Exception {
@@ -114,11 +129,9 @@ public class RDF12Tests extends SPARQLBaseTest {
 			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
 		}
 	}
-	
+
 	@Test
-	public void testRetrieval_sparql1_2_join_multiSource() throws Exception {
-		
-		fedxRule.enableDebug();
+	public void testRetrieval_sparql1_2_join_singleSourceJoin() throws Exception {
 
 		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
 
@@ -131,13 +144,103 @@ public class RDF12Tests extends SPARQLBaseTest {
 							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 							SELECT * WHERE {
 							   ?node rdf:reifies <<( ex:bob ex:jobTitle ?jobTitle )>> ;
-							      ex:accordingTo ?title .
+							      ex:accordingTo ?titleSource .
 							}
 							""");
 			var res = Iterations.asList(tq.evaluate());
 
 			Assertions.assertEquals(1, res.size());
 			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
+			Assertions.assertEquals(ex("sourceBobTitle"), res.get(0).getValue("titleSource"));
+		}
+	}
+
+	@Test
+	public void testRetrieval_sparql1_2_variant_singleSourceJoin() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"""
+							PREFIX ex:    <http://www.example.org/>
+							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+							SELECT * WHERE {
+							   << ex:bob ex:jobTitle ?jobTitle >> ex:accordingTo ?titleSource
+							}
+							""");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(1, res.size());
+			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
+			Assertions.assertEquals(ex("sourceBobTitle"), res.get(0).getValue("titleSource"));
+		}
+	}
+
+	@Test
+	public void testRetrieval_sparql1_2_join_multiSourceJoin() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"""
+							PREFIX ex:    <http://www.example.org/>
+							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+							SELECT * WHERE {
+							   ?node rdf:reifies <<( ?subject ex:jobTitle ?jobTitle )>> ;
+							      ex:accordingTo ?titleSource .
+							}
+							""");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(2, res.size());
+			var bobBindingSet = res.stream().filter(bs -> bs.getValue("subject").equals(ex("bob"))).findFirst().get();
+			Assertions.assertEquals("Designer", bobBindingSet.getValue("jobTitle").stringValue());
+			Assertions.assertEquals(ex("sourceBobTitle"), bobBindingSet.getValue("titleSource"));
+
+			var aliceBindingSet = res.stream()
+					.filter(bs -> bs.getValue("subject").equals(ex("alice")))
+					.findFirst()
+					.get();
+			Assertions.assertEquals("HR Manager", aliceBindingSet.getValue("jobTitle").stringValue());
+			Assertions.assertEquals(ex("sourceAliceTitle"), aliceBindingSet.getValue("titleSource"));
+		}
+	}
+
+	@Test
+	public void testRetrieval_sparql1_2_variant_multiSourceJoin() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"""
+							PREFIX ex:    <http://www.example.org/>
+							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+							SELECT * WHERE {
+							   << ?subject ex:jobTitle ?jobTitle >> ex:accordingTo ?titleSource
+							}
+							""");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(2, res.size());
+			var bobBindingSet = res.stream().filter(bs -> bs.getValue("subject").equals(ex("bob"))).findFirst().get();
+			Assertions.assertEquals("Designer", bobBindingSet.getValue("jobTitle").stringValue());
+			Assertions.assertEquals(ex("sourceBobTitle"), bobBindingSet.getValue("titleSource"));
+
+			var aliceBindingSet = res.stream()
+					.filter(bs -> bs.getValue("subject").equals(ex("alice")))
+					.findFirst()
+					.get();
+			Assertions.assertEquals("HR Manager", aliceBindingSet.getValue("jobTitle").stringValue());
+			Assertions.assertEquals(ex("sourceAliceTitle"), aliceBindingSet.getValue("titleSource"));
 		}
 	}
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/RDF12Tests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/RDF12Tests.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.TripleTerm;
+import org.eclipse.rdf4j.model.util.Values;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RDF12Tests extends SPARQLBaseTest {
+
+	@Test
+	public void testRetrieval_openVar() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"SELECT * WHERE { ?node <http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies> ?tripleTerm }");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(
+					Set.of(ex("bob"), ex("alice")),
+					res.stream()
+							.map(bs -> bs.getValue("tripleTerm"))
+							.map(TripleTerm.class::cast)
+							.map(tt -> tt.getSubject())
+							.collect(Collectors.toSet()));
+		}
+	}
+
+	@Test
+	public void testRetrieval_sparql1_2_singleSource() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"""
+							PREFIX ex:    <http://www.example.org/>
+							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+							SELECT * WHERE {
+							   ?node rdf:reifies <<( ex:bob ex:jobTitle ?jobTitle )>>
+							}
+							""");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(1, res.size());
+			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
+		}
+	}
+
+	@Test
+	public void testRetrieval_sparql1_2_join_singleSource() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"""
+							PREFIX ex:    <http://www.example.org/>
+							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+							SELECT * WHERE {
+							   ?node rdf:reifies <<( ex:bob ex:jobTitle ?jobTitle )>> ;
+							      ex:accordingTo ex:sourceBobTitle .
+							}
+							""");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(1, res.size());
+			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
+		}
+	}
+
+	@Test
+	public void testRetrieval_sparql1_2_variant_singleSource() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/rdf1_2/data01endpoint1.ttl", "/tests/rdf1_2/data01endpoint2.ttl"));
+
+		var fedxRepo = fedxRule.getRepository();
+
+		try (var conn = fedxRepo.getConnection()) {
+			var tq = conn.prepareTupleQuery(
+					"""
+							PREFIX ex:    <http://www.example.org/>
+							PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+							SELECT * WHERE {
+							   << ex:bob ex:jobTitle ?jobTitle >> ex:accordingTo ex:sourceBobTitle
+							}
+							""");
+			var res = Iterations.asList(tq.evaluate());
+
+			Assertions.assertEquals(1, res.size());
+			Assertions.assertEquals("Designer", res.get(0).getValue("jobTitle").stringValue());
+		}
+	}
+
+	// real federated queries
+
+	static IRI ex(String localName) {
+		return Values.iri("http://www.example.org/", localName);
+	}
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizerTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizerTest.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.optimizer;
 
+import static org.mockito.Mockito.when;
+
 import org.eclipse.rdf4j.federated.FedXBaseTest;
+import org.eclipse.rdf4j.federated.FedXConfig;
 import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
 import org.eclipse.rdf4j.federated.algebra.TripleRefStatementPattern;
@@ -19,6 +22,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -29,6 +33,15 @@ public class GenericInfoOptimizerTest extends FedXBaseTest {
 
 	@Mock
 	private QueryInfo queryInfo;
+
+	@Mock
+	private FederationContext federationContext;
+
+	@BeforeEach
+	public void setUp() {
+		when(queryInfo.getFederationContext()).thenReturn(federationContext);
+		when(federationContext.getConfig()).thenReturn(new FedXConfig().withEnableTripleRefSupport(true));
+	}
 
 	/**
 	 * Verifies that a query containing a reification triple pattern (RDF 1.2 style) is optimized into a

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizerTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizerTest.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.optimizer;
+
+import org.eclipse.rdf4j.federated.FedXBaseTest;
+import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.federated.algebra.NJoin;
+import org.eclipse.rdf4j.federated.algebra.TripleRefStatementPattern;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class GenericInfoOptimizerTest extends FedXBaseTest {
+
+	@Mock
+	private QueryInfo queryInfo;
+
+	/**
+	 * Verifies that a query containing a reification triple pattern (RDF 1.2 style) is optimized into a
+	 * {@link TripleRefStatementPattern} node rather than left as a Join over a StatementPattern and a TripleRef.
+	 */
+	@Test
+	public void testTripleRefJoinIsOptimizedToTripleRefStatementPattern() {
+		String query = """
+				PREFIX ex:    <http://www.example.org/>
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				SELECT * WHERE {
+				   ?node rdf:reifies <<( ex:bob ex:jobTitle ?jobTitle )>>
+				}
+				""";
+
+		ParsedTupleQuery parsedQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, query, null);
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		GenericInfoOptimizer optimizer = new GenericInfoOptimizer(queryInfo);
+		optimizer.optimize(tupleExpr);
+
+		String expectedQueryPlan = """
+				QueryRoot
+				   Projection
+				      ProjectionElemList
+				         ProjectionElem "node"
+				         ProjectionElem "jobTitle"
+				      TripleRefStatementPattern
+				         Var (name=node)
+				         Var (name=_const_9fd69527_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies, anonymous)
+				         Var (name=_anon_2ce88c483427245f9ab5869662768984301, anonymous)
+				         TripleRef
+				            Var (name=_const_ad4a55dd_uri, value=http://www.example.org/bob, anonymous)
+				            Var (name=_const_d9dc6573_uri, value=http://www.example.org/jobTitle, anonymous)
+				            Var (name=jobTitle)
+				            Var (name=_anon_2ce88c483427245f9ab5869662768984301, anonymous)
+								""";
+
+		assertQueryPlanEquals(expectedQueryPlan, tupleExpr.toString());
+	}
+
+	/**
+	 * Verifies that a query with an embedded triple as the subject (RDF 1.2 style) is optimized into a
+	 * {@link TripleRefStatementPattern} node rather than left as a Join over a TripleRef and a StatementPattern.
+	 */
+	@Test
+	public void testEmbeddedTripleSubjectIsOptimizedToTripleRefStatementPattern() {
+		String query = """
+				PREFIX ex:    <http://www.example.org/>
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				SELECT * WHERE {
+				   << ex:bob ex:jobTitle ?jobTitle >> ex:accordingTo ?source
+				}
+				""";
+
+		ParsedTupleQuery parsedQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, query, null);
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		GenericInfoOptimizer optimizer = new GenericInfoOptimizer(queryInfo);
+		optimizer.optimize(tupleExpr);
+
+		String expectedQueryPlan = """
+				QueryRoot
+				   Projection
+				      ProjectionElemList
+				         ProjectionElem "jobTitle"
+				         ProjectionElem "source"
+				      NJoin
+				         TripleRefStatementPattern
+				            Var (name=_anon_18a7b5c1b9b9045c4b34845786c50a85f0, anonymous)
+				            Var (name=reifies, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies, anonymous)
+				            Var (name=_anon_28a7b5c1b9b9045c4b34845786c50a85f01, anonymous)
+				            ReifiedTripleRef
+				               Var (name=_const_ad4a55dd_uri, value=http://www.example.org/bob, anonymous)
+				               Var (name=_const_d9dc6573_uri, value=http://www.example.org/jobTitle, anonymous)
+				               Var (name=jobTitle)
+				               Var (name=_anon_28a7b5c1b9b9045c4b34845786c50a85f01, anonymous)
+				               Var (name=_anon_18a7b5c1b9b9045c4b34845786c50a85f0, anonymous)
+				         StatementPattern
+				            Var (name=_anon_18a7b5c1b9b9045c4b34845786c50a85f0, anonymous)
+				            Var (name=_const_50f03f65_uri, value=http://www.example.org/accordingTo, anonymous)
+				            Var (name=source)
+								""";
+
+		assertQueryPlanEquals(expectedQueryPlan, tupleExpr.toString());
+	}
+
+	/**
+	 * Verifies that a query with a reification triple pattern combined with a further statement (RDF 1.2 style) is
+	 * optimized into an {@link NJoin} that contains a {@link TripleRefStatementPattern} as a direct child.
+	 */
+	@Test
+	public void testTripleRefInJoinIsOptimizedToNJoinWithTripleRefStatementPattern() {
+		String query = """
+				PREFIX ex:    <http://www.example.org/>
+				PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				SELECT * WHERE {
+				   ?node rdf:reifies <<( ex:bob ex:jobTitle ?jobTitle )>> ;
+				      ex:accordingTo ?source
+				}
+				""";
+
+		ParsedTupleQuery parsedQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, query, null);
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		GenericInfoOptimizer optimizer = new GenericInfoOptimizer(queryInfo);
+		optimizer.optimize(tupleExpr);
+
+		String expectedQueryPlan = """
+				QueryRoot
+				   Projection
+				      ProjectionElemList
+				         ProjectionElem "node"
+				         ProjectionElem "jobTitle"
+				         ProjectionElem "source"
+				      NJoin
+				         TripleRefStatementPattern
+				            Var (name=node)
+				            Var (name=_const_9fd69527_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies, anonymous)
+				            Var (name=_anon_22aef978a7edb4a9ba38159091244d07501, anonymous)
+				            TripleRef
+				               Var (name=_const_ad4a55dd_uri, value=http://www.example.org/bob, anonymous)
+				               Var (name=_const_d9dc6573_uri, value=http://www.example.org/jobTitle, anonymous)
+				               Var (name=jobTitle)
+				               Var (name=_anon_22aef978a7edb4a9ba38159091244d07501, anonymous)
+				         StatementPattern
+				            Var (name=node)
+				            Var (name=_const_50f03f65_uri, value=http://www.example.org/accordingTo, anonymous)
+				            Var (name=source)
+								""";
+
+		assertQueryPlanEquals(expectedQueryPlan, tupleExpr.toString());
+	}
+
+	@Override
+	protected FederationContext federationContext() {
+		// Not yet required for this test
+		throw new UnsupportedOperationException();
+	}
+}

--- a/tools/federation/src/test/resources/tests/rdf1_2/data01endpoint1.ttl
+++ b/tools/federation/src/test/resources/tests/rdf1_2/data01endpoint1.ttl
@@ -1,0 +1,6 @@
+PREFIX :    <http://www.example.org/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+:bob  :familyName                     "Smith" .
+_:anno rdf:reifies <<( :bob :jobTitle "Designer" )>> .
+_:anno :accordingTo                     :sourceBobTitle .

--- a/tools/federation/src/test/resources/tests/rdf1_2/data01endpoint2.ttl
+++ b/tools/federation/src/test/resources/tests/rdf1_2/data01endpoint2.ttl
@@ -1,0 +1,6 @@
+PREFIX :    <http://www.example.org/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+:alice  :familyName                     "Alice" .
+_:anno1 rdf:reifies <<( :alice :jobTitle "HR Manager" )>> .
+_:anno1 :accordingTo                     :sourceAliceTitle .


### PR DESCRIPTION
GitHub issue resolved: #5870 

**Commit 1: GH-5870: add initial RDF 1.2 support to FedX query optimizer (WIP)**

Introduce TripleRefStatementPattern as a new FedX algebra node that
combines a StatementPattern with a TripleRef, representing SPARQL/RDF
1.2 reification patterns (rdf:reifies and embedded triple subjects).

Wire GenericInfoOptimizer to fold Join(TripleRef, StatementPattern) into
TripleRefStatementPattern via OptimizerUtil.flattenTripleRefJoins, and
register the resulting node in the statements list via meetOther.

Extend SourceSelection to handle FedXStatementPattern instances directly
(avoiding an unnecessary StatementSourcePattern wrapper), and update
QueryStringUtil to serialize the triple term syntax <<( ... )>> for
TripleRefStatementPattern.

Add unit tests for GenericInfoOptimizer covering three AST shapes, and
integration tests in RDF12Tests for single-source reification queries.

Note: TripleRefStatementPattern.evaluate() is not yet implemented;
federated (multi-source) RDF 1.2 query handling remains incomplete.



**Commit 2: GH-5870: add initial RDF 1.2 support to FedX query optimizer (WIP)**

Introduce TripleRefStatementPattern as a new FedX algebra node that
combines a StatementPattern with a TripleRef, representing SPARQL/RDF
1.2 reification patterns (rdf:reifies and embedded triple subjects).

Wire GenericInfoOptimizer to fold Join(TripleRef, StatementPattern) into
TripleRefStatementPattern via OptimizerUtil.flattenTripleRefJoins, and
register the resulting node in the statements list via meetOther.

Extend SourceSelection to handle FedXStatementPattern instances directly
(avoiding an unnecessary StatementSourcePattern wrapper), and update
QueryStringUtil to serialize the triple term syntax <<( ... )>> for
TripleRefStatementPattern.

Add unit tests for GenericInfoOptimizer covering three AST shapes, and
integration tests in RDF12Tests for single-source reification queries.

Note: TripleRefStatementPattern.evaluate() is not yet implemented;
federated (multi-source) RDF 1.2 query handling remains incomplete.



**Commit 3: GH-5870: add end-to-end evaluation of TripleRefJoinGroup for RDF 1.2**

Introduce enableTripleRefSupport config flag (default false) to gate RDF
1.2 triple term handling; both GenericInfoOptimizer
(flattenTripleRefJoins) and TripleRefJoinOptimizer only activate when
the flag is set, and GenericInfoOptimizer now tracks hasTripleRefExpr to
skip the latter pass when no triple ref patterns are present.

Generalize TripleRefJoinGroup and TripleRefStatementPattern from a
single StatementSource to List<StatementSource>, removing the earlier
single-source assumption and enabling multi-source reification queries.

Wire evaluation of TripleRefJoinGroup into FederationEvaluationStrategy:
build a SELECT query via
QueryStringUtil.selectQueryStringTripleRefJoinGroup and dispatch it to
the assigned sources.

Add test data files for two endpoints and extend RDF12Tests with four
integration tests covering single- and multi-source reification joins in
both the rdf:reifies and embedded-triple-subject syntactic forms.



----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

