### PR TITLE
GH-5878: RDF XML format should properly support RDF 1.2

### DIFF
--- a/core/common/xml/src/main/java/org/eclipse/rdf4j/common/xml/XMLUtil.java
+++ b/core/common/xml/src/main/java/org/eclipse/rdf4j/common/xml/XMLUtil.java
@@ -424,4 +424,20 @@ public class XMLUtil {
 	private static boolean _charInRange(char c, int start, int end) {
 		return c >= start && c <= end;
 	}
+
+	/**
+	 * Strips the provided direction of the leading dashes.
+	 * @param direction - literal direction
+	 * @return the direction without the leading dashes
+	 */
+	public static String sanitizeLiteralDirection(String direction) {
+		if (direction == null) {
+			return null;
+		}
+		String result = direction.trim();
+		if (result.startsWith("--")) {
+			result = result.substring(2);
+		}
+		return result;
+	}
 }

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
@@ -83,7 +83,7 @@ public class RDFFormat extends FileFormat {
 			Arrays.asList("application/rdf+xml", "application/xml", "text/xml"), StandardCharsets.UTF_8,
 			Arrays.asList("rdf", "rdfs", "owl", "xml"),
 			SimpleValueFactory.getInstance().createIRI("http://www.w3.org/ns/formats/RDF_XML"), SUPPORTS_NAMESPACES,
-			NO_CONTEXTS, NO_TRIPLE_TERMS
+			NO_CONTEXTS, SUPPORTS_TRIPLE_TERMS
 	);
 
 	/**

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -1003,7 +1003,7 @@ public abstract class AbstractParserHandlingTest {
 	@Test
 	public void testRDF12Compatibility1() throws Exception {
 		Model expectedModel = new LinkedHashModel();
-		TripleTerm t1 = vf.createTripleTerm(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
+		TripleTerm t1 = vf.createTripleTerm(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/p2"),
 				vf.createLiteral("example", vf.createIRI("http://example.com/3")));
 		expectedModel.add(vf.createStatement(vf.createIRI("http://example.com/4"), DC.SOURCE, t1));
 		TripleTerm t2 = vf.createTripleTerm(vf.createIRI("http://example.com/s"), DC.DATE, t1);
@@ -1024,7 +1024,8 @@ public abstract class AbstractParserHandlingTest {
 	@Test
 	public void testRDF12Compatibility2() throws Exception {
 		Model expectedModel = new LinkedHashModel();
-		TripleTerm t1 = vf.createTripleTerm(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
+		TripleTerm t1 = vf.createTripleTerm(vf.createIRI("http://example.com/а1"),
+				vf.createIRI("http://example.com/p2"),
 				vf.createLiteral("example", vf.createIRI("http://example.com/3")));
 		expectedModel.add(vf.createStatement(vf.createIRI("http://example.com/4"), DC.SOURCE, t1));
 		TripleTerm t2 = vf.createTripleTerm(vf.createIRI("http://example.com/s"), DC.DATE, t1);

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -749,14 +749,6 @@ public abstract class RDFWriterTest {
 			}
 
 			IRI pred = potentialPredicates.get(prng.nextInt(potentialPredicates.size()));
-			while (obj instanceof TripleTerm && pred.equals(RDF.TYPE)) {
-				// Avoid statements "x rdf:type <<triple>>" as those use the shorter syntax in RDFXMLPrettyWriter
-				// and the writer produces invalid XML in that case. Even though the triples are encoded as
-				// valid IRIs, XML has limitations on what characters may form an XML tag name and thus a limitation
-				// on what IRIs may be used in predicates (predicates are XML tags) or the short form of rdf:type
-				// (where the type is also an XML tag).
-				obj = potentialObjects.get(prng.nextInt(potentialObjects.size()));
-			}
 			model.add(potentialSubjects.get(prng.nextInt(potentialSubjects.size())),
 					pred, obj);
 		}

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -20,7 +20,13 @@ import java.util.*;
 import org.apache.commons.io.input.BOMInputStream;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.common.xml.XMLUtil;
-import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.TripleTerm;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -312,11 +318,10 @@ public class RDFXMLParser extends XMLReaderBasedParser implements ErrorHandler {
 	void startElement(String namespaceURI, String localName, String qName, Atts atts)
 			throws RDFParseException, RDFHandlerException {
 		Att rdfVersion = atts.removeAtt(RDF.NAMESPACE, "version");
-		if (rdfVersion != null) {
-			if ("1.2".equals(rdfVersion.getValue())) {
-				rdf12Mode = true;
-			}
+		if (rdfVersion != null && "1.2".equals(rdfVersion.getValue())) {
+			rdf12Mode = true;
 		}
+
 		if (topIsProperty()) {
 			// this element represents the subject and/or object of a statement
 			processNodeElt(namespaceURI, localName, qName, atts, false);
@@ -360,7 +365,7 @@ public class RDFXMLParser extends XMLReaderBasedParser implements ErrorHandler {
 					if (!tripleStack.isEmpty()) {
 						TripleContext parent = tripleStack.peek();
 						parent.capturedTriple = st;
-					} else {
+					} else if (rdfHandler != null) {
 						rdfHandler.handleStatement(st);
 					}
 					elementStack.pop();

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
@@ -17,12 +17,21 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.common.xml.XMLUtil;
-import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.TripleTerm;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -47,7 +56,6 @@ public class RDFXMLWriter extends AbstractRDFWriter implements CharSink {
 	protected Resource lastWrittenSubject = null;
 	protected char quote = '"';
 	protected boolean entityQuote = false;
-	private boolean itsNamespaceUsed = false;
 
 	/**
 	 * Creates a new RDFXMLWriter that will write to the supplied OutputStream.
@@ -117,11 +125,7 @@ public class RDFXMLWriter extends AbstractRDFWriter implements CharSink {
 			// This export format needs the RDF namespace to be defined, add a
 			// prefix for it if there isn't one yet.
 			setNamespace(RDF.PREFIX, RDF.NAMESPACE);
-			if (itsNamespaceUsed) {
-				writeNewLine();
-				writeIndent();
-				writeQuotedAttribute("xmlns:its", ITS_NAMESPACE);
-			}
+			setNamespace("its", ITS_NAMESPACE);
 
 			WriterConfig writerConfig = getWriterConfig();
 			quote = writerConfig.get(XMLWriterSettings.USE_SINGLE_QUOTES) ? '\'' : '\"';
@@ -257,17 +261,7 @@ public class RDFXMLWriter extends AbstractRDFWriter implements CharSink {
 
 				// Write new subject:
 				writeNewLine();
-				writeStartOfStartTag(RDF.NAMESPACE, "Description");
-				if (subj instanceof BNode) {
-					BNode bNode = (BNode) subj;
-					writeAttribute("nodeID", getValidNodeId(bNode));
-				} else if (baseIRI != null) {
-					writeAttribute("about", baseIRI.relativize(subj.stringValue()));
-				} else {
-					IRI uri = (IRI) subj;
-					writeAttribute("about", uri.toString());
-				}
-				writeEndOfStartTag();
+				writeSubject(subj);
 				writeNewLine();
 
 				lastWrittenSubject = subj;
@@ -278,105 +272,26 @@ public class RDFXMLWriter extends AbstractRDFWriter implements CharSink {
 			writeStartOfStartTag(predNamespace, predLocalName);
 
 			// OBJECT
-			if (obj instanceof TripleTerm) {
+			if (obj instanceof TripleTerm tripleTerm) {
+				writeAttribute(RDF.NAMESPACE, "version", "1.2");
 
-				TripleTerm t = (TripleTerm) obj;
-				writeAttribute("parseType", "Resource");
+				// RDF 1.2 triple terms use rdf:parseType="Triple"
+				writeAttribute(RDF.NAMESPACE, "parseType", "Triple");
 				writeEndOfStartTag();
 				writeNewLine();
-				// rdf:subject
-				writeIndent();
-				writeIndent();
-				writeStartOfStartTag(RDF.NAMESPACE, "subject");
-				writeAttribute("resource", t.getSubject().stringValue());
-				writeEndOfEmptyTag();
-				writeNewLine();
-				// rdf:predicate
-				writeIndent();
-				writeIndent();
-				writeStartOfStartTag(RDF.NAMESPACE, "predicate");
-				writeAttribute("resource", t.getPredicate().stringValue());
-				writeEndOfEmptyTag();
-				writeNewLine();
-				// rdf:object
-				writeIndent();
-				writeIndent();
-				writeStartOfStartTag(RDF.NAMESPACE, "object");
 
-				Value innerObj = t.getObject();
-				if (innerObj instanceof IRI) {
-					writeAttribute("resource", innerObj.stringValue());
-					writeEndOfEmptyTag();
-				} else if (innerObj instanceof BNode) {
-					writeAttribute("nodeID", getValidNodeId((BNode) innerObj));
-					writeEndOfEmptyTag();
-				} else {
-					Literal lit = (Literal) innerObj;
-					if (lit.getLanguage().isPresent()) {
-						writeAttribute(lit.getLanguage().get());
-					} else if (lit.getCoreDatatype() != CoreDatatype.XSD.STRING) {
-						writeAttribute("datatype", lit.getDatatype().toString());
-					}
-					writeEndOfStartTag();
-					writeCharacterData(lit.getLabel());
-					writeEndTag(RDF.NAMESPACE, "object");
-				}
+				// Write nested triple as normal RDF/XML so RDFXMLParser's parseType="Triple"
+				// logic can capture exactly one inner triple as a TripleTerm.
+				writeTripleTerm(tripleTerm);
 
 				writeNewLine();
 				writeIndent();
 				writeEndTag(predNamespace, predLocalName);
-			} else if (obj instanceof Resource) {
-				Resource objRes = (Resource) obj;
 
-				if (objRes instanceof BNode) {
-					BNode bNode = (BNode) objRes;
-					writeAttribute("nodeID", getValidNodeId(bNode));
-				} else if (baseIRI != null) {
-					writeAttribute("resource", baseIRI.relativize(objRes.stringValue()));
-				} else {
-					IRI uri = (IRI) objRes;
-					writeAttribute("resource", uri.toString());
-				}
-
-				writeEndOfEmptyTag();
-			} else if (obj instanceof Literal) {
-				Literal objLit = (Literal) obj;
-				// datatype attribute
-				boolean isXMLLiteral = false;
-
-				if (objLit.getCoreDatatype() == CoreDatatype.RDF.DIRLANGSTRING) {
-					// DIRLANGSTRING is always a language literal
-					writeAttribute(objLit.getLanguage().get());
-					String dir = String.valueOf(objLit.getBaseDirection());
-					itsNamespaceUsed = true;
-					writeAttribute("its:dir", dir);
-
-				} else if (Literals.isLanguageLiteral(objLit)) {
-					writeAttribute(objLit.getLanguage().get());
-
-				} else {
-					// other datatypes
-					CoreDatatype coreDatatype = objLit.getCoreDatatype();
-					isXMLLiteral = coreDatatype == CoreDatatype.RDF.XMLLITERAL;
-
-					if (isXMLLiteral) {
-						writeAttribute("parseType", "Literal");
-					} else if (coreDatatype != CoreDatatype.XSD.STRING) {
-						writeAttribute("datatype", objLit.getDatatype().toString());
-					}
-				}
-
-				writeEndOfStartTag();
-
-				// label
-				if (isXMLLiteral) {
-					// Write XML literal as plain XML
-					writer.write(objLit.getLabel());
-				} else {
-					writeCharacterData(objLit.getLabel());
-				}
-
-				writeEndTag(predNamespace, predLocalName);
+			} else if (obj instanceof Resource objRes) {
+				writeResource(objRes);
+			} else if (obj instanceof Literal objLit) {
+				writeLiteral(objLit, predNamespace, predLocalName, true);
 			}
 
 			writeNewLine();
@@ -386,6 +301,140 @@ public class RDFXMLWriter extends AbstractRDFWriter implements CharSink {
 		} catch (IOException e) {
 			throw new RDFHandlerException(e);
 		}
+	}
+
+	private void writeSubject(Resource subj) throws IOException {
+		writeStartOfStartTag(RDF.NAMESPACE, "Description");
+		if (subj instanceof BNode bNode) {
+			writeAttribute(RDF.NAMESPACE, "nodeID", getValidNodeId(bNode));
+		} else if (baseIRI != null) {
+			writeAttribute(RDF.NAMESPACE, "about", baseIRI.relativize(subj.stringValue()));
+		} else {
+			IRI uri = (IRI) subj;
+			writeAttribute(RDF.NAMESPACE, "about", uri.toString());
+		}
+		writeEndOfStartTag();
+	}
+
+	private void writeResource(Resource resource) throws IOException {
+		if (resource instanceof BNode bNode) {
+			writeAttribute(RDF.NAMESPACE, "nodeID", getValidNodeId(bNode));
+		} else if (baseIRI != null) {
+			writeAttribute(RDF.NAMESPACE, "resource", baseIRI.relativize(resource.stringValue()));
+		} else {
+			IRI uri = (IRI) resource;
+			writeAttribute(RDF.NAMESPACE, "resource", uri.toString());
+		}
+
+		writeEndOfEmptyTag();
+	}
+
+	private void writeLiteral(Literal objLit, String predNamespace, String predLocalName, boolean shouldAddVersion)
+			throws IOException {
+		// datatype attribute
+		boolean isXMLLiteral = false;
+
+		if (objLit.getCoreDatatype() == CoreDatatype.RDF.DIRLANGSTRING) {
+			// DIRLANGSTRING is always a language literal
+			writeXmlLangAttribute(objLit.getLanguage().get());
+			if (shouldAddVersion) {
+				writeAttribute(RDF.NAMESPACE, "version", "1.2");
+			}
+			writeAttribute(ITS_NAMESPACE, "version", "2.0");
+			String dir = String.valueOf(objLit.getBaseDirection());
+			writeAttribute(ITS_NAMESPACE, "dir", XMLUtil.sanitizeLiteralDirection(dir));
+
+		} else if (Literals.isLanguageLiteral(objLit)) {
+			writeXmlLangAttribute(objLit.getLanguage().get());
+
+		} else {
+			// other datatypes
+			CoreDatatype coreDatatype = objLit.getCoreDatatype();
+			isXMLLiteral = coreDatatype == CoreDatatype.RDF.XMLLITERAL;
+
+			if (isXMLLiteral) {
+				writeAttribute(RDF.NAMESPACE, "parseType", "Literal");
+			} else if (coreDatatype != CoreDatatype.XSD.STRING) {
+				writeAttribute(RDF.NAMESPACE, "datatype", objLit.getDatatype().toString());
+			}
+		}
+
+		writeEndOfStartTag();
+
+		// label
+		if (isXMLLiteral) {
+			// Write XML literal as plain XML
+			writer.write(objLit.getLabel());
+		} else {
+			writeCharacterData(objLit.getLabel());
+		}
+
+		writeEndTag(predNamespace, predLocalName);
+	}
+
+	/**
+	 * Writes a triple term as RDF/XML content for rdf:parseType="Triple".
+	 *
+	 * For a triple term (s, p, o) this encodes:
+	 *
+	 * <rdf:Description rdf:about|rdf:nodeID="s"> <p ...encoding-of-o.../> </rdf:Description>
+	 *
+	 * Nested triple terms in object position are handled by using rdf:parseType="Triple" again and recursively calling
+	 * this method.
+	 */
+	protected void writeTripleTerm(TripleTerm t) throws IOException, RDFHandlerException {
+		// Inner subject node element for the triple term
+		writeIndent();
+		writeIndent();
+
+		Resource subj = t.getSubject();
+		writeSubject(subj);
+		writeNewLine();
+
+		// Inner predicate/property element for the triple term
+		IRI pred = t.getPredicate();
+		String predString = pred.toString();
+		int predSplitIdx = XMLUtil.findURISplitIndex(predString);
+		if (predSplitIdx == -1) {
+			throw new RDFHandlerException(
+					"Unable to create XML namespace-qualified name for triple term predicate: " + predString);
+		}
+		String predNamespace = predString.substring(0, predSplitIdx);
+		String predLocalName = predString.substring(predSplitIdx);
+
+		writeIndent();
+		writeIndent();
+		writeIndent();
+		writeStartOfStartTag(predNamespace, predLocalName);
+
+		// Inner object of the triple term
+		Value innerObj = t.getObject();
+
+		if (innerObj instanceof TripleTerm tripleTerm) {
+			// Nested triple term: <p rdf:parseType="Triple"> ... </p>
+			writeAttribute(RDF.NAMESPACE, "parseType", "Triple");
+			writeEndOfStartTag();
+			writeNewLine();
+
+			writeTripleTerm(tripleTerm);
+
+			writeNewLine();
+			writeIndent();
+			writeIndent();
+			writeIndent();
+			writeEndTag(predNamespace, predLocalName);
+
+		} else if (innerObj instanceof Resource objRes) {
+			writeResource(objRes);
+
+		} else if (innerObj instanceof Literal lit) {
+			writeLiteral(lit, predNamespace, predLocalName, false);
+		}
+
+		writeNewLine();
+		writeIndent();
+		writeIndent();
+		writeEndTag(RDF.NAMESPACE, "Description");
 	}
 
 	@Override
@@ -439,18 +488,18 @@ public class RDFXMLWriter extends AbstractRDFWriter implements CharSink {
 		}
 	}
 
-	protected void writeAttribute(String value) throws IOException {
+	protected void writeXmlLangAttribute(String value) throws IOException {
 		writeQuotedAttribute(" " + "xml:lang", value);
 	}
 
-	protected void writeAttribute(String attName, String value)
+	protected void writeAttribute(String namespace, String attName, String value)
 			throws IOException, RDFHandlerException {
 		// Note: attribute cannot use the default namespace
-		String prefix = namespaceTable.get(RDF.NAMESPACE);
+		String prefix = namespaceTable.get(namespace);
 
 		if (prefix == null) {
 			throw new RDFHandlerException(
-					"No prefix has been declared for the namespace used in this attribute: " + RDF.NAMESPACE);
+					"No prefix has been declared for the namespace used in this attribute: " + namespace);
 		}
 
 		writeQuotedAttribute(" " + prefix + ":" + attName, value);

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.TripleTerm;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -129,6 +130,8 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 	 */
 	private final Stack<IRI> predicateStack = new Stack<>();
 
+	private boolean prettyPrintingDisabled = false;
+
 	private boolean writingEnded;
 
 	/*--------------*
@@ -202,8 +205,8 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 			try {
 				flushPendingStatements();
 			} catch (RDFHandlerException e) {
-				if (e.getCause() != null && e.getCause() instanceof IOException) {
-					throw (IOException) e.getCause();
+				if (e.getCause() != null && e.getCause()instanceof IOException ioe) {
+					throw ioe;
 				} else {
 					throw new IOException(e);
 				}
@@ -244,6 +247,7 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 		if (!nodeStack.isEmpty()) {
 			popStacks(null);
 		}
+		super.flushPendingStatements();
 	}
 
 	/**
@@ -340,6 +344,35 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 
 	@Override
 	public void consumeStatement(Statement st) throws RDFHandlerException {
+		// Once we’ve turned off pretty printing, just delegate everything.
+		if (prettyPrintingDisabled) {
+			super.consumeStatement(st);
+			return;
+		}
+
+		// TripleTerm objects are RDF 1.2 features that the pretty-printing
+		// striped/typed logic was not designed for.
+		if (st.getObject() instanceof TripleTerm) {
+			try {
+				if (!headerWritten) {
+					writeHeader();
+				}
+
+				// Close any open pretty-writer stacks AND any open base-writer subject.
+				flushPendingStatements();
+
+				// From now on, never use striped/typed syntax again in this document.
+				prettyPrintingDisabled = true;
+
+				super.consumeStatement(st);
+				return;
+			} catch (IOException e) {
+				throw new RDFHandlerException(e);
+			}
+		}
+
+		// Original pretty-writer striped/typed logic unchanged below:
+
 		Resource subj = st.getSubject();
 		IRI pred = st.getPredicate();
 		Value obj = st.getObject();
@@ -369,9 +402,9 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 			// element is possible
 			// FIXME: verify that an XML namespace-qualified name can be created
 			// for the type URI
-			if (pred.equals(RDF.TYPE) && obj instanceof IRI && !topSubject.hasType() && !topSubject.isWritten()) {
+			if (pred.equals(RDF.TYPE) && obj instanceof IRI iri && !topSubject.hasType() && !topSubject.isWritten()) {
 				// Use typed node element
-				topSubject.setType((IRI) obj);
+				topSubject.setType(iri);
 			} else {
 				if (!nodeStack.isEmpty() && pred.equals(nodeStack.peek().nextLi())) {
 					pred = RDF.LI;
@@ -385,6 +418,12 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 		} catch (IOException e) {
 			throw new RDFHandlerException(e);
 		}
+	}
+
+	private void writeNodeStartTag(Node node) throws IOException, RDFHandlerException {
+		writeNodeStartOfStartTag(node);
+		writeEndOfStartTag();
+		writeNewLine();
 	}
 
 	/**
@@ -404,24 +443,14 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 			writeStartOfStartTag(RDF.NAMESPACE, "Description");
 		}
 
-		if (value instanceof IRI) {
-			IRI uri = (IRI) value;
-			writeAttribute("about", uri.toString());
+		if (value instanceof IRI iri) {
+			writeAttribute(RDF.NAMESPACE, "about", iri.toString());
 		} else {
 			BNode bNode = (BNode) value;
 			if (!inlineBlankNodes) {
-				writeAttribute("nodeID", getValidNodeId(bNode));
+				writeAttribute(RDF.NAMESPACE, "nodeID", getValidNodeId(bNode));
 			}
 		}
-	}
-
-	/**
-	 * Write out the opening tag of the subject or object of a statement.
-	 */
-	private void writeNodeStartTag(Node node) throws IOException, RDFHandlerException {
-		writeNodeStartOfStartTag(node);
-		writeEndOfStartTag();
-		writeNewLine();
 	}
 
 	/**
@@ -452,20 +481,16 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 		var predQName = new QName(pred);
 		writeStartOfStartTag(predQName.getNamespace(), predQName.getLocalName());
 
-		if (obj instanceof Resource) {
-			Resource objRes = (Resource) obj;
-
-			if (objRes instanceof IRI) {
-				IRI uri = (IRI) objRes;
-				writeAttribute("resource", uri.toString());
+		if (obj instanceof Resource objRes) {
+			if (objRes instanceof IRI iri) {
+				writeAttribute(RDF.NAMESPACE, "resource", iri.toString());
 			} else {
 				BNode bNode = (BNode) objRes;
-				writeAttribute("nodeID", getValidNodeId(bNode));
+				writeAttribute(RDF.NAMESPACE, "nodeID", getValidNodeId(bNode));
 			}
 
 			writeEndOfEmptyTag();
-		} else if (obj instanceof Literal) {
-			Literal objLit = (Literal) obj;
+		} else if (obj instanceof Literal objLit) {
 			// datatype attribute
 			CoreDatatype datatype = objLit.getCoreDatatype();
 			// Check if datatype is rdf:XMLLiteral
@@ -473,12 +498,12 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 
 			// language attribute
 			if (Literals.isLanguageLiteral(objLit)) {
-				writeAttribute(objLit.getLanguage().get());
+				writeXmlLangAttribute(objLit.getLanguage().get());
 			} else {
 				if (isXmlLiteral) {
-					writeAttribute("parseType", "Literal");
+					writeAttribute(RDF.NAMESPACE, "parseType", "Literal");
 				} else {
-					writeAttribute("datatype", objLit.getDatatype().toString());
+					writeAttribute(RDF.NAMESPACE, "datatype", objLit.getDatatype().toString());
 				}
 			}
 

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterTest.java
@@ -140,7 +140,8 @@ public class RDFXMLPrettyWriterTest extends AbstractRDFXMLWriterTest {
 		String expectedOutput = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 				"<rdf:RDF\n" +
 				"\txmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\"\n" +
-				"\txmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+				"\txmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n" +
+				"\txmlns:its=\"http://www.w3.org/2005/11/its\">\n" +
 				"<rdf:Description rdf:about=\"http://example.org/subject\">\n" +
 				"\t<relation xmlns=\"http://example.org/\">\n" +
 				"\t\t<rdf:Description>\n" +


### PR DESCRIPTION
Added native support for Triple terms for the RDFXMLWriter and RDFXMLPrettyWriter.

Current implementation adds rdf:version attribute on every node that requires it according to the RDF 1.2 specification. It also adds its prefix in the namespaces regardless if it is required or not.

The RDFXMLPrettyWriter delegates the TripleTerm serialization to the RDFXMLParser as I am not sure how this could be prettified.


GitHub issue resolved: #5878

Briefly describe the changes proposed in this PR: 

Added native support for Triple terms for the RDFXMLWriter and RDFXMLPrettyWriter.

Current implementation adds rdf:version attribute on every node that requires it according to the RDF 1.2 specification. It also adds its prefix in the namespaces regardless if it is required or not. 

The RDFXMLPrettyWriter delegates the TripleTerm serialization to the RDFXMLParser as I am not sure how this could be prettified.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

