### PR TITLE
GH-5879 Make buildRequest protected in ApacheHC5RDF4JHttpClient to allow request cancellation.

### DIFF
--- a/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClient.java
+++ b/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClient.java
@@ -94,7 +94,7 @@ public class ApacheHC5RDF4JHttpClient implements RDF4JHttpClient {
 		}
 	}
 
-	private HttpUriRequestBase buildRequest(HttpRequest request) throws IOException {
+	protected HttpUriRequestBase buildRequest(HttpRequest request) throws IOException {
 		String method = request.getMethod();
 		String uri = request.getUri().toASCIIString();
 


### PR DESCRIPTION
Current implementation has buildRequest as package-private, which prevents subclasses from accessing the constructed HttpUriRequestBase instance. 
This makes it impossible for library users to cancel long-running HTTP requests such as SPARQL queries.

GitHub issue resolved: #5879