### PR TITLE
GH-0000 build: bump Central Publishing Maven Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
-						<version>0.7.0</version>
+						<version>0.11.0</version>
 						<extensions>true</extensions>
 						<configuration>
 							<publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Summary

- Bumps `org.sonatype.central:central-publishing-maven-plugin` from `0.7.0` to `0.11.0` in the `ossrh` release profile.

## Why

Central Portal responses now include fields that older plugin versions do not parse, which can fail publishing after artifacts have already been uploaded.

## Verification

- `./checkCopyrightPresent.sh`
- `mvn -o -Dmaven.repo.local=.m2_repo -q -T 2C process-resources`
- `mvn -B -ntp -Dmaven.compiler.showWarnings=false -T 1C -o -Dmaven.repo.local=.m2_repo -Pquick install`
- `git diff --cached --check`