### PR TITLE
GH-0000 restore secure JSON-LD Docker default

### DIFF
--- a/docker/Dockerfile-tomcat
+++ b/docker/Dockerfile-tomcat
@@ -17,7 +17,7 @@ MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
 RUN apt-get clean && apt-get update && apt-get upgrade -y && apt-get clean
 
 ENV JAVA_OPTS="-Xmx2g"
-ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j -Dorg.eclipse.rdf4j.rio.jsonld_secure_mode=false"
+ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"
 
 RUN adduser --system tomcat
 
@@ -35,4 +35,3 @@ USER tomcat
 WORKDIR /usr/local/tomcat/
 
 EXPOSE 8080
-


### PR DESCRIPTION
GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

