### PR TITLE
GH-5909 Use parameter of BNODE() function as prefix of BNode ID.

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryEvaluationContext.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryEvaluationContext.java
@@ -167,7 +167,7 @@ public interface QueryEvaluationContext {
 			}
 
 			return bnodesByLabel.computeIfAbsent(nodeLabel,
-					ignored -> valueFactory.createBNode("bnode_" + bnodeSolutionId + "_" + bnodeId++));
+					ignored -> valueFactory.createBNode(nodeLabel + "_" + bnodeSolutionId + "_" + bnodeId++));
 		}
 	}
 
@@ -183,7 +183,8 @@ public interface QueryEvaluationContext {
 
 	default BNode getOrCreateBNode(String nodeLabel, BindingSet bindings, ValueFactory valueFactory) {
 		return valueFactory.createBNode(
-				"bnode_" + System.identityHashCode(bindings) + "_" + Integer.toUnsignedString(nodeLabel.hashCode()));
+				nodeLabel + "_" + System.identityHashCode(bindings) + "_"
+						+ Integer.toUnsignedString(nodeLabel.hashCode()));
 	}
 
 	default MutableBindingSet createBindingSet() {

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextTest.java
@@ -16,18 +16,20 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class MinimalContextNowTest {
+public class MinimalContextTest {
 
 	@Test
 	public void testNow() {
@@ -51,7 +53,6 @@ public class MinimalContextNowTest {
 
 		ExecutorService executorService = Executors.newCachedThreadPool();
 		try {
-
 			for (int i = 0; i < numberOfIterations; i++) {
 				QueryEvaluationContext.Minimal context = new QueryEvaluationContext.Minimal(null);
 
@@ -67,7 +68,7 @@ public class MinimalContextNowTest {
 								throw new RuntimeException(e);
 							}
 						}))
-						.collect(Collectors.toList());
+						.toList();
 
 				Literal prev = null;
 				for (Future<Literal> future : futures) {
@@ -78,13 +79,42 @@ public class MinimalContextNowTest {
 					}
 					prev = now;
 				}
-
 			}
-
 		} finally {
 			List<Runnable> runnables = executorService.shutdownNow();
 			Assertions.assertTrue(runnables.isEmpty());
 		}
+	}
 
+	@Test
+	public void testBNodePrefixUsesNodeLabel() {
+		QueryEvaluationContext.Minimal context = new QueryEvaluationContext.Minimal(null);
+
+		BNode bNode = context.getOrCreateBNode("nodeLabel", EmptyBindingSet.getInstance(),
+				SimpleValueFactory.getInstance());
+
+		Assertions.assertTrue(bNode.getID().startsWith("nodeLabel_"),
+				"Expected generated bnode id to start with node label prefix");
+	}
+
+	@Test
+	public void testDefaultBNodePrefixUsesNodeLabel() {
+		QueryEvaluationContext context = new QueryEvaluationContext() {
+			@Override
+			public Literal getNow() {
+				return SimpleValueFactory.getInstance().createLiteral("now");
+			}
+
+			@Override
+			public Dataset getDataset() {
+				return null;
+			}
+		};
+
+		BNode bNode = context.getOrCreateBNode("nodeLabel", EmptyBindingSet.getInstance(),
+				SimpleValueFactory.getInstance());
+
+		Assertions.assertTrue(bNode.getID().startsWith("nodeLabel_"),
+				"Expected generated bnode id to start with node label prefix");
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #5909

Briefly describe the changes proposed in this PR:

Use parameter of BNODE() function as prefix for generated BNode IDs within SPARQL queries.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

