### PR TITLE
GH-5723: bump httpclient5, httpcore5, and jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,11 @@
 		<logback.version>1.5.26</logback.version>
 		<log4j.version>2.25.4</log4j.version>
 		<httpclient.version>4.5.14</httpclient.version>
-		<httpclient5.version>5.4.3</httpclient5.version>
-		<httpcore5.version>5.3.4</httpcore5.version>
-		<jackson.version>2.21.0</jackson.version>
-		<jackson.annotations.version>2.21</jackson.annotations.version>
-		<jackson3.version>3.1.2</jackson3.version>
+		<httpclient5.version>5.6.1</httpclient5.version>
+		<httpcore5.version>5.4.3</httpcore5.version>
+		<jackson.version>2.22.0</jackson.version>
+		<jackson.annotations.version>2.22</jackson.annotations.version>
+		<jackson3.version>3.2.0</jackson3.version>
 		<httpcore.version>4.4.16</httpcore.version>
 		<jsonldjava.version>0.13.4</jsonldjava.version>
 		<last.japicmp.compare.version>6.0.0</last.japicmp.compare.version>


### PR DESCRIPTION
- httpclient5: 5.4.3 → 5.6.1
- httpcore5: 5.3.4 → 5.4.3
- jackson: 2.21.0 → 2.22.0
- jackson.annotations: 2.21 → 2.22
- jackson3: 3.1.2 → 3.2.0


GitHub issue resolved: #5723 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

