### PR TITLE
GH-5917 Update vulnerable dependencies

### DIFF
--- a/core/queryresultio/xlsx/pom.xml
+++ b/core/queryresultio/xlsx/pom.xml
@@ -39,12 +39,12 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>5.4.1</version>
+			<version>5.5.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -56,28 +56,28 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<enforce-javaee-provided.fail>true</enforce-javaee-provided.fail>
 		<slf4j.version>2.0.17</slf4j.version>
-		<logback.version>1.5.26</logback.version>
+		<logback.version>1.5.37</logback.version>
 		<log4j.version>2.25.4</log4j.version>
 		<httpclient.version>4.5.14</httpclient.version>
-		<httpclient5.version>5.4.3</httpclient5.version>
-		<httpcore5.version>5.3.4</httpcore5.version>
-		<jackson.version>2.21.0</jackson.version>
-		<jackson.annotations.version>2.21</jackson.annotations.version>
-		<jackson3.version>3.1.2</jackson3.version>
+		<httpclient5.version>5.6.2</httpclient5.version>
+		<httpcore5.version>5.4.3</httpcore5.version>
+		<jackson.version>2.22.0</jackson.version>
+		<jackson.annotations.version>2.22</jackson.annotations.version>
+		<jackson3.version>3.2.0</jackson3.version>
 		<httpcore.version>4.4.16</httpcore.version>
-		<jsonldjava.version>0.13.4</jsonldjava.version>
+		<jsonldjava.version>0.13.6</jsonldjava.version>
 		<last.japicmp.compare.version>6.0.0</last.japicmp.compare.version>
 		<jaxb.version>2.3.8</jaxb.version>
 		<lwjgl.version>3.4.1</lwjgl.version>
-		<lucene.version>10.3.2</lucene.version>
-		<elasticsearch.version>9.2.4</elasticsearch.version>
-		<spring.version>7.0.3</spring.version>
-		<guava.version>32.1.3-jre</guava.version>
+		<lucene.version>10.5.0</lucene.version>
+		<elasticsearch.version>9.4.2</elasticsearch.version>
+		<spring.version>7.0.8</spring.version>
+		<guava.version>33.6.0-jre</guava.version>
 		<jmhVersion>1.37</jmhVersion>
-		<junit.version>6.0.2</junit.version>
+		<junit.version>6.1.1</junit.version>
 		<junit-pioneer.version>2.3.0</junit-pioneer.version>
-		<mockito.version>5.21.0</mockito.version>
-		<mockserver.version>5.15.0</mockserver.version>
+		<mockito.version>5.23.0</mockito.version>
+		<mockserver.version>7.2.0</mockserver.version>
 		<assertj.version>3.27.7</assertj.version>
 		<hamcrest.version>3.0</hamcrest.version>
 		<topbraid.shacl.version>1.4.4</topbraid.shacl.version>
@@ -87,9 +87,11 @@
 		<jakarta.jsp.version>4.0.0</jakarta.jsp.version>
 		<jakarta.jstl.version>3.0.1</jakarta.jstl.version>
 		<wiremock.version>4.0.0-beta.29</wiremock.version>
-		<jetty.version>12.1.4</jetty.version>
-		<netty.version>4.2.8.Final</netty.version>
-		<testcontainers.version>2.0.3</testcontainers.version>
+		<jetty.version>12.1.10</jetty.version>
+		<netty.version>4.2.15.Final</netty.version>
+		<opentelemetry.version>1.63.0</opentelemetry.version>
+		<bouncycastle.version>1.84</bouncycastle.version>
+		<testcontainers.version>2.0.5</testcontainers.version>
 		<mockito.javaagent>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</mockito.javaagent>
 		<argLine />
 	</properties>
@@ -506,6 +508,16 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+				<groupId>tools.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>${jackson3.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>tools.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>${jackson3.version}</version>
+			</dependency>
 			<!-- fix dependencies for elasticsearch client libraries -->
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
@@ -529,9 +541,21 @@
 				<scope>import</scope>
 			</dependency>
 			<dependency>
+				<groupId>io.opentelemetry</groupId>
+				<artifactId>opentelemetry-bom</artifactId>
+				<version>${opentelemetry.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.wiremock</groupId>
 				<artifactId>wiremock</artifactId>
 				<version>${wiremock.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.jknack</groupId>
+				<artifactId>handlebars</artifactId>
+				<version>4.5.2</version>
 			</dependency>
 			<!-- Annotations is designed to be fixed at the 2.x.0 minor version level, but in practice is still being released for
 				2.8.x patch versions. See https://github.com/FasterXML/jackson-bom/issues/4 -->
@@ -543,7 +567,7 @@
 			<dependency>
 				<groupId>com.opencsv</groupId>
 				<artifactId>opencsv</artifactId>
-				<version>5.3</version>
+				<version>5.12.0</version>
 				<exclusions>
 					<exclusion>
 						<groupId>commons-logging</groupId>
@@ -563,13 +587,13 @@
 			<dependency>
 				<groupId>commons-cli</groupId>
 				<artifactId>commons-cli</artifactId>
-				<version>1.4</version>
+				<version>1.11.0</version>
 			</dependency>
 			<!-- note this affects the xlsx query result format using apache POI -->
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.18.0</version>
+				<version>2.22.0</version>
 			</dependency>
 			<dependency>
 				<groupId>co.elastic.clients</groupId>
@@ -596,17 +620,62 @@
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.15</version>
+				<version>1.22.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-text</artifactId>
-				<version>1.10.0</version>
+				<version>1.15.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.18.0</version>
+				<version>3.20.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>2.10.0</version>
+			</dependency>
+			<dependency>
+				<groupId>net.minidev</groupId>
+				<artifactId>json-smart</artifactId>
+				<version>2.6.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.yaml</groupId>
+				<artifactId>snakeyaml</artifactId>
+				<version>2.6</version>
+			</dependency>
+			<dependency>
+				<groupId>org.xmlunit</groupId>
+				<artifactId>xmlunit-core</artifactId>
+				<version>2.12.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>${bouncycastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mozilla</groupId>
+				<artifactId>rhino</artifactId>
+				<version>1.8.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.thrift</groupId>
+				<artifactId>libthrift</artifactId>
+				<version>0.23.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>

--- a/spring-components/pom.xml
+++ b/spring-components/pom.xml
@@ -13,7 +13,7 @@
 		<module>rdf4j-spring-demo</module>
 	</modules>
 	<properties>
-		<spring.boot.version>4.0.2</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
 	</properties>
 	<artifactId>rdf4j-spring-components</artifactId>
 	<name>RDF4J: Spring components</name>
@@ -61,6 +61,21 @@
 				<version>${netty.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>${jackson.annotations.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>${jackson.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/tools/server-boot/pom.xml
+++ b/tools/server-boot/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>jar</packaging>
 	<name>RDF4J: Server + Workbench Spring Boot runner</name>
 	<properties>
-		<spring.boot.version>4.0.2</spring.boot.version>
+		<spring.boot.version>4.1.0</spring.boot.version>
 		<spring-framework.version>${spring.version}</spring-framework.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<enforce-javaee-provided.fail>false</enforce-javaee-provided.fail>


### PR DESCRIPTION
Closes #5917.

## What changed
- Updates vulnerable direct and managed dependency trains across Jackson 2/3, Spring/Spring Boot, Jetty, Netty, Elasticsearch, MockServer, Logback, Guava, JUnit, Mockito, Testcontainers, POI, OpenCSV, JSON-LD Java, and Apache Commons.
- Adds dependency-management overrides for vulnerable transitives pulled through MockServer, WireMock, Jena, Elasticsearch, and Spring paths.
- Keeps the implementation to POM dependency-management/version changes only.

## Why
The resolved Maven dependency graph had registered OSV advisories for direct and transitive dependencies. After the updates, OSV querybatch over the refreshed resolved tree reports zero findings.

## Verification
- `mvn -B -ntp -Dmaven.compiler.showWarnings=false -T 1C -o -Dmaven.repo.local=.m2_repo -Pquick clean install`
- `python3 .codex/skills/mvnf/scripts/mvnf.py core/http/client --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py spring-components/rdf4j-spring --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py tools/server-boot --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py core/queryresultio/xlsx --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py core/sail/elasticsearch --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py core/sail/elasticsearch-store --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py core/repository/http --retain-logs`
- `python3 .codex/skills/mvnf/scripts/mvnf.py core/repository/manager --retain-logs`
- `mvn -o -Dmaven.repo.local=.m2_repo -q -T 2C process-resources`
- `git diff --check`
- OSV querybatch over 556 resolved Maven coordinates: `0` findings
