### PR TITLE
GH-5919 build: add Brotli native runtimes

### DIFF
--- a/core/rio/api/pom.xml
+++ b/core/rio/api/pom.xml
@@ -35,7 +35,47 @@
 		</dependency>
 		<dependency>
 			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-linux-armv7</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-linux-ppc64le</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-linux-riscv64</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-linux-s390x</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
 			<artifactId>native-linux-x86_64</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-osx-aarch64</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-osx-x86_64</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-windows-aarch64</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.aayushatharva.brotli4j</groupId>
+			<artifactId>native-windows-x86_64</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -636,7 +636,47 @@
 			</dependency>
 			<dependency>
 				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-linux-armv7</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-linux-ppc64le</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-linux-riscv64</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-linux-s390x</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
 				<artifactId>native-linux-x86_64</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-osx-aarch64</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-osx-x86_64</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-windows-aarch64</artifactId>
+				<version>${brotli4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.aayushatharva.brotli4j</groupId>
+				<artifactId>native-windows-x86_64</artifactId>
 				<version>${brotli4j.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
## Summary

- Add the remaining Brotli4j native runtime artifacts to root dependency management.
- Add matching runtime dependencies to core/rio/api for supported Linux, macOS, and Windows architectures.

## Validation

- git diff --check
- mvn -B -ntp -Dmaven.compiler.showWarnings=false -T 1C -o -Dmaven.repo.local=.m2_repo -Pquick clean install
- python3 .codex/skills/mvnf/scripts/mvnf.py core/rio/api --retain-logs: 86 tests, 0 failures, 0 errors, 8 skipped
