### PR TITLE
GH-5963 allow overwriting of writeNodeStartOfStartTag

### DIFF
--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
@@ -430,7 +430,7 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 	 * Write out the opening tag of the subject or object of a statement up to (but not including) the end of the tag.
 	 * Used both in writeStartSubject and writeEmptySubject.
 	 */
-	private void writeNodeStartOfStartTag(Node node) throws IOException, RDFHandlerException {
+	protected void writeNodeStartOfStartTag(Node node) throws IOException, RDFHandlerException {
 		Boolean inlineBlankNodes = getWriterConfig().get(BasicWriterSettings.INLINE_BLANK_NODES);
 		Value value = node.getValue();
 


### PR DESCRIPTION
GitHub issue resolved: #5963 

Briefly describe the changes proposed in this PR:

Make the writeNodeStartOfStartTag() method of the RDFXMLPrettyWriter protected, to allow the overwriting of it.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

