### PR TITLE
GH-5979: Fix TLS system-property fallback in Apache 5 HTTP client

### DIFF
--- a/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClientFactory.java
+++ b/core/http/client-apache5/src/main/java/org/eclipse/rdf4j/http/client/apache5/ApacheHC5RDF4JHttpClientFactory.java
@@ -79,6 +79,7 @@ public class ApacheHC5RDF4JHttpClientFactory implements RDF4JHttpClientFactory {
 	public RDF4JHttpClient create(RDF4JHttpClientConfig config) {
 		// Build connection manager
 		PoolingHttpClientConnectionManagerBuilder cmBuilder = PoolingHttpClientConnectionManagerBuilder.create()
+				.useSystemProperties()
 				.setMaxConnPerRoute(config.getMaxConnectionsPerRoute())
 				.setMaxConnTotal(config.getMaxConnectionsTotal())
 				.setDefaultSocketConfig(SocketConfig.custom()


### PR DESCRIPTION
PoolingHttpClientConnectionManagerBuilder.build() only takes the createSystemDefault() path for its TlsSocketStrategy when its own systemProperties flag is set via useSystemProperties(). Without it, build() silently falls back to createDefault() (a fresh, uncached SSLContext) which ignores javax.net.ssl.keyStore/trustStore.

ApacheHC5RDF4JHttpClientFactory only called useSystemProperties() on the outer HttpClientBuilder, not on the connection-manager builder itself. By the time the outer builder saw it, the connection manager (and its TLS strategy) had already been built, so the call had no effect on TLS.

Any RDF4JHttpClientConfig without an explicit
sslContext/disableHostnameVerification therefore lost support for javax.net.ssl.keyStore/trustStore-based configuration, including mutual TLS / X.509 client-certificate authentication — a regression versus the pre-6.0 Apache HttpClient 4.x based implementation.

Call useSystemProperties() on the
PoolingHttpClientConnectionManagerBuilder itself so it takes the createSystemDefault() branch whenever no explicit TLS configuration is set.


GitHub issue resolved: #5979 



----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

