### PR TITLE
GH-5977 fix resolveURI logic for relative IRIs

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/URIUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/URIUtil.java
@@ -371,4 +371,44 @@ public class URIUtil {
 				|| codePoint >= 0x0300 && codePoint <= 0x036F || codePoint >= 0x203F && codePoint <= 0x2040;
 	}
 
+	/**
+	 * True if the string starts with a valid RFC 3986 scheme followed by ':'. A colon appearing after '/', '?' or '#'
+	 * does not make the reference absolute.
+	 *
+	 * @param iri a string representing an RDF IRI reference to check.
+	 * @throws IllegalArgumentException if the reference begins with ':' (an empty scheme, which is not a valid
+	 *                                  URI-reference per RFC 3986).
+	 */
+	public static boolean isAbsoluteIri(String iri) {
+		for (int i = 0; i < iri.length(); i++) {
+			char c = iri.charAt(i);
+			if (c == ':') {
+				if (i == 0) {
+					throw new IllegalArgumentException("Invalid IRI \"" + iri
+							+ "\": empty scheme / colon at start is not allowed per RFC 3986");
+				}
+				return true;
+			}
+			if (c == '/' || c == '?' || c == '#') {
+				return false;
+			}
+			if (i == 0) {
+				if (!isAsciiAlpha(c)) {
+					return false;
+				}
+			} else if (!isAsciiAlpha(c) && !isAsciiDigit(c) && c != '+' && c != '-' && c != '.') {
+				return false;
+			}
+		}
+		return false;
+	}
+
+	private static boolean isAsciiAlpha(char c) {
+		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+	}
+
+	private static boolean isAsciiDigit(char c) {
+		return c >= '0' && c <= '9';
+	}
+
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
@@ -11,9 +11,13 @@
 package org.eclipse.rdf4j.model.util;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * @author Arjohn Kampman
@@ -109,5 +113,54 @@ public class URIUtilTest {
 		assertFalse(URIUtil.isValidLocalName("foo\nbar"));
 		assertFalse(URIUtil.isValidLocalName("*foobar"));
 		assertTrue(URIUtil.isValidLocalName("fo\\'obar"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"http://example.org/x",
+			"https://example.org/x?y=z#frag",
+			"urn:isbn:0451450523",
+			"mailto:user@example.org",
+			"tel:+1-816-555-1212",
+			"file:///tmp/data.ttl",
+			"a:b", // single-letter scheme is valid
+			"z:", // scheme with empty hier-part
+			"news:comp.infosystems",
+			"scheme+ext.1-x:path", // ALPHA *( ALPHA / DIGIT / + / - / . )
+			"HTTP://EXAMPLE.ORG/x" // scheme is case-insensitive
+	})
+	void absoluteIris(String iri) {
+		Assertions.assertTrue(URIUtil.isAbsoluteIri(iri),
+				"should be classified as absolute: " + iri);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"", // same-document reference
+			"#frag",
+			"#a:b", // colon in fragment
+			"?q=a:b", // colon in query
+			"path/foo:bar", // colon in a later path segment
+			"./a:b", // dot-segment then colon — classic RFC 3986 example
+			"foo/bar",
+			"../up/one",
+			"//example.org/x", // network-path reference: relative!
+			"/rooted/path",
+			"1http://example.org/", // scheme must start with ALPHA
+			"-http:x",
+			"+ssh:x",
+			"ht tp://example.org/", // space before colon breaks scheme
+			"héllo:x", // non-ASCII letter — not a valid scheme
+			"http٣x:y", // Arabic-Indic digit in scheme
+			"ｈttp://example.org/" // fullwidth letter
+	})
+	void relativeReferences(String iri) {
+		Assertions.assertFalse(URIUtil.isAbsoluteIri(iri),
+				"should be classified as relative: " + iri);
+	}
+
+	@Test
+	void isAbsoluteIri_shouldThrowIfIriStartsWithLeadingColon() {
+		assertThrows(IllegalArgumentException.class, () -> URIUtil.isAbsoluteIri(":foo"));
 	}
 }

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -33,6 +33,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.URIUtil;
 import org.eclipse.rdf4j.rio.ParseErrorListener;
 import org.eclipse.rdf4j.rio.ParseLocationListener;
 import org.eclipse.rdf4j.rio.ParserConfig;
@@ -322,7 +323,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 * Resolves a URI-string against the base URI and creates a {@link IRI} object for it.
 	 */
 	protected IRI resolveURI(String uriSpec) throws RDFParseException {
-		if (uriSpec.indexOf(':') < 0) {
+		if (isRelativeIri(uriSpec)) {
 			// Resolve relative URIs against base URI
 			if (baseURI == null) {
 				reportFatalError("Unable to resolve URIs, no base URI has been set");
@@ -337,8 +338,17 @@ public abstract class AbstractRDFParser implements RDFParser {
 
 			return createURI(baseURI.resolve(uriSpec));
 		} else {
-			// URI is not relative
+			// URI has a scheme, i.e. it is absolute
 			return createURI(uriSpec);
+		}
+	}
+
+	private boolean isRelativeIri(String iri) {
+		try {
+			return !URIUtil.isAbsoluteIri(iri);
+		} catch (IllegalArgumentException e) {
+			reportFatalError(e);
+			throw e;
 		}
 	}
 

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ResolveUriTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ResolveUriTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ResolveUriTest {
+
+	private TestParser parser;
+
+	@BeforeEach
+	void setUp() {
+		parser = new TestParser();
+		parser.setBaseUri("http://example.org/dir/doc");
+	}
+
+	@Test
+	void absoluteIriIsNotResolved() {
+		IRI iri = parser.resolve("http://other.org/x");
+		assertEquals("http://other.org/x", iri.stringValue());
+	}
+
+	@Test
+	void urnIsNotResolved() {
+		IRI iri = parser.resolve("urn:isbn:0451450523");
+		assertEquals("urn:isbn:0451450523", iri.stringValue());
+	}
+
+	@Test
+	void singleLetterSchemeIsNotResolved() {
+		IRI iri = parser.resolve("a:b");
+		assertEquals("a:b", iri.stringValue());
+	}
+
+	@Test
+	void plainRelativePathIsResolved() {
+		IRI iri = parser.resolve("other");
+		assertEquals("http://example.org/dir/other", iri.stringValue());
+	}
+
+	@Test
+	void colonInLaterPathSegmentIsResolved() {
+		IRI iri = parser.resolve("path/foo:bar");
+		assertEquals("http://example.org/dir/path/foo:bar", iri.stringValue());
+	}
+
+	@Test
+	void dotSegmentColonIsResolved() {
+		// RFC 3986 explicitly recommends "./a:b" to express this reference
+		IRI iri = parser.resolve("./a:b");
+		assertEquals("http://example.org/dir/a:b", iri.stringValue());
+	}
+
+	@Test
+	void colonInQueryIsResolved() {
+		IRI iri = parser.resolve("?q=a:b");
+		assertEquals("http://example.org/dir/doc?q=a:b", iri.stringValue());
+	}
+
+	@Test
+	void colonInFragmentIsResolved() {
+		IRI iri = parser.resolve("#a:b");
+		assertEquals("http://example.org/dir/doc#a:b", iri.stringValue());
+	}
+
+	@Test
+	void networkPathReferenceUsesBaseScheme() {
+		IRI iri = parser.resolve("//other.org/x");
+		assertEquals("http://other.org/x", iri.stringValue());
+	}
+
+	@Test
+	void emptyStringResolvesToBase() {
+		IRI iri = parser.resolve("");
+		assertEquals("http://example.org/dir/doc", iri.stringValue());
+	}
+
+	@Test
+	void fragmentOnlyResolvesAgainstBase() {
+		IRI iri = parser.resolve("#frag");
+		assertEquals("http://example.org/dir/doc#frag", iri.stringValue());
+	}
+
+	@Test
+	void relativeIriWithoutBaseFails() {
+		TestParser noBase = new TestParser(); // no base URI set
+		assertThrows(RDFParseException.class, () -> noBase.resolve("relative/path"));
+	}
+
+	@Test
+	void colonInPathWithoutBaseFails() {
+		TestParser noBase = new TestParser();
+		assertThrows(RDFParseException.class, () -> noBase.resolve("path/foo:bar"));
+	}
+
+	@Test
+	void leadingColonInFirstPathSegmentIsRejected() {
+		assertThrows(RDFParseException.class, () -> parser.resolve(":foo"));
+	}
+
+	/**
+	 * Minimal concrete parser exposing resolveURI for testing.
+	 */
+	private static class TestParser extends AbstractRDFParser {
+
+		IRI resolve(String uriSpec) {
+			return resolveURI(uriSpec);
+		}
+
+		void setBaseUri(String base) {
+			setBaseURI(base);
+		}
+
+		// --- boilerplate to satisfy the abstract contract ---
+
+		@Override
+		public org.eclipse.rdf4j.rio.RDFFormat getRDFFormat() {
+			return org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
+		}
+
+		@Override
+		public void parse(java.io.InputStream in, String baseURI) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void parse(java.io.Reader reader, String baseURI) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
@@ -39,7 +40,9 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -538,6 +541,32 @@ public class TurtleParserTest extends AbstractParserTest {
 			assertTrue(statementCollector.getStatements().size() == 1);
 		} catch (RDFParseException e) {
 			fail("Complex unicode characters should be parsed correctly (" + e.getMessage() + ")");
+		}
+	}
+
+	@Test
+	public void testParseBaseIriParsing() throws Exception {
+		String data = """
+				@base <http://example.com/> .
+				@prefix my: <https://mydomain.com/> .
+
+				<system/x:ABC> a my:Item .
+
+				<http://example.com/system/x:DEF> a my:Item .
+
+				my:abc a my:Item .
+				""";
+		Reader r = new StringReader(data);
+		try {
+			parser.parse(r);
+			var stmts = statementCollector.getStatements();
+			assertEquals(3, stmts.size());
+			var model = new TreeModel(stmts);
+			assertEquals(Set.of(Values.iri("http://example.com/system/x:ABC"),
+					Values.iri("http://example.com/system/x:DEF"), Values.iri("https://mydomain.com/abc")),
+					model.subjects());
+		} catch (RDFParseException e) {
+			fail("parse error on correct data: " + e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
GitHub issue resolved: # GH-5977

Briefly describe the changes proposed in this PR:

Fixes an issue with the AbstractRDFParser.resolveURI where a relative IRI is threated as absolute.

Introduce logic that check if string is  a valid RFC 3986 scheme followed by ':'. A colon appearing after '/', '?' or '#' does not make the reference absolute.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

