### PR TITLE
GH-414: document gzip uploads on the Workbench add page

### DIFF
--- a/site/content/documentation/tools/server-workbench.md
+++ b/site/content/documentation/tools/server-workbench.md
@@ -378,7 +378,9 @@ Data may be added to or removed from current repository using any of the sidebar
 
 ### Add
 
-The “Add” page allows you to specify a URL with RDF data, a local file on on your client system, or to enter serialized RDF data into its text area for loading into the present repository. It is also possible to specify the Base URI and a Context for the triples. Think of the Context as a 4th element of each RDF statement, specifying a graph within the repository. You may specify one of eight serialization formats, or select “auto-detect” to let the server do a best guess at the format.
+The “Add” page allows you to specify a URL with RDF data, a local file on your client system, or to enter serialized RDF data into its text area for loading into the present repository. It is also possible to specify the Base URI and a Context for the triples. Think of the Context as a 4th element of each RDF statement, specifying a graph within the repository. You may specify one of eight serialization formats, or select “auto-detect” to let the server do a best guess at the format.
+
+Local files (and URLs that serve compressed bytes) may be gzip-compressed for faster transfer, for example `data.ttl.gz` or `data.rdf.gzip`. Workbench decompresses the stream automatically before parsing. With auto-detect, the RDF format is taken from the name after the compression suffix (`ttl` in `data.ttl.gz`). Gzip is always available; deflate, zstd, and brotli are used when the matching library is on the classpath. Zip archives (`.zip` with multiple entries) are not unpacked here.
 
 #### Remove
 

--- a/tools/workbench/src/main/webapp/locale/messages.xsl
+++ b/tools/workbench/src/main/webapp/locale/messages.xsl
@@ -161,6 +161,9 @@
 	<variable name="upload-file.desc">
 		Select the file containing the RDF data you wish to upload
 	</variable>
+	<variable name="upload-file.hint">
+		Gzip-compressed files such as data.ttl.gz are accepted and decompressed automatically.
+	</variable>
 	<variable name="upload-file.label">RDF Data File</variable>
 	<variable name="upload-text.desc">
 		Enter the RDF data you wish to upload

--- a/tools/workbench/src/main/webapp/transformations/add.xsl
+++ b/tools/workbench/src/main/webapp/transformations/add.xsl
@@ -147,6 +147,9 @@
 						</th>
 						<td>
 							<input type="file" id="file" name="content" onchange="workbench.add.enabledInput('file')" />
+							<div class="hint">
+								<xsl:value-of select="$upload-file.hint" />
+							</div>
 						</td>
 						<td></td>
 					</tr>


### PR DESCRIPTION
GitHub issue resolved: #414

Briefly describe the changes proposed in this PR:

Document that the Workbench Add page accepts gzip-compressed RDF files (for example `data.ttl.gz`) and decompresses them before parsing. Also show a short hint next to the file picker.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
