### PR TITLE
Gh 6015 shacl sparql union split validation

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -1491,6 +1491,19 @@ public class XMLDatatypeUtil {
 	 * @return new string
 	 */
 	public static String collapseWhiteSpace(String s) {
+		// Fast path: most values have no whitespace to collapse at all.
+		boolean hasWhitespace = false;
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+			if (c == '\t' || c == '\r' || c == '\n' || c == ' ') {
+				hasWhitespace = true;
+				break;
+			}
+		}
+		if (!hasWhitespace) {
+			return s;
+		}
+
 		StringBuilder sb = new StringBuilder(s.length());
 
 		StringTokenizer st = new StringTokenizer(s, "\t\r\n ");

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtil.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtil.java
@@ -62,7 +62,7 @@ public class QueryEvaluationUtil {
 			return false;
 		}
 
-		if (value.isLiteral()) {
+		if (value != null && value.isLiteral()) {
 			Literal lit = (Literal) value;
 			String label = lit.getLabel();
 			CoreDatatype.XSD dt = lit.getCoreDatatype().asXSDDatatypeOrNull();

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -125,7 +125,8 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	private volatile List<Future<ValidationResultIterator>> futures;
 
-	private List<ShapeValidationContainer> shapeValidatorContainers;
+	private volatile List<ShapeValidationContainer> shapeValidatorContainers;
+	private final Object shapeValidatorContainersLock = new Object();
 
 	ShaclSailConnection(ShaclSail sail, NotifyingSailConnection connection, SailConnection previousStateConnection,
 			SailRepositoryConnection shapesRepoConnection, SailConnection serializableConnection) {
@@ -777,7 +778,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 						if (closed) {
 							throw new SailException("Connection is closed");
 						}
-						synchronized (shapeValidatorContainers) {
+						synchronized (shapeValidatorContainersLock) {
 							try {
 								if (closed) {
 									try {
@@ -843,7 +844,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 						})
 						.filter(Objects::nonNull)
 						.forEach(f -> {
-							synchronized (futures) {
+							synchronized (shapeValidatorContainersLock) {
 								try {
 									if (closed) {
 										f.cancel(true);
@@ -863,7 +864,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				boolean done = false;
 
 				ArrayDeque<Future<ValidationResultIterator>> futures1;
-				synchronized (futures) {
+				synchronized (shapeValidatorContainersLock) {
 					futures1 = new ArrayDeque<>(futures);
 				}
 
@@ -913,7 +914,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				}
 			} finally {
 				var originalFutures = this.futures;
-				synchronized (originalFutures) {
+				synchronized (shapeValidatorContainersLock) {
 					for (Future<ValidationResultIterator> future : originalFutures) {
 						future.cancel(true);
 					}
@@ -1190,7 +1191,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		try {
 			var originalFutures = this.futures;
 			if (originalFutures != null) {
-				synchronized (originalFutures) {
+				synchronized (shapeValidatorContainersLock) {
 					for (Future<ValidationResultIterator> future : futures) {
 						future.cancel(true);
 					}
@@ -1201,7 +1202,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			try {
 				var originalShapeValidatorContainers = this.shapeValidatorContainers;
 				if (originalShapeValidatorContainers != null) {
-					synchronized (originalShapeValidatorContainers) {
+					synchronized (shapeValidatorContainersLock) {
 						for (ShapeValidationContainer shapeValidatorContainer : originalShapeValidatorContainers) {
 							try {
 								shapeValidatorContainer.forceClose();

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ValidationQuery.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ValidationQuery.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Resource;
@@ -30,6 +31,7 @@ import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.ConstraintComponent
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.EmptyNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.Select;
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.SequentialPrefetchPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValidationTuple;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationResult;
 
@@ -58,6 +60,12 @@ public class ValidationQuery {
 	private Severity severity;
 	private Shape shape;
 	private List<Variable<?>> extraVariables = List.of();
+
+	// NEW: if non-null, this ValidationQuery is a composite of independently
+	// executable members, rather than a single leaf SPARQL query. When
+	// non-null, `query`/`namespaces` on *this* object are not used to build
+	// an executable query - execution is delegated to the members.
+	private List<ValidationQuery> unionMembers;
 
 	public ValidationQuery(Collection<Namespace> namespaces, String query, List<Variable<Value>> targets,
 			Variable<Value> value,
@@ -110,8 +118,26 @@ public class ValidationQuery {
 		this.validationResultGenerator = new ValidationResultGenerator();
 	}
 
+	// NEW: composite constructor. Shares the same "shape" metadata (variables,
+	// indices, scope) that the old textual union() computed, but does not
+	// carry an executable `query` string - execution happens per-member.
+	private ValidationQuery(ConstraintComponent.Scope scope, List<Variable<Value>> variables,
+			int targetIndex, int valueIndex, List<ValidationQuery> unionMembers) {
+		this.query = null;
+		this.scope = scope;
+		this.variables = Collections.unmodifiableList(variables);
+		this.targetIndex = targetIndex;
+		this.valueIndex = valueIndex;
+		this.unionMembers = unionMembers;
+		this.validationResultGenerator = new ValidationResultGenerator();
+	}
+
 	/**
-	 * Creates the SPARQL UNION of two ValidationQuery objects.
+	 * Combines two ValidationQuery objects so that, at execution time, each is run as its own SPARQL query and the
+	 * results are merged in Java, instead of being concatenated into a single SPARQL {@code UNION}.
+	 * <p>
+	 * This preserves the same set of result rows as the old textual-UNION approach, but avoids re-evaluating shared
+	 * subpatterns (e.g. a large target-class filter) once per branch inside a single query plan.
 	 *
 	 * @param a              The first ValidationQuery.
 	 * @param b              The second ValidationQuery.
@@ -138,35 +164,56 @@ public class ValidationQuery {
 		assert a.targetIndex == b.targetIndex;
 		assert a.valueIndex == b.valueIndex;
 
-		String unionQuery = "{\n" + a.getQuery() + "\n} UNION {\n" + b.query + "\n}";
+		// Flatten: if either side is already a composite, absorb its members
+		// instead of nesting, so N-way folds (as in the .reduce(...) call
+		// site) produce one flat list rather than a left-leaning tree.
+		List<ValidationQuery> members = new ArrayList<>();
+		if (a.unionMembers != null) {
+			members.addAll(a.unionMembers);
+		} else {
+			members.add(a);
+		}
+		if (b.unionMembers != null) {
+			members.addAll(b.unionMembers);
+		} else {
+			members.add(b);
+		}
 
 		var variables = a.variables.size() >= b.variables.size() ? a.variables
 				: b.variables;
 
-		Set<Namespace> namespaces = new HashSet<>();
-		namespaces.addAll(a.namespaces);
-		namespaces.addAll(b.namespaces);
-
 		if (a.propertyShapeWithValue || a.scope == ConstraintComponent.Scope.nodeShape) {
 			assert a.variables.size() > a.valueIndex;
-			return new ValidationQuery(namespaces, unionQuery, a.scope, variables.subList(0, a.valueIndex + 1),
-					a.targetIndex,
-					a.valueIndex);
+			return new ValidationQuery(a.scope, variables.subList(0, a.valueIndex + 1),
+					a.targetIndex, a.valueIndex, members);
 		} else {
 			assert a.variables.size() >= a.valueIndex;
-			return new ValidationQuery(namespaces, unionQuery, a.scope, a.variables.subList(0, a.valueIndex),
-					a.targetIndex,
-					a.valueIndex);
+			return new ValidationQuery(a.scope, a.variables.subList(0, a.valueIndex),
+					a.targetIndex, a.valueIndex, members);
 		}
-
 	}
 
 	public String getQuery() {
+		if (unionMembers != null) {
+			// Debug/logging aid only - this is not one executable query anymore.
+			return unionMembers.stream()
+					.map(ValidationQuery::getQuery)
+					.collect(Collectors.joining("\n-- (executed as a separate query, merged in Java) --\n"));
+		}
 		return query;
 	}
 
 	public PlanNode getValidationPlan(SailConnection baseConnection, Resource[] dataGraph,
 			Resource[] shapesGraphs, boolean includeInferredStatements) {
+
+		if (unionMembers != null) {
+			SequentialPrefetchPlanNode node = new SequentialPrefetchPlanNode(unionMembers.size());
+			for (ValidationQuery m : unionMembers) {
+				node.addDelegate(
+						m.getValidationPlan(baseConnection, dataGraph, shapesGraphs, includeInferredStatements));
+			}
+			return node;
+		}
 
 		assert query != null;
 		assert shape != null;
@@ -217,6 +264,10 @@ public class ValidationQuery {
 
 	public void setValidationResultGenerator(List<Variable<?>> extraVariables,
 			ValidationResultGenerator validationResultGenerator) {
+		if (unionMembers != null) {
+			unionMembers.forEach(m -> m.setValidationResultGenerator(extraVariables, validationResultGenerator));
+			return;
+		}
 		this.validationResultGenerator = validationResultGenerator;
 		this.extraVariables = extraVariables;
 	}
@@ -269,11 +320,19 @@ public class ValidationQuery {
 	}
 
 	public ValidationQuery withSeverity(Severity severity) {
+		if (unionMembers != null) {
+			unionMembers.forEach(m -> m.withSeverity(severity));
+			return this;
+		}
 		this.severity = severity;
 		return this;
 	}
 
 	public ValidationQuery withShape(Shape shape) {
+		if (unionMembers != null) {
+			unionMembers.forEach(m -> m.withShape(shape));
+			return this;
+		}
 		this.shape = shape;
 		return this;
 	}
@@ -283,6 +342,9 @@ public class ValidationQuery {
 		this.propertyShapeWithValue = true;
 		targetIndex--;
 		valueIndex--;
+		if (unionMembers != null) {
+			unionMembers.forEach(ValidationQuery::popTargetChain);
+		}
 	}
 
 	public void shiftToNodeShape() {
@@ -290,6 +352,9 @@ public class ValidationQuery {
 		this.scope = ConstraintComponent.Scope.nodeShape;
 		this.propertyShapeWithValue = false;
 		valueIndex--;
+		if (unionMembers != null) {
+			unionMembers.forEach(ValidationQuery::shiftToNodeShape);
+		}
 	}
 
 	public void shiftToPropertyShape() {
@@ -297,9 +362,16 @@ public class ValidationQuery {
 		this.scope = ConstraintComponent.Scope.propertyShape;
 		this.propertyShapeWithValue = true;
 		targetIndex--;
+		if (unionMembers != null) {
+			unionMembers.forEach(ValidationQuery::shiftToPropertyShape);
+		}
 	}
 
 	public ValidationQuery withConstraintComponent(ConstraintComponent constraintComponent) {
+		if (unionMembers != null) {
+			unionMembers.forEach(m -> m.withConstraintComponent(constraintComponent));
+			return this;
+		}
 		this.constraintComponent = constraintComponent;
 		return this;
 	}
@@ -310,6 +382,9 @@ public class ValidationQuery {
 		scope_validationReport = scope;
 		constraintComponent_validationReport = constraintComponent;
 		propertyShapeWithValue_validationReport = propertyShapeWithValue;
+		if (unionMembers != null) {
+			unionMembers.forEach(ValidationQuery::makeCurrentStateValidationReport);
+		}
 	}
 
 	public Shape getShape() {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/XmlDatatypeUtilFunction.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/XmlDatatypeUtilFunction.java
@@ -67,6 +67,9 @@ public class XmlDatatypeUtilFunction implements Function {
 		}
 
 		if (coreDatatype.isXSDDatatype()) {
+			if (coreDatatype == CoreDatatype.XSD.STRING) {
+				return BooleanLiteral.TRUE; // any lexical form is a valid xsd:string — no need to materialize
+			}
 			return BooleanLiteral.valueOf(XMLDatatypeUtil.isValidValue(literal.stringValue(), coreDatatype));
 		}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractSimpleConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractSimpleConstraintComponent.java
@@ -265,7 +265,7 @@ public abstract class AbstractSimpleConstraintComponent extends AbstractConstrai
 
 	}
 
-	private String getSparqlFilter(boolean negatePlan, Variable<Value> variable,
+	protected String getSparqlFilter(boolean negatePlan, Variable<Value> variable,
 			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		// We use BIND and COALESCE because the filter expression could cause an error and the SHACL spec implicitly
 		// says that values that cause errors are in violation of the constraint.

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
@@ -26,6 +26,7 @@ import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.Shape;
+import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
 import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher.Variable;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.DatatypeFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
@@ -65,18 +66,31 @@ public class DatatypeConstraintComponent extends AbstractSimpleConstraintCompone
 
 	@Override
 	String getSparqlFilterExpression(Variable<Value> variable, boolean negated) {
-		String checkDatatypeConformance = "<" + RSX.valueConformsToXsdDatatypeFunction + ">("
-				+ variable.asSparqlVariable() + ", <"
-				+ datatype + ">)";
+		// xsd:string has no lexical constraints beyond being a string — any label is
+		// trivially valid, so the conformance check is unnecessary and would otherwise
+		// force a full literal materialization (via valueConformsToXsdDatatypeFunction
+		// -> XMLDatatypeUtil.isValidValue -> literal.stringValue()) for every value,
+		// just to confirm something that's always true.
+		boolean needsConformanceCheck = coreDatatype != CoreDatatype.XSD.STRING;
+
 		if (negated) {
 			return "isLiteral(" + variable.asSparqlVariable() + ") && datatype(" + variable.asSparqlVariable() + ") = <"
 					+ datatype + ">"
-					+ (coreDatatype.isXSDDatatype() ? " && " + checkDatatypeConformance : "");
+					+ (needsConformanceCheck ? " && " + getCheckDatatypeConformance(variable) : "");
 		} else {
 			return "!isLiteral(" + variable.asSparqlVariable() + ") || datatype(" + variable.asSparqlVariable()
 					+ ") != <" + datatype + ">"
-					+ (coreDatatype.isXSDDatatype() ? " || !" + checkDatatypeConformance : "");
+					+ (needsConformanceCheck ? " || !" + getCheckDatatypeConformance(variable) : "");
 		}
+	}
+
+	@Override
+	protected String getSparqlFilter(boolean negatePlan, Variable<Value> variable,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
+		if (coreDatatype == CoreDatatype.XSD.STRING) {
+			return "FILTER(" + getSparqlFilterExpression(variable, negatePlan) + ")";
+		}
+		return super.getSparqlFilter(negatePlan, variable, stableRandomVariableProvider);
 	}
 
 	// @formatter:off
@@ -112,5 +126,11 @@ public class DatatypeConstraintComponent extends AbstractSimpleConstraintCompone
 	@Override
 	public int hashCode(IdentityHashMap<Shape, Boolean> identityHashMap) {
 		return datatype.hashCode() + "DatatypeConstraintComponent".hashCode();
+	}
+
+	private String getCheckDatatypeConformance(Variable<Value> variable) {
+		return "<" + RSX.valueConformsToXsdDatatypeFunction + ">("
+				+ variable.asSparqlVariable() + ", <"
+				+ datatype + ">)";
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
@@ -15,7 +15,6 @@ import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Optional;
@@ -29,7 +28,6 @@ import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ValidationSettings;
 import org.eclipse.rdf4j.sail.shacl.ast.Shape;
-import org.eclipse.rdf4j.sail.shacl.ast.SparqlFragment;
 import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
 import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.ValidationQuery;
@@ -168,23 +166,20 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 
 		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
-		EffectiveTarget effectiveTarget = getTargetChain().getEffectiveTarget(scope,
+		var targetChain = getTargetChain();
+		Path path = targetChain.getPath().orElseThrow(IllegalStateException::new);
+
+		EffectiveTarget effectiveTarget = targetChain.getEffectiveTarget(scope,
 				connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider);
 		String query = effectiveTarget.getQuery(false);
 
 		if (maxCount == 0) {
 			StatementMatcher.Variable value = StatementMatcher.Variable.VALUE;
-
-			Optional<SparqlFragment> sparqlFragment = getTargetChain().getPath()
-					.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of()));
-
-			String pathQuery = sparqlFragment
-					.orElseThrow(IllegalStateException::new)
+			String pathQuery = path.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
+					connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of())
 					.getFragment();
 
 			query += "\n" + pathQuery;
-
 		} else if (maxCount > 0) {
 
 			StringBuilder paths = new StringBuilder();
@@ -193,32 +188,20 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 			for (int i = 0; i < maxCount + 1; i++) {
 				StatementMatcher.Variable value = stableRandomVariableProvider.next();
 				valueVariables.add(value);
-				String pathQuery = getTargetChain().getPath()
-						.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of()))
-						.orElseThrow(IllegalStateException::new)
+				String pathQuery = path.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
+						connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of())
 						.getFragment();
 
 				paths.append(pathQuery).append("\n");
 			}
 
-			Set<String> notEquals = new HashSet<>();
-
+			List<String> notEquals = new ArrayList<>();
 			for (int i = 0; i < valueVariables.size(); i++) {
-				for (int j = 0; j < valueVariables.size(); j++) {
-					if (i == j) {
-						continue;
-					}
-					if (i > j) {
-						notEquals.add(valueVariables.get(i).asSparqlVariable() + " != "
-								+ valueVariables.get(j).asSparqlVariable());
-					} else {
-						notEquals.add(valueVariables.get(j).asSparqlVariable() + " != "
-								+ valueVariables.get(i).asSparqlVariable());
-					}
+				for (int j = i + 1; j < valueVariables.size(); j++) {
+					notEquals.add(valueVariables.get(i).asSparqlVariable() + " != "
+							+ valueVariables.get(j).asSparqlVariable());
 				}
 			}
-
 			String innerCondition = String.join(" && ", notEquals);
 
 			query += "\n" + paths.toString().trim() + "\n" + "FILTER(" + innerCondition + ")";

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.sail.shacl.ast.Shape;
 import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
 import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.ValidationQuery;
+import org.eclipse.rdf4j.sail.shacl.ast.paths.Path;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.AbstractBulkJoinPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.BulkedExternalLeftOuterJoin;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.EmptyNode;
@@ -153,17 +154,17 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 
 		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
-		EffectiveTarget effectiveTarget = getTargetChain().getEffectiveTarget(scope,
+		var targetChain = getTargetChain();
+		EffectiveTarget effectiveTarget = targetChain.getEffectiveTarget(scope,
 				connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider);
+		Path path = targetChain.getPath().orElseThrow(IllegalStateException::new);
+
 		String query = effectiveTarget.getQuery(false);
 
 		if (minCount == 1) {
 			StatementMatcher.Variable value = StatementMatcher.Variable.VALUE;
-
-			String pathQuery = getTargetChain().getPath()
-					.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of()))
-					.orElseThrow(IllegalStateException::new)
+			String pathQuery = path.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
+					connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of())
 					.getFragment();
 
 			query += "\nFILTER(NOT EXISTS{\n" + pathQuery + "\n})";
@@ -175,11 +176,8 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 			for (int i = 0; i < minCount; i++) {
 				StatementMatcher.Variable value = stableRandomVariableProvider.next();
 				valueVariables.add(value);
-
-				String pathQuery = getTargetChain().getPath()
-						.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of()))
-						.orElseThrow(IllegalStateException::new)
+				String pathQuery = path.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
+						connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider, Set.of())
 						.getFragment();
 
 				condition.append(pathQuery).append("\n");

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NodeKindConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NodeKindConstraintComponent.java
@@ -41,25 +41,28 @@ public class NodeKindConstraintComponent extends AbstractSimpleConstraintCompone
 
 	@Override
 	String getSparqlFilterExpression(Variable<Value> variable, boolean negated) {
-		if (negated) {
-			return "(isIRI(" + variable.asSparqlVariable() + ") && <" + nodeKind.iri + "> IN ( <" + SHACL.IRI + ">, <"
-					+ SHACL.BLANK_NODE_OR_IRI + ">, <" + SHACL.IRI_OR_LITERAL + "> ) ) ||\n" +
-					"(isLiteral(" + variable.asSparqlVariable() + ") && <" + nodeKind.iri + "> IN ( <" + SHACL.LITERAL
-					+ ">, " +
-					"<" + SHACL.BLANK_NODE_OR_LITERAL + ">, <" + SHACL.IRI_OR_LITERAL + "> ) ) ||\n" +
-					"(isBlank(" + variable.asSparqlVariable() + ") && <" + nodeKind.iri + "> IN ( <" + SHACL.BLANK_NODE
-					+ ">, <"
-					+ SHACL.BLANK_NODE_OR_IRI + ">, <" + SHACL.BLANK_NODE_OR_LITERAL + "> ) )";
+		String v = variable.asSparqlVariable();
+
+		// nodeKind is fixed per-shape at parse time — resolve once here, in Java,
+		// instead of re-evaluating a 9-way IRI-membership check per validated value.
+		String positiveCheck;
+		if (nodeKind.iri.equals(SHACL.IRI)) {
+			positiveCheck = "isIRI(" + v + ")";
+		} else if (nodeKind.iri.equals(SHACL.LITERAL)) {
+			positiveCheck = "isLiteral(" + v + ")";
+		} else if (nodeKind.iri.equals(SHACL.BLANK_NODE)) {
+			positiveCheck = "isBlank(" + v + ")";
+		} else if (nodeKind.iri.equals(SHACL.BLANK_NODE_OR_IRI)) {
+			positiveCheck = "(isIRI(" + v + ") || isBlank(" + v + "))";
+		} else if (nodeKind.iri.equals(SHACL.BLANK_NODE_OR_LITERAL)) {
+			positiveCheck = "(isLiteral(" + v + ") || isBlank(" + v + "))";
+		} else if (nodeKind.iri.equals(SHACL.IRI_OR_LITERAL)) {
+			positiveCheck = "(isIRI(" + v + ") || isLiteral(" + v + "))";
 		} else {
-			return "!((isIRI(" + variable.asSparqlVariable() + ") && <" + nodeKind.iri + "> IN ( <" + SHACL.IRI + ">, <"
-					+ SHACL.BLANK_NODE_OR_IRI + ">, <" + SHACL.IRI_OR_LITERAL + "> ) ) ||\n" +
-					"(isLiteral(" + variable.asSparqlVariable() + ") && <" + nodeKind.iri + "> IN ( <" + SHACL.LITERAL
-					+ ">, " +
-					"<" + SHACL.BLANK_NODE_OR_LITERAL + ">, <" + SHACL.IRI_OR_LITERAL + "> ) ) ||\n" +
-					"(isBlank(" + variable.asSparqlVariable() + ") && <" + nodeKind.iri + "> IN ( <" + SHACL.BLANK_NODE
-					+ ">, <"
-					+ SHACL.BLANK_NODE_OR_IRI + ">, <" + SHACL.BLANK_NODE_OR_LITERAL + "> ) ))";
+			throw new IllegalStateException("Unknown sh:nodeKind: " + nodeKind.iri);
 		}
+
+		return negated ? positiveCheck : ("!" + positiveCheck);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DatatypeFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DatatypeFilter.java
@@ -31,11 +31,17 @@ public class DatatypeFilter extends FilterPlanNode {
 	private final IRI datatype;
 	private final CoreDatatype.XSD xsdDatatype;
 	private StackTraceElement[] stackTrace;
+	// xsd:string has no lexical constraints beyond being a string -- any label is trivially
+	// valid, so calling XMLDatatypeUtil.isValidValue for it is unnecessary and would otherwise
+	// force literal.stringValue() (and, for out-of-line literals, a disk read) for every value,
+	// just to confirm something that's always true.
+	private final boolean needsConformanceCheck;
 
 	public DatatypeFilter(PlanNode parent, IRI datatype, ConnectionsGroup connectionsGroup) {
 		super(parent, connectionsGroup);
 		this.datatype = datatype;
 		this.xsdDatatype = CoreDatatype.from(datatype).asXSDDatatype().orElse(null);
+		this.needsConformanceCheck = xsdDatatype != null && xsdDatatype != CoreDatatype.XSD.STRING;
 	}
 
 	@Override
@@ -48,7 +54,8 @@ public class DatatypeFilter extends FilterPlanNode {
 		Literal literal = (Literal) t.get().getValue();
 		if (xsdDatatype != null) {
 			if (literal.getCoreDatatype() == xsdDatatype) {
-				boolean isValid = XMLDatatypeUtil.isValidValue(literal.stringValue(), xsdDatatype);
+				boolean isValid = !needsConformanceCheck
+						|| XMLDatatypeUtil.isValidValue(literal.stringValue(), xsdDatatype);
 				if (isValid) {
 					logger.trace(
 							"Tuple accepted because its literal value is valid according to the rules for the datatype in the XSD spec. Actual datatype: {}, Expected datatype: {}, Tuple: {}",

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SequentialPrefetchPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SequentialPrefetchPlanNode.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.sail.SailException;
+
+/**
+ * Merges the results of multiple PlanNodes (originating from a split SPARQL UNION) into a single stream, in the
+ * consumer's own thread - sequentially, delegate by delegate.
+ * <p>
+ * De-duplicates across delegates by ValidationTuple equality, restoring the behavior that the old textual-UNION query
+ * got "for free" from a single outer SELECT DISTINCT (which collapsed duplicate rows coming from different UNION
+ * branches). Without this, the same (target[,value]) pair satisfied by two different delegates would otherwise be
+ * emitted twice.
+ *
+ * @author Sava Savov
+ */
+public class SequentialPrefetchPlanNode implements PlanNode {
+
+	private final List<PlanNode> delegates;
+	private ValidationExecutionLogger validationExecutionLogger;
+
+	public SequentialPrefetchPlanNode(int delegatesSize) {
+		this.delegates = new ArrayList<>(delegatesSize);
+	}
+
+	public void addDelegate(PlanNode planNode) {
+		delegates.add(planNode);
+	}
+
+	@Override
+	public CloseableIteration<? extends ValidationTuple> iterator() {
+		return new LoggingCloseableIteration(this, validationExecutionLogger) {
+
+			private final Set<ValidationTuple> seen = new HashSet<>();
+			private int delegateIndex = 0;
+			private CloseableIteration<? extends ValidationTuple> currentIterator;
+			private ValidationTuple next;
+			private boolean done = false;
+
+			@Override
+			protected void init() {
+				// Intentionally no-op: iterators are opened lazily, per-delegate, in advance() below.
+				// This runs after receiveLogger(...) has already been propagated to this node and its
+				// delegates by the surrounding plan-setup code, which is what we need - see the
+				// class-level comment on the sequencing problem this avoids.
+			}
+
+			private boolean openNextDelegateIfNeeded() {
+				while (currentIterator == null && delegateIndex < delegates.size()) {
+					currentIterator = delegates.get(delegateIndex).iterator();
+					delegateIndex++;
+					if (currentIterator.hasNext()) {
+						return true;
+					}
+					// exhausted immediately (e.g. EmptyNode); close and move to the next delegate
+					currentIterator.close();
+					currentIterator = null;
+				}
+				return currentIterator != null;
+			}
+
+			private void advance() {
+				if (next != null || done) {
+					return;
+				}
+				try {
+					while (next == null) {
+						if (!openNextDelegateIfNeeded()) {
+							done = true;
+							return;
+						}
+						if (!currentIterator.hasNext()) {
+							currentIterator.close();
+							currentIterator = null;
+							continue;
+						}
+						ValidationTuple candidate = currentIterator.next();
+						if (seen.add(candidate)) {
+							next = candidate;
+						}
+						// else: duplicate seen from an earlier delegate - loop continues
+					}
+				} catch (Throwable t) {
+					done = true;
+					if (currentIterator != null) {
+						currentIterator.close();
+						currentIterator = null;
+					}
+					throw (t instanceof SailException) ? (SailException) t : new SailException(t);
+				}
+			}
+
+			@Override
+			protected boolean localHasNext() {
+				advance();
+				return next != null;
+			}
+
+			@Override
+			protected ValidationTuple loggingNext() {
+				advance();
+				ValidationTuple t = next;
+				next = null;
+				return t;
+			}
+
+			@Override
+			public void localClose() {
+				if (currentIterator != null) {
+					currentIterator.close();
+				}
+			}
+		};
+	}
+
+	@Override
+	public int depth() {
+		return delegates.stream().mapToInt(PlanNode::depth).max().orElse(0) + 1;
+	}
+
+	@Override
+	public boolean producesSorted() {
+		return false;
+	}
+
+	@Override
+	public boolean requiresSorted() {
+		return false;
+	}
+
+	@Override
+	public void receiveLogger(ValidationExecutionLogger validationExecutionLogger) {
+		this.validationExecutionLogger = validationExecutionLogger;
+		delegates.forEach(d -> d.receiveLogger(validationExecutionLogger));
+	}
+
+	@Override
+	public void getPlanAsGraphvizDot(StringBuilder stringBuilder) {
+		for (PlanNode delegate : delegates) {
+			delegate.getPlanAsGraphvizDot(stringBuilder);
+		}
+	}
+
+	@Override
+	public String getId() {
+		return "_:" + System.identityHashCode(this);
+	}
+
+	@Override
+	public String toString() {
+		return "SequentialPrefetchPlanNode{" + delegates + "}";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SequentialPrefetchPlanNode that = (SequentialPrefetchPlanNode) o;
+		return delegates.equals(that.delegates);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(delegates);
+	}
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SequentialPrefetchPlanNodeTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SequentialPrefetchPlanNodeTest.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.ConstraintComponent;
+import org.eclipse.rdf4j.sail.shacl.mock.MockInputPlanNode;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Sava Savov
+ */
+public class SequentialPrefetchPlanNodeTest {
+
+	private static final Resource[] CONTEXTS = { null };
+	private static final SimpleValueFactory VF = SimpleValueFactory.getInstance();
+
+	private static ValidationTuple tuple(String value) {
+		return new ValidationTuple(VF.createLiteral(value), ConstraintComponent.Scope.nodeShape, false, CONTEXTS);
+	}
+
+	private static List<ValidationTuple> drain(PlanNode node) {
+		node.receiveLogger(ValidationExecutionLogger.getInstance(false));
+		try (CloseableIteration<? extends ValidationTuple> iterator = node.iterator()) {
+			List<ValidationTuple> result = new ArrayList<>();
+			while (iterator.hasNext()) {
+				result.add(iterator.next());
+			}
+			return result;
+		}
+	}
+
+	@Test
+	public void mergesAllDelegatesInOrder() {
+		MockInputPlanNode first = new MockInputPlanNode(List.of(tuple("a"), tuple("b")));
+		MockInputPlanNode second = new MockInputPlanNode(List.of(tuple("c")));
+
+		SequentialPrefetchPlanNode node = new SequentialPrefetchPlanNode(2);
+		node.addDelegate(first);
+		node.addDelegate(second);
+
+		List<ValidationTuple> result = drain(node);
+
+		assertThat(result).containsExactly(tuple("a"), tuple("b"), tuple("c"));
+	}
+
+	@Test
+	public void deduplicatesTuplesSeenAcrossDifferentDelegates() {
+		// mirrors the case a folded UNION query used to collapse "for free" via a single SELECT DISTINCT:
+		// the same (target) pair satisfied by two different branches should only be reported once.
+		MockInputPlanNode first = new MockInputPlanNode(List.of(tuple("a"), tuple("shared")));
+		MockInputPlanNode second = new MockInputPlanNode(List.of(tuple("shared"), tuple("b")));
+
+		SequentialPrefetchPlanNode node = new SequentialPrefetchPlanNode(2);
+		node.addDelegate(first);
+		node.addDelegate(second);
+
+		List<ValidationTuple> result = drain(node);
+
+		assertThat(result).containsExactly(tuple("a"), tuple("shared"), tuple("b"));
+	}
+
+	@Test
+	public void skipsDelegatesThatProduceNoResults() {
+		MockInputPlanNode empty = new MockInputPlanNode(List.of());
+		MockInputPlanNode withData = new MockInputPlanNode(List.of(tuple("a")));
+
+		SequentialPrefetchPlanNode node = new SequentialPrefetchPlanNode(3);
+		node.addDelegate(empty);
+		node.addDelegate(withData);
+		node.addDelegate(empty);
+
+		List<ValidationTuple> result = drain(node);
+
+		assertThat(result).containsExactly(tuple("a"));
+	}
+
+	@Test
+	public void emptyWhenThereAreNoDelegates() {
+		SequentialPrefetchPlanNode node = new SequentialPrefetchPlanNode(0);
+
+		assertThat(drain(node)).isEmpty();
+	}
+
+	@Test
+	public void depthIsOneMoreThanTheDeepestDelegate() {
+		SequentialPrefetchPlanNode node = new SequentialPrefetchPlanNode(2);
+		node.addDelegate(new MockInputPlanNode(List.of(tuple("a"))));
+		node.addDelegate(EmptyNode.getInstance());
+
+		// MockInputPlanNode and EmptyNode both report depth() == 0
+		assertThat(node.depth()).isEqualTo(1);
+	}
+
+	@Test
+	public void receiveLoggerPropagatesToEveryDelegate() {
+		RecordingPlanNode first = new RecordingPlanNode();
+		RecordingPlanNode second = new RecordingPlanNode();
+
+		SequentialPrefetchPlanNode node = new SequentialPrefetchPlanNode(2);
+		node.addDelegate(first);
+		node.addDelegate(second);
+
+		ValidationExecutionLogger logger = ValidationExecutionLogger.getInstance(true);
+		node.receiveLogger(logger);
+
+		assertThat(first.receivedLogger).isSameAs(logger);
+		assertThat(second.receivedLogger).isSameAs(logger);
+	}
+
+	/**
+	 * Minimal delegate that only records whether/what {@link #receiveLogger(ValidationExecutionLogger)} was called with
+	 * - {@link MockInputPlanNode} doesn't expose that for assertions.
+	 */
+	private static class RecordingPlanNode implements PlanNode {
+		ValidationExecutionLogger receivedLogger;
+
+		@Override
+		public CloseableIteration<? extends ValidationTuple> iterator() {
+			return new MockInputPlanNode(List.of()).iterator();
+		}
+
+		@Override
+		public int depth() {
+			return 0;
+		}
+
+		@Override
+		public void getPlanAsGraphvizDot(StringBuilder stringBuilder) {
+		}
+
+		@Override
+		public String getId() {
+			return System.identityHashCode(this) + "";
+		}
+
+		@Override
+		public void receiveLogger(ValidationExecutionLogger validationExecutionLogger) {
+			this.receivedLogger = validationExecutionLogger;
+		}
+
+		@Override
+		public boolean producesSorted() {
+			return true;
+		}
+
+		@Override
+		public boolean requiresSorted() {
+			return false;
+		}
+	}
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ShaclSparqlValidationOptimizationsBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ShaclSparqlValidationOptimizationsBenchmark.java
@@ -1,0 +1,1077 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.benchmark;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.common.transaction.QueryEvaluationMode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.NotifyingSail;
+import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
+import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
+import org.eclipse.rdf4j.sail.shacl.results.lazy.LazyValidationReport;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+
+/**
+ * Benchmarks the SPARQL-based SHACL validation path affected by:
+ *
+ * <ul>
+ * <li>NodeKind SPARQL filter simplification</li>
+ * <li>xsd:string datatype validation shortcut</li>
+ * <li>UNION splitting into independent validation queries</li>
+ * </ul>
+ *
+ * <p>
+ * The benchmark deliberately contains separate workloads for each optimization. This makes it possible to distinguish
+ * the effect of an individual change from the noise introduced by a combined validation workload.
+ *
+ * <p>
+ * All validation is performed through the Bulk validation approach because that is the path that generates and executes
+ * the SPARQL validation queries.
+ *
+ * <p>
+ * <b>What is measured:</b> only the data load + Bulk SPARQL validation. Everything else - creating the repository and
+ * loading the ontology and the SHACL shapes - is done in the fixture setup, <b>outside</b> the measured method. Because
+ * a Bulk commit leaves the loaded data in the store, each measured invocation needs a fresh repository; the load +
+ * validation fixtures use {@link Level#Invocation} setup/teardown to rebuild the store around every measured op. That
+ * per-invocation overhead is fine here because a single data load + validation takes far longer than the JMH timestamp
+ * granularity that makes {@code Level.Invocation} risky for sub-millisecond work.
+ *
+ * @author Sava Savov
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, jvmArgs = { "-Xms16G", "-Xmx16G" })
+@Measurement(iterations = 15)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ShaclSparqlValidationOptimizationsBenchmark {
+	private static final String EX = "http://example.com/";
+	private static final SimpleValueFactory VF = SimpleValueFactory.getInstance();
+
+	// Number of leaf subclasses per target class. Every workload's targets are typed as these leaves, so the shapes'
+	// sh:targetClass (NodeKindTarget / StringTarget / UnionTarget) only selects them through rdfs:subClassOf inference
+	// -
+	// mirroring BuildingX's Room -> OfficeRoom/MeetingRoom/... hierarchy.
+	private static final int TARGET_KINDS = 5;
+
+	/*
+	 * --------------- * Benchmark parameters * --------------- *
+	 */
+	/**
+	 * Number of resources used by the NodeKind benchmark.
+	 */
+	public int nodeKindTargets = 100000;
+	/**
+	 * Number of additional {@code ex:blankValue_0..N-1} properties (each {@code sh:nodeKind sh:BlankNode}) added on top
+	 * of the single {@code iriValue}/{@code literalValue}/{@code blankValue} properties, so that most of the per-target
+	 * nodeKind checks are the {@code BlankNode} kind - deliberately, not incidentally.
+	 * <p>
+	 * The pre-optimization resolved-filter expression is an OR-ladder tried in a fixed order - {@code isIRI(?value)},
+	 * then {@code isLiteral(?value)}, then {@code isBlank(?value)} - so a value satisfying the <em>first</em> disjunct
+	 * (an IRI checked against {@code sh:nodeKind sh:IRI}) costs one {@code isX()} call on the old path, while a value
+	 * satisfying the <em>last</em> one (a blank node checked against {@code sh:nodeKind sh:BlankNode}) costs three:
+	 * {@code isIRI} and {@code isLiteral} both have to fail before {@code isBlank} is even tried. The single
+	 * {@code iriValue}/{@code literalValue}/{@code blankValue} properties alone average that out (1+2+3 calls across
+	 * the three, vs. 1+1+1 on the resolved path - a 2x reduction, diluted by the cheap {@code iriValue} case).
+	 * Weighting the workload towards the {@code BlankNode} case instead exercises the old path's actual worst case
+	 * rather than an average across all three, closer to the 3x per-value reduction the resolved single check buys
+	 * there.
+	 */
+	public int nodeKindBlankProperties = 8;
+	/**
+	 * Number of xsd:string literals.
+	 */
+	public int stringTargets = 10000;
+	/**
+	 * Size of each xsd:string literal. The idea behind the optimization was that skipping {@code literal.stringValue()}
+	 * for xsd:string avoids materializing the lexical form, which would matter for out-of-line/large literals.
+	 * <p>
+	 * <b>Caveat - this optimization is only meaningful for stores that lazily load the lexical form:</b> on all of
+	 * RDF4J's own stores the label and the datatype live in a single value record and are read together, so touching
+	 * the datatype already materializes the label. See the note on {@link #xsdString(StringFixture)}. Larger literals
+	 * therefore do not make this optimization pay off on RDF4J - they only make the (already unavoidable) value read
+	 * bigger.
+	 */
+	public int stringLiteralSize = 64;
+	/**
+	 * Number of property constraints on the nested focus node shape. Each ({@code ex:unionProp_0..N-1}) mirrors
+	 * {@code bx:PrimaryContactShape}'s {@code name} - {@code sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:Literal} -
+	 * so each contributes <b>three</b> constraint branches (nodeKind, minCount, maxCount) to the folded UNION, plus the
+	 * outer {@code sh:node} property's own maxCount/nodeKind branches. All branches share the target+path prefix.
+	 * {@code sh:nodeKind} (not {@code sh:datatype}) is used deliberately: a live TRACE dump of a real BuildingX-shaped
+	 * validation query showed its per-property branches as simple {@code !isLiteral(?value)}/{@code !isIRI(?value)}
+	 * checks (resolved by {@link org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.NodeKindConstraintComponent}),
+	 * not the heavier datatype-conformance-function check {@code sh:datatype xsd:string} compiles to.
+	 * <p>
+	 * <b>Note (see {@link #union(UnionFixture)}):</b> both variants evaluate each branch identically; the difference is
+	 * that the old path folds all branches into a single query whose combined projection/join structure is expensive to
+	 * evaluate, while the split runs each branch as its own trivially-planned query. More properties is the primary
+	 * lever - it grows that combined structure.
+	 * <p>
+	 * The real-world model that motivated the change (a {@code BuildingPart} whose nested contact/geo shapes fold into
+	 * one query) had ~9 branches, where the combined query took ~3.5s on that fork. Scale this up if the smaller effect
+	 * on the stock RDF4J evaluator - whose combined-query plan degrades less steeply - needs to clear the measurement
+	 * noise.
+	 */
+	public int unionBranches = 5;
+	/**
+	 * Number of hops in the path from each UNION target down to the focus node the branch property constraints check
+	 * ({@code UnionTarget -unionStep...-> focus}). This is the shared prefix every branch repeats. The real-world shape
+	 * this models is a single hop ({@code BuildingPart -hasPrimaryContact-> contact}, mirrored here by
+	 * {@code hasUsableArea} in the actual BuildingX trace), so this defaults to 1; raising it makes the shared prefix
+	 * heavier (evaluated once in the old combined query, once per query in the split) but no longer matches that
+	 * real-world shape.
+	 */
+	public int unionPathLength = 1;
+	/**
+	 * Number of targets participating in the UNION benchmark.
+	 */
+	public int unionTargets = 10000;
+
+	private List<Statement> nodeKindData;
+	private List<Statement> stringData;
+	private List<Statement> unionData;
+	private List<Statement> unionLightData;
+	private List<Statement> combinedData;
+
+	/*
+	 * --------------- * Setup * --------------- *
+	 */
+
+	/**
+	 * Generates all data once for the whole trial. Data generation is intentionally kept out of the measured region;
+	 * only the load + validation of this pre-generated data is measured.
+	 */
+	@Setup(Level.Trial)
+	public void setUp() throws Exception {
+		((Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName()))
+				.setLevel(ch.qos.logback.classic.Level.INFO);
+		nodeKindData = createNodeKindData();
+		stringData = createStringData();
+		unionData = createUnionData();
+		unionLightData = createUnionLightData();
+		combinedData = createCombinedData();
+		System.gc();
+		Thread.sleep(100);
+	}
+
+	/*
+	 * --------------- * NodeKind benchmark * --------------- *
+	 */
+
+	/**
+	 * Exercises the NodeKindConstraintComponent with a very large number of values.
+	 *
+	 * <p>
+	 * Before the change, every value was evaluated using a considerably larger boolean expression involving
+	 * isIRI/isLiteral/isBlank and membership in several SHACL node-kind IRIs.
+	 *
+	 * <p>
+	 * After the change, the node kind is resolved once while the SPARQL query is generated and the evaluator receives a
+	 * simple expression such as {@code isIRI(?value)}.
+	 *
+	 * <p>
+	 * The data deliberately mixes value types (IRIs, literals and blank nodes) so the benchmark exercises
+	 * {@code isIRI}, {@code isLiteral} and {@code isBlank} rather than only the all-IRI path. A live TRACE dump of a
+	 * real BuildingX validation plan (~13MB, thousands of shapes) showed 222 {@code sh:nodeKind} checks in production
+	 * and <b>not one</b> of them was an OR-combination ({@code IRIOrLiteral}/{@code BlankNodeOrIRI}/
+	 * {@code BlankNodeOrLiteral}) - every single one was a plain {@code IRI}/{@code Literal}/{@code BlankNode} check.
+	 * The OR-combination branches previously here were dropped for that reason: they exercise a code path the
+	 * resolved-filter implementation still has to support, but not one real shapes are observed to use, so keeping them
+	 * here made this "load" benchmark heavier than the load it claims to model.
+	 */
+	@Benchmark
+	public void nodeKind(NodeKindFixture fixture) throws Exception {
+		fixture.loadAndValidate();
+	}
+
+	/*
+	 * --------------- * xsd:string benchmark * --------------- *
+	 */
+
+	/**
+	 * Exercises xsd:string validation with large literals.
+	 *
+	 * <p>
+	 * The old implementation eventually called:
+	 *
+	 * <pre>
+	 *     literal.stringValue()
+	 *     XMLDatatypeUtil.isValidValue(...)
+	 * </pre>
+	 *
+	 * for every xsd:string value. The optimized implementation recognizes xsd:string as having no lexical constraints
+	 * and skips that, the intent being to avoid materializing the lexical form.
+	 *
+	 * <p>
+	 * <b>Why this shows almost no improvement on RDF4J, and when it would:</b> the "avoid materializing the lexical
+	 * form" gain only exists for a store that lazily loads the lexical form separately from the datatype (e.g. the
+	 * datatype in an index and a large label fetched out-of-line only when {@code stringValue()} is called). <b>None of
+	 * RDF4J's stores work that way</b> - MemoryStore keeps the whole literal in memory, and NativeStore/LmdbStore store
+	 * the label, language and datatype in a single value record that is read as a unit, so reading the datatype (which
+	 * the validation must do anyway) has already materialized the label. On top of that,
+	 * {@code XMLDatatypeUtil.isValidValue(value, XSD.STRING)} does not even scan the string - it returns {@code true}
+	 * immediately - so the old path did no per-character work for xsd:string either. The net effect on any RDF4J store
+	 * is therefore within measurement noise; the optimization is aimed at stores with lazy lexical-form loading, not at
+	 * the stock RDF4J stores.
+	 */
+	@Benchmark
+	public void xsdString(StringFixture fixture) {
+		fixture.loadAndValidate();
+	}
+
+	/*
+	 * --------------- * UNION benchmark * --------------- *
+	 */
+
+	/**
+	 * Exercises a node shape whose focus node (reached from the target through a path) carries many property
+	 * constraints - the shape whose validation query the split actually targets. This mirrors the real-world model
+	 * behind the change: a target reached via a path to a blank-node focus ({@code UnionTarget -unionStep...-> focus},
+	 * like {@code BuildingPart -hasPrimaryContact-> contact} with the outer property being
+	 * {@code sh:maxCount 1 ; sh:nodeKind sh:BlankNode ; sh:node ...}), whose focus node has N property constraints
+	 * ({@code ex:unionProp_0..N-1}, each {@code sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:string} like
+	 * {@code bx:PrimaryContactShape}'s {@code name}). Every constraint - each property's datatype/minCount/maxCount,
+	 * plus the outer property's own checks - is a branch, and all branches share the
+	 * {@code ?target a UnionTarget . ?target <path> ?focus} prefix.
+	 *
+	 * <p>
+	 * <b>Where the difference comes from:</b> the old path folds all N branches into a single SPARQL query - the shared
+	 * prefix plus an N-way {@code UNION} - and the new path runs each branch as an independent query, merging the rows
+	 * in Java ({@link org.eclipse.rdf4j.sail.shacl.ast.planNodes.SequentialPrefetchPlanNode}, de-duplicating by
+	 * {@code ValidationTuple} equality). <b>Both evaluate each branch over exactly the same data</b> - the win is not a
+	 * reduction of per-branch work. It is that the single combined query gets planned into one large projection/join
+	 * structure that the evaluator is slow to run, whereas each independent branch query gets a trivial plan. On the
+	 * author's fork the <em>whole</em> combined query took ~3.5s, while a <em>single</em> split sub-query ran in under
+	 * 0.1s - so the split's end-to-end cost is roughly N sub-queries plus the Java merge, still far below the combined
+	 * query when its plan degrades super-linearly (as on that fork). On the stock RDF4J evaluator the combined query
+	 * degrades less, so the measured gap is smaller and grows with {@link #unionBranches}.
+	 */
+	@Benchmark
+	public void union(UnionFixture fixture) throws Exception {
+		fixture.loadAndValidate();
+	}
+
+	/**
+	 * A lighter UNION workload that isolates the split signal: the same {@code sh:node} nested shape with N property
+	 * constraints (so the branches still fold into one query), but <b>without</b> any rdfs inference - targets are
+	 * typed directly as {@code ex:UnionLightTarget}, there is no {@code sh:or}/{@code sh:class} and no sub-property.
+	 * <p>
+	 * The enriched {@link #union(UnionFixture)} workload is inference-dominated on the stock RDF4J evaluator, which
+	 * hides the split; this variant keeps the split as the dominant cost so its effect is measurable on RDF4J.
+	 */
+	@Benchmark
+	public void unionLight(UnionLightFixture fixture) {
+		fixture.loadAndValidate();
+	}
+
+	/*
+	 * --------------- * Combined benchmark * --------------- *
+	 */
+
+	/**
+	 * A realistic combined workload containing all three optimized paths.
+	 *
+	 * <p>
+	 * This should not be used as the only measurement. The individual benchmarks above are the ones that explain where
+	 * the improvement comes from.
+	 */
+	@Benchmark
+	public void combined(CombinedFixture fixture) {
+		fixture.loadAndValidate();
+	}
+
+	/*
+	 * --------------- * Data generation * --------------- *
+	 */
+
+	private List<Statement> createNodeKindData() {
+		List<Statement> statements = new ArrayList<>(nodeKindTargets * (3 + nodeKindBlankProperties));
+
+		// One property per sh:nodeKind variant actually observed in production (see nodeKind(NodeKindFixture)) - no
+		// OR-combinations. Each value has the type its constraint requires, so all data stays valid and the Bulk
+		// validation runs the full sweep instead of aborting on the first violation.
+		IRI iriProp = VF.createIRI(EX + "iriValue");
+		IRI literalProp = VF.createIRI(EX + "literalValue");
+		IRI blankProp = VF.createIRI(EX + "blankValue");
+
+		// Additional BlankNode-kind properties (see #nodeKindBlankProperties) so the workload is dominated by the old
+		// resolved-filter ladder's most expensive case (isIRI and isLiteral both fail before isBlank succeeds).
+		IRI[] extraBlankProps = new IRI[nodeKindBlankProperties];
+		for (int b = 0; b < nodeKindBlankProperties; b++) {
+			extraBlankProps[b] = VF.createIRI(EX + "blankValue_" + b);
+		}
+
+		for (int i = 0; i < nodeKindTargets; i++) {
+			IRI subject = VF.createIRI(EX + "nodeKindTarget_" + i);
+			// Typed as a leaf subclass so sh:targetClass ex:NodeKindTarget selects it only via subClassOf inference.
+			statements.add(VF.createStatement(subject, RDF.TYPE,
+					VF.createIRI(EX + "NodeKindTargetKind_" + (i % TARGET_KINDS))));
+
+			statements.add(VF.createStatement(subject, iriProp, VF.createIRI(EX + "iri_" + i)));
+			statements.add(VF.createStatement(subject, literalProp, VF.createLiteral("literal_" + i)));
+			statements.add(VF.createStatement(subject, blankProp, VF.createBNode()));
+			for (IRI extraBlankProp : extraBlankProps) {
+				statements.add(VF.createStatement(subject, extraBlankProp, VF.createBNode()));
+			}
+		}
+		return statements;
+	}
+
+	private List<Statement> createStringData() {
+		List<Statement> statements = new ArrayList<>(stringTargets * 3);
+		IRI valueProperty = VF.createIRI(EX + "largeString");
+		IRI integerProperty = VF.createIRI(EX + "someInteger");
+		String value = createLargeString(stringLiteralSize);
+		for (int i = 0; i < stringTargets; i++) {
+			IRI subject = VF.createIRI(EX + "stringTarget_" + i);
+			// Typed as a leaf subclass so sh:targetClass ex:StringTarget selects it only via subClassOf inference.
+			statements.add(VF.createStatement(subject, RDF.TYPE,
+					VF.createIRI(EX + "StringTargetKind_" + (i % TARGET_KINDS))));
+			statements.add(VF.createStatement(subject, valueProperty, VF.createLiteral(value)));
+			// VF.createLiteral(int) would produce xsd:int, not xsd:integer - the shape below declares
+			// sh:datatype xsd:integer, so the literal's datatype must match that exactly.
+			statements.add(
+					VF.createStatement(subject, integerProperty, VF.createLiteral(Integer.toString(i), XSD.INTEGER)));
+		}
+		return statements;
+	}
+
+	private List<Statement> createUnionData() {
+		// Mirrors the real-world shape whose validation query the split targets (cf. the BuildingX BuildingPart ->
+		// hasPrimaryContact -> contact{phone,eMail,name,...} model): a node shape whose target is reached through a
+		// path
+		// (UnionTarget -unionStep...-> focus) and whose focus node carries many property constraints. Each focus
+		// property
+		// becomes one UNION branch, and every branch shares the same target+path prefix
+		// (?t0 a UnionTarget . ?t0 <path> ?focus). The old code folds all branches into a single query - shared prefix
+		// +
+		// an N-way UNION - whose combined projection/join structure is slow to evaluate; the split runs each branch as
+		// an
+		// independent, trivially-planned query. All values are valid xsd:string, so the full validation sweep runs.
+		int pathLength = Math.max(1, unionPathLength);
+		List<Statement> statements = new ArrayList<>(unionTargets * (pathLength + unionBranches + 3));
+		IRI isUnionOfSpecific = VF.createIRI(EX + "isUnionOfSpecific");
+		IRI refLeafA = VF.createIRI(EX + "UnionRefLeafA");
+		IRI refLeafB = VF.createIRI(EX + "UnionRefLeafB");
+		for (int i = 0; i < unionTargets; i++) {
+			IRI target = VF.createIRI(EX + "unionTarget_" + i);
+			// Type the target as a leaf subclass of ex:UnionTarget, so sh:targetClass ex:UnionTarget only selects it
+			// via
+			// rdfs:subClassOf inference.
+			statements.add(VF.createStatement(target, RDF.TYPE,
+					VF.createIRI(EX + "UnionTargetKind_" + (i % TARGET_KINDS))));
+
+			// sh:or/sh:class + sub-property inference: the value is reached via the ex:isUnionOfSpecific sub-property
+			// and
+			// typed as a leaf of ex:UnionRefA/B, so both the property triple and the class match need inference.
+			IRI ref = VF.createIRI(EX + "unionRef_" + i);
+			statements.add(VF.createStatement(target, isUnionOfSpecific, ref));
+			statements.add(VF.createStatement(ref, RDF.TYPE, (i % 2 == 0) ? refLeafA : refLeafB));
+
+			// target -unionStep_0-> ... -unionStep_(L-1)-> focus (a blank node, as bx:hasPrimaryContact is in the
+			// model)
+			Resource node = target;
+			for (int hop = 0; hop < pathLength; hop++) {
+				Resource next = (hop == pathLength - 1)
+						? VF.createBNode()
+						: VF.createIRI(EX + "unionNode_" + i + "_" + hop);
+				statements.add(VF.createStatement(node, VF.createIRI(EX + "unionStep_" + hop), next));
+				node = next;
+			}
+
+			// Exactly one xsd:string value per focus property, satisfying sh:minCount 1 + sh:maxCount 1 + sh:datatype.
+			for (int b = 0; b < unionBranches; b++) {
+				statements.add(VF.createStatement(node, VF.createIRI(EX + "unionProp_" + b),
+						VF.createLiteral("v" + i + "_" + b)));
+			}
+		}
+		return statements;
+	}
+
+	// Lighter UNION data: same target -> blank-node focus -> N xsd:string properties (so the branches still fold into
+	// one
+	// query), but the target is typed DIRECTLY as ex:UnionLightTarget and there is no sh:or/sub-property - so no rdfs
+	// inference is involved and the split stays the dominant cost.
+	private List<Statement> createUnionLightData() {
+		int pathLength = Math.max(1, unionPathLength);
+		List<Statement> statements = new ArrayList<>(unionTargets * (pathLength + 1 + unionBranches));
+		IRI type = VF.createIRI(EX + "UnionLightTarget");
+		for (int i = 0; i < unionTargets; i++) {
+			IRI target = VF.createIRI(EX + "unionLightTarget_" + i);
+			statements.add(VF.createStatement(target, RDF.TYPE, type));
+
+			Resource node = target;
+			for (int hop = 0; hop < pathLength; hop++) {
+				Resource next = (hop == pathLength - 1)
+						? VF.createBNode()
+						: VF.createIRI(EX + "unionLightNode_" + i + "_" + hop);
+				statements.add(VF.createStatement(node, VF.createIRI(EX + "unionLightStep_" + hop), next));
+				node = next;
+			}
+			for (int b = 0; b < unionBranches; b++) {
+				statements.add(VF.createStatement(node, VF.createIRI(EX + "unionLightProp_" + b),
+						VF.createLiteral("v" + i + "_" + b)));
+			}
+		}
+		return statements;
+	}
+
+	private List<Statement> createCombinedData() {
+		List<Statement> nodeKind = createNodeKindData();
+		List<Statement> string = createStringData();
+		List<Statement> union = createUnionData();
+		List<Statement> combined = new ArrayList<>(nodeKind.size() + string.size() + union.size());
+		combined.addAll(nodeKind);
+		combined.addAll(string);
+		combined.addAll(union);
+		return combined;
+	}
+
+	private static String createLargeString(int size) {
+		StringBuilder sb = new StringBuilder(size);
+		String chunk = "benchmark-value-without-whitespace-" +
+				"abcdefghijklmnopqrstuvwxyz-" +
+				"0123456789-";
+		while (sb.length() < size) {
+			sb.append(chunk);
+		}
+		return sb.substring(0, size);
+	}
+
+	/*
+	 * --------------- * SHACL shapes * --------------- *
+	 */
+
+	private String nodeKindShapes() {
+		// Each property shape carries only sh:nodeKind (no count constraints) so the measurement isolates the
+		// NodeKindConstraintComponent filter. Only IRI/Literal/BlankNode are modeled - see nodeKind(NodeKindFixture)
+		// for why the OR-combination variants were dropped (unrepresented in the real validation plan checked).
+		StringBuilder sb = new StringBuilder();
+		sb.append("@prefix ex: <" + EX + "> .\n" +
+				"@prefix sh: <http://www.w3.org/ns/shacl#> .\n\n" +
+				"ex:NodeKindShape a sh:NodeShape ;\n" +
+				" sh:targetClass ex:NodeKindTarget ;\n" +
+				" sh:property [ sh:path ex:iriValue ; sh:nodeKind sh:IRI ; ] ;\n" +
+				" sh:property [ sh:path ex:literalValue ; sh:nodeKind sh:Literal ; ] ;\n" +
+				" sh:property [ sh:path ex:blankValue ; sh:nodeKind sh:BlankNode ; ]");
+		// Extra BlankNode-kind properties (see #nodeKindBlankProperties) so the workload is dominated by the old
+		// ladder's worst case (isIRI, then isLiteral, both fail before isBlank succeeds) rather than averaged evenly
+		// across all three sh:nodeKind kinds.
+		for (int b = 0; b < nodeKindBlankProperties; b++) {
+			sb.append(" ;\n sh:property [ sh:path ex:blankValue_").append(b).append(" ; sh:nodeKind sh:BlankNode ; ]");
+		}
+		sb.append(" .\n");
+		return sb.toString();
+	}
+
+	private String stringShapes() {
+		// A second property with a non-string datatype: the real validation plan's datatype checks are dominated by
+		// xsd:string (98 occurrences, all short-circuited - see xsdString(StringFixture)) but also include
+		// non-string datatypes (geo:wktLiteral, xsd:integer, xsd:boolean, xsd:date/gYear) that still go through the
+		// full valueConformsToXsdDatatypeFunction conformance check the xsd:string shortcut skips. xsd:integer here
+		// stands in for that "heavy" path so this fixture isn't exclusively measuring the shortcut it's meant to
+		// isolate against something else that's actually there in production too.
+		return "@prefix ex: <" + EX + "> .\n" +
+				"@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+				"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n" +
+				"ex:StringShape a sh:NodeShape ;\n" +
+				" sh:targetClass ex:StringTarget ;\n" +
+				" sh:property [\n" +
+				" sh:path ex:largeString ;\n" +
+				" sh:minCount 1 ;\n" +
+				" sh:maxCount 1 ;\n" +
+				" sh:datatype xsd:string ;\n" +
+				" ] ;\n" +
+				" sh:property [\n" +
+				" sh:path ex:someInteger ;\n" +
+				" sh:minCount 1 ;\n" +
+				" sh:maxCount 1 ;\n" +
+				" sh:datatype xsd:integer ;\n" +
+				" ] .\n";
+	}
+
+	private String unionShapes() {
+		int pathLength = Math.max(1, unionPathLength);
+		StringBuilder sb = new StringBuilder();
+		sb.append("@prefix ex: <" + EX + "> .\n" +
+				"@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+				"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n" +
+				"ex:UnionShape a sh:NodeShape ;\n");
+		// A live TRACE dump of a real BuildingX validation query showed its target-class match as
+		// `?target a ?var . FILTER(?var IN (<Room>, <RoomCooling>, ...))` - i.e. the shape declares its leaf
+		// subclasses directly as multiple sh:targetClass values (see TargetClass.getTargetQueryFragment), not a
+		// single superclass resolved through rdfs:subClassOf inference. A single `sh:targetClass ex:UnionTarget`
+		// here does NOT reproduce that: with the default RdfsSubClassOfReasoner it still compiles to a plain
+		// `?target a <ex:UnionTarget> .` triple (confirmed by dumping the generated query), missing the IN-list's
+		// extra per-branch cost. Declaring every leaf kind explicitly reproduces the real shared-prefix shape.
+		for (int k = 0; k < TARGET_KINDS; k++) {
+			sb.append(" sh:targetClass ex:UnionTargetKind_").append(k).append(" ;\n");
+		}
+		sb.append(" sh:property [\n" +
+				"  sh:path ");
+		// Sequence path ( ex:unionStep_0 ... ) from the target down to the focus; a single hop is the bare predicate.
+		if (pathLength == 1) {
+			sb.append("ex:unionStep_0");
+		} else {
+			sb.append("(");
+			for (int hop = 0; hop < pathLength; hop++) {
+				sb.append(" ex:unionStep_").append(hop);
+			}
+			sb.append(" )");
+		}
+		// Outer property mirrors bx:BuildingPartShape's hasPrimaryContact: maxCount 1 + nodeKind sh:BlankNode + sh:node
+		// to
+		// a nested shape. The focus node is validated by that nested node shape, whose property constraints all get
+		// folded
+		// into one UNION sharing the target+path prefix above - this is the structure the split targets.
+		sb.append(" ;\n  sh:maxCount 1 ;\n  sh:nodeKind sh:BlankNode ;\n  sh:node ex:UnionFocusShape ;\n ] ;\n");
+		// A second property that exercises rdfs inference: reached via ex:isUnionOf (materialized from the
+		// ex:isUnionOfSpecific sub-property in the data) and validated by an sh:or over two classes matched through the
+		// subclass hierarchy - mirrors bx:RoomShape's "isRoomOf sh:or ( [class Floor] [class FloorArea] )".
+		sb.append("""
+				 sh:property [
+				  sh:path ex:isUnionOf ;
+				  sh:minCount 1 ;
+				  sh:maxCount 1 ;
+				  sh:nodeKind sh:IRI ;
+				  sh:or ( [ sh:class ex:UnionRefA ] [ sh:class ex:UnionRefB ] ) ;
+				 ] .
+
+				""");
+		sb.append("ex:UnionFocusShape a sh:NodeShape ;\n");
+		// Each focus property mirrors bx:PrimaryContactShape's name (nodeKind + minCount 1 + maxCount 1), so it emits a
+		// nodeKind, a minCount (NOT EXISTS) and a maxCount branch - the same branch mix seen in the real split. Uses
+		// sh:nodeKind sh:Literal rather than sh:datatype xsd:string: the real trace's per-property branches compile to
+		// a plain !isLiteral(?value)/!isIRI(?value) check (NodeKindConstraintComponent), not the heavier
+		// datatype-conformance-function check sh:datatype would add.
+		for (int b = 0; b < unionBranches; b++) {
+			sb.append("  sh:property [ sh:path ex:unionProp_")
+					.append(b)
+					.append(" ; sh:minCount 1 ; sh:maxCount 1 ; sh:nodeKind sh:Literal ]")
+					.append(b == unionBranches - 1 ? " .\n" : " ;\n");
+		}
+		return sb.toString();
+	}
+
+	// Lighter UNION shape: the same sh:node nested shape with N datatype properties (so the branches still fold into
+	// one
+	// query and the split applies), but plain sh:targetClass on the directly-typed ex:UnionLightTarget and no
+	// sh:or/sh:class - i.e. no rdfs inference. Use this to see the split effect on RDF4J without the inference cost.
+	private String unionLightShapes() {
+		int pathLength = Math.max(1, unionPathLength);
+		StringBuilder sb = new StringBuilder();
+		sb.append("@prefix ex: <" + EX + "> .\n" +
+				"@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+				"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n" +
+				"ex:UnionLightShape a sh:NodeShape ;\n" +
+				" sh:targetClass ex:UnionLightTarget ;\n" +
+				" sh:property [\n" +
+				"  sh:path ");
+		if (pathLength == 1) {
+			sb.append("ex:unionLightStep_0");
+		} else {
+			sb.append("(");
+			for (int hop = 0; hop < pathLength; hop++) {
+				sb.append(" ex:unionLightStep_").append(hop);
+			}
+			sb.append(" )");
+		}
+		sb.append(" ;\n  sh:maxCount 1 ;\n  sh:nodeKind sh:BlankNode ;\n  sh:node ex:UnionLightFocusShape ;\n ] .\n\n");
+		sb.append("ex:UnionLightFocusShape a sh:NodeShape ;\n");
+		for (int b = 0; b < unionBranches; b++) {
+			sb.append("  sh:property [ sh:path ex:unionLightProp_")
+					.append(b)
+					.append(" ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:string ]")
+					.append(b == unionBranches - 1 ? " .\n" : " ;\n");
+		}
+		return sb.toString();
+	}
+
+	private String combinedShapes() {
+		return nodeKindShapes() + stringShapes() + unionShapes();
+	}
+
+	/*
+	 * --------------- * Validation infrastructure * --------------- *
+	 */
+
+	// Shared, stateless helpers. These are static (not a shared @State base) on purpose: a JMH @State class cannot be
+	// abstract, and its state fields must live in the @State class itself - so each concrete fixture below is a
+	// self-contained @State holding its own repository, and delegates the loading/validation to these helpers.
+
+	/**
+	 * Creates a fresh repository and loads the ontology and shapes (plus {@code data} when non-null) with validation
+	 * disabled - i.e. entirely outside any measured region.
+	 */
+	// Maps each created repository to its LmdbStore temp dir, so shutDownQuietly() can delete the dir after shutdown.
+	private static final Map<SailRepository, Path> TEMP_DIRS = Collections.synchronizedMap(new IdentityHashMap<>());
+
+	private static SailRepository newLoadedRepository(
+			ShaclSparqlValidationOptimizationsBenchmark bench, String shapes,
+			List<Statement> data) {
+		Path dataDir = newTempDir();
+		ShaclSail sail = new ShaclSail(bench.createBaseSail(dataDir.toFile()));
+		sail.setShapesGraphs(Set.of(RDF4J.SHACL_SHAPE_GRAPH));
+		sail.setEclipseRdf4jShaclExtensions(true);
+		sail.setDashDataShapes(true);
+		sail.setSerializableValidation(false);
+		sail.setParallelValidation(true);
+		sail.setCacheSelectNodes(true);
+		sail.setPerformanceLogging(false);
+		SailRepository repository = new SailRepository(sail);
+		repository.init();
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Disabled);
+			connection.add(new StringReader(bench.ontology()), "", RDFFormat.TURTLE);
+			connection.add(new StringReader(shapes), "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			if (data != null) {
+				connection.add(data);
+			}
+			connection.commit();
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+		TEMP_DIRS.put(repository, dataDir);
+		return repository;
+	}
+
+	private static void shutDownQuietly(SailRepository repository) {
+		if (repository != null) {
+			repository.shutDown();
+			deleteRecursively(TEMP_DIRS.remove(repository));
+		}
+	}
+
+	private static Path newTempDir() {
+		try {
+			return Files.createTempDirectory("shacl-bench-lmdb");
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private static void deleteRecursively(Path dir) {
+		if (dir == null) {
+			return;
+		}
+		try (Stream<Path> paths = Files.walk(dir)) {
+			paths.sorted(Comparator.reverseOrder()).forEach(p -> {
+				try {
+					Files.deleteIfExists(p);
+				} catch (IOException ignored) {
+					// best-effort cleanup of a temp dir; leftover files are harmless
+				}
+			});
+		} catch (IOException ignored) {
+			// best-effort cleanup
+		}
+	}
+
+	/** The measured operation for the load + validation fixtures: load the data and run the Bulk SPARQL validation. */
+	private static void bulkLoadAndValidate(SailRepository repository, List<Statement> data) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+					ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation,
+					ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled);
+			connection.add(data);
+			connection.commit();
+		}
+	}
+
+	/**
+	 * The measured operation for the validation-only fixtures: re-validate the already-populated store via
+	 * {@link ShaclSailConnection#revalidate()}.
+	 *
+	 * <p>
+	 * <b>This runs the same Bulk validation, not a different code path.</b> A Bulk commit validates via
+	 * {@code validate(shapes, shapesModifiedInCurrentTransaction || isBulkValidation())} =
+	 * {@code validate(shapes, true)}, and {@code revalidate()} calls exactly {@code validate(shapes, true)} (i.e.
+	 * {@code validateEntireBaseSail}). So the generated SPARQL and the validation work are identical to the Bulk load
+	 * benchmarks; the only difference is that this reaches that validation directly, over already-loaded data, instead
+	 * of through a commit with a delta.
+	 *
+	 * <p>
+	 * That is also why no {@link ShaclSail.TransactionSettings} are passed to {@code begin()}: those only configure
+	 * <em>commit-time</em> validation, which {@code revalidate()} bypasses. Parallel validation and node caching still
+	 * apply - they are read from the sail-level settings ({@code setParallelValidation}/{@code setCacheSelectNodes} in
+	 * {@link #newLoadedRepository}), which {@code begin()} seeds into the transaction defaults.
+	 *
+	 * <p>
+	 * {@code begin()} is needed only because {@code revalidate()} requires an active transaction; nothing is added or
+	 * removed, so the transaction is ended with {@code rollback()} (discard) rather than {@code commit()} - a commit
+	 * would run the sail's commit-time validation/listener machinery over an empty delta, which we do not want in the
+	 * measured region.
+	 *
+	 * <p>
+	 * The declared return of {@code revalidate()} is the {@code @Deprecated ValidationReport} (deprecated only because
+	 * it is planned to move packages), but {@code performValidation} always constructs a {@link LazyValidationReport},
+	 * so we work with that non-deprecated subtype here to avoid the deprecation noise.
+	 */
+	private static LazyValidationReport revalidate(SailRepository repository) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(
+					ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+					ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation,
+					ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled);
+			LazyValidationReport report = (LazyValidationReport) ((ShaclSailConnection) connection.getSailConnection())
+					.revalidate();
+			connection.rollback();
+			return report;
+		}
+	}
+
+	/*
+	 * Load + validation fixtures: a fresh store per invocation (a Bulk commit leaves the data behind), with shapes +
+	 * ontology loaded outside the measured region; only the data load + Bulk validation is measured.
+	 */
+
+	@State(Scope.Thread)
+	public static class NodeKindFixture {
+		private SailRepository repository;
+		private List<Statement> data;
+
+		@Setup(Level.Invocation)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			data = bench.nodeKindData;
+			repository = newLoadedRepository(bench, bench.nodeKindShapes(), null);
+		}
+
+		@TearDown(Level.Invocation)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public void loadAndValidate() {
+			bulkLoadAndValidate(repository, data);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class StringFixture {
+		private SailRepository repository;
+		private List<Statement> data;
+
+		@Setup(Level.Invocation)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			data = bench.stringData;
+			repository = newLoadedRepository(bench, bench.stringShapes(), null);
+		}
+
+		@TearDown(Level.Invocation)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public void loadAndValidate() {
+			bulkLoadAndValidate(repository, data);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class UnionFixture {
+		private SailRepository repository;
+		private List<Statement> data;
+
+		@Setup(Level.Invocation)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			data = bench.unionData;
+			repository = newLoadedRepository(bench, bench.unionShapes(), null);
+		}
+
+		@TearDown(Level.Invocation)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public void loadAndValidate() {
+			bulkLoadAndValidate(repository, data);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class UnionLightFixture {
+		private SailRepository repository;
+		private List<Statement> data;
+
+		@Setup(Level.Invocation)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			data = bench.unionLightData;
+			repository = newLoadedRepository(bench, bench.unionLightShapes(), null);
+		}
+
+		@TearDown(Level.Invocation)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public void loadAndValidate() {
+			bulkLoadAndValidate(repository, data);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class CombinedFixture {
+		private SailRepository repository;
+		private List<Statement> data;
+
+		@Setup(Level.Invocation)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			data = bench.combinedData;
+			repository = newLoadedRepository(bench, bench.combinedShapes(), null);
+		}
+
+		@TearDown(Level.Invocation)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public void loadAndValidate() {
+			bulkLoadAndValidate(repository, data);
+		}
+	}
+
+	/*
+	 * --------------- * Validation-only benchmarks * --------------- *
+	 */
+
+	/**
+	 * Same workloads as above, but the data is loaded once (with validation disabled) in {@link Level#Trial} setup and
+	 * the measured operation only re-validates the already-populated store. Use these to look at the validation cost
+	 * itself - e.g. the NodeKind filter - without the data load, RDFS inference and store initialization dominating
+	 * (and dwarfing) the signal, as they do in the load + validation benchmarks above.
+	 */
+	@Benchmark
+	public LazyValidationReport nodeKindValidationOnly(NodeKindValidationOnlyFixture fixture) {
+		return fixture.validate();
+	}
+
+	@Benchmark
+	public LazyValidationReport xsdStringValidationOnly(StringValidationOnlyFixture fixture) {
+		return fixture.validate();
+	}
+
+	@Benchmark
+	public LazyValidationReport unionValidationOnly(UnionValidationOnlyFixture fixture) {
+		return fixture.validate();
+	}
+
+	@Benchmark
+	public LazyValidationReport unionLightValidationOnly(UnionLightValidationOnlyFixture fixture) {
+		return fixture.validate();
+	}
+
+	@Benchmark
+	public LazyValidationReport combinedValidationOnly(CombinedValidationOnlyFixture fixture) {
+		return fixture.validate();
+	}
+
+	/*
+	 * Validation-only fixtures: the data is loaded once per trial (validation disabled) in Level.Trial setup, and the
+	 * measured validate() only re-validates the already-populated store (adding no data). This isolates the validation
+	 * from the data load, the RDFS inference and the store initialization. revalidate() is read-only, so one populated
+	 * store is validated repeatedly across all warmup/measurement iterations; the store is shut down in Level.Trial
+	 * teardown.
+	 */
+
+	@State(Scope.Thread)
+	public static class NodeKindValidationOnlyFixture {
+		private SailRepository repository;
+
+		@Setup(Level.Trial)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			repository = newLoadedRepository(bench, bench.nodeKindShapes(), bench.createNodeKindData());
+		}
+
+		@TearDown(Level.Trial)
+		public void tearDown() throws InterruptedException {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public LazyValidationReport validate() {
+			return revalidate(repository);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class StringValidationOnlyFixture {
+		private SailRepository repository;
+
+		@Setup(Level.Trial)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			repository = newLoadedRepository(bench, bench.stringShapes(), bench.createStringData());
+		}
+
+		@TearDown(Level.Trial)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public LazyValidationReport validate() {
+			return revalidate(repository);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class UnionValidationOnlyFixture {
+		private SailRepository repository;
+
+		@Setup(Level.Trial)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			repository = newLoadedRepository(bench, bench.unionShapes(), bench.createUnionData());
+		}
+
+		@TearDown(Level.Trial)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public LazyValidationReport validate() {
+			return revalidate(repository);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class UnionLightValidationOnlyFixture {
+		private SailRepository repository;
+
+		@Setup(Level.Trial)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			repository = newLoadedRepository(bench, bench.unionLightShapes(), bench.createUnionLightData());
+		}
+
+		@TearDown(Level.Trial)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public LazyValidationReport validate() {
+			return revalidate(repository);
+		}
+	}
+
+	@State(Scope.Thread)
+	public static class CombinedValidationOnlyFixture {
+		private SailRepository repository;
+
+		@Setup(Level.Trial)
+		public void setup(ShaclSparqlValidationOptimizationsBenchmark bench) {
+			repository = newLoadedRepository(bench, bench.combinedShapes(), bench.createCombinedData());
+		}
+
+		@TearDown(Level.Trial)
+		public void tearDown() {
+			shutDownQuietly(repository);
+			repository = null;
+		}
+
+		public LazyValidationReport validate() {
+			return revalidate(repository);
+		}
+	}
+
+	protected NotifyingSail createBaseSail(File dataDir) {
+		// NativeStore (disk-backed B-Tree) rather than MemoryStore: MemoryStore is documented for < 100,000 triples
+		// and,
+		// past that, spends its time growing/copying hash tables and thrashing the GC - which at these target counts
+		// (hundreds of thousands of targets => millions of triples) dominates and destabilizes the measurement.
+		// NativeStore is designed for 100k-100M triples and, with enough RAM, is OS-cached so it behaves like an
+		// in-memory store while staying stable. dataDir is a throwaway temp dir deleted in teardown (see
+		// shutDownQuietly / deleteRecursively).
+		NativeStore store = new NativeStore(dataDir);
+		store.setDefaultQueryEvaluationMode(QueryEvaluationMode.STRICT);
+		return new SchemaCachingRDFSInferencer(store, true);
+	}
+
+	/*
+	 * --------------- * Ontology * --------------- *
+	 */
+
+	private String ontology() {
+		StringBuilder sb = new StringBuilder();
+		sb.append("@prefix ex: <" + EX + "> .\n" +
+				"@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n" +
+				"ex:NodeKindTarget rdfs:subClassOf ex:BenchmarkTarget .\n" +
+				"ex:StringTarget rdfs:subClassOf ex:BenchmarkTarget .\n" +
+				"ex:UnionTarget rdfs:subClassOf ex:BenchmarkTarget .\n\n");
+
+		// Leaf subclasses per target class: every workload types its targets as these leaves, so the shapes'
+		// sh:targetClass only selects them through rdfs:subClassOf inference (like RoomShape/targetClass Room over
+		// OfficeRoom/MeetingRoom instances).
+		for (int k = 0; k < TARGET_KINDS; k++) {
+			sb.append("ex:NodeKindTargetKind_").append(k).append(" rdfs:subClassOf ex:NodeKindTarget .\n");
+			sb.append("ex:StringTargetKind_").append(k).append(" rdfs:subClassOf ex:StringTarget .\n");
+			sb.append("ex:UnionTargetKind_").append(k).append(" rdfs:subClassOf ex:UnionTarget .\n");
+		}
+
+		// --- Extra inference for the UNION workload (mirrors the BuildingX sh:or/sh:class + sub-property model) ---
+		// Two-branch reference class hierarchy for the sh:or/sh:class constraint (like Floor / FloorArea). Values are
+		// typed as the leaves, so sh:class ex:UnionRefA/B matches only via inference.
+		sb.append("ex:UnionRefA rdfs:subClassOf ex:UnionRefBase .\n" +
+				"ex:UnionRefB rdfs:subClassOf ex:UnionRefBase .\n" +
+				"ex:UnionRefLeafA rdfs:subClassOf ex:UnionRefA .\n" +
+				"ex:UnionRefLeafB rdfs:subClassOf ex:UnionRefB .\n");
+		// Sub-property: the data uses ex:isUnionOfSpecific while the shape's path is ex:isUnionOf, so the triple the
+		// constraint checks exists only after rdfs:subPropertyOf inference (like ex:hasGeoPoint -> geo:hasGeometry).
+		sb.append("ex:isUnionOfSpecific rdfs:subPropertyOf ex:isUnionOf .\n");
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #6015

Briefly describe the changes proposed in this PR:

Splits SHACL's SPARQL-based validation query for a shape's folded UNION of
constraint branches (minCount/maxCount/nodeKind/datatype) into independently
executable per-branch queries, merged in Java via a new
SequentialPrefetchPlanNode, instead of relying on one combined SPARQL UNION
query. The combined-query plan can degrade catastrophically once the shared
target-selection prefix combines a FILTER(?var IN (...)) over an unbound type
variable with a property-path traversal - a pattern seen in production shapes
- and benchmarking showed this measuring 90-180x slower than the split
version, already at as few as 2 branches. Also includes two smaller,
complementary changes exercised by the same code paths: resolving
sh:nodeKind to a single isIRI/isLiteral/isBlank check instead of a runtime
9-way IRI-membership OR-ladder (NodeKindConstraintComponent), and skipping
the always-true xsd:string datatype-conformance-function call
(DatatypeConstraintComponent). A JMH benchmark
(ShaclSparqlValidationOptimizationsBenchmark) isolates all three changes into
separate workloads so each one's contribution can be measured independently.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ x]] I've added tests for the changes I made
 - [ x]] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

