### PR TITLE
GH-0000 Allow more time for Central publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,10 @@
 					<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 				</snapshotRepository>
 			</distributionManagement>
+			<properties>
+				<!-- Allow two hours for Central validation and publishing; the plugin default is 30 minutes. -->
+				<central.publishing.waitMaxTime>7200</central.publishing.waitMaxTime>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>
@@ -117,6 +121,7 @@
 							<publishingServerId>central</publishingServerId>
 							<autoPublish>true</autoPublish>
 							<waitUntil>published</waitUntil>
+							<waitMaxTime>${central.publishing.waitMaxTime}</waitMaxTime>
 							<centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
 						</configuration>
 					</plugin>

--- a/site/content/documentation/developer/releases.md
+++ b/site/content/documentation/developer/releases.md
@@ -170,10 +170,22 @@ The job will ask for the github release tag as an input parameters, e.g. '2.2.1'
 
 After successful completion, it will kick off a second job:
 `rdf4j-deploy-release-ossrh`. This job will build all Maven artifacts and
-upload them to [OSS Sonatype](https://oss.sonatype.org/).  After successful
-upload, it will also automatically invoke synchronization with the Central
-Repository.  Note that after successful completion, the artifacts may not be
-available on the Central Repository for several hours.
+upload them to the [Central Publisher Portal](https://central.sonatype.com/).
+The `ossrh` Maven profile automatically publishes the deployment and waits
+for Central to report it as published.
+
+The profile allows up to two hours for validation and publishing, instead
+of the publishing plugin's 30-minute default. The limit is configured in
+seconds by `central.publishing.waitMaxTime`; add, for example,
+`-Dcentral.publishing.waitMaxTime=10800` to the Maven deployment command to
+allow three hours. The CI job timeout must allow time for the build and
+upload as well as this wait.
+
+If Maven reports `Polling for ... timed out before the deployment completed`,
+check the deployment ID from the log in the
+[Portal deployments page](https://central.sonatype.com/publishing/deployments)
+before retrying. A Maven polling timeout does not mean that Central has
+stopped processing the deployment.
 
 ## Eclipse release reviews
 


### PR DESCRIPTION
GitHub issue resolved: N/A (internal release issue; no public issue number, so using GH-0000).

Central publishing can fail at the final `rdf4j-bom` module when validation and publication exceed the publishing plugin's [default 30-minute polling limit](https://central.sonatype.org/publish/publish-portal-maven/#waitmaxtime). Give the shared `ossrh` profile a two-hour limit through `central.publishing.waitMaxTime`, which can be overridden on the Maven command line. Automatic publishing continues to wait for Central to report the deployment as published.

Update the release instructions with the timeout override, the corresponding CI timeout requirement, and guidance to check the existing deployment's status before retrying a timed-out release.

Validation:

- Full offline root `-Pquick clean install` passed before and after the change, and again after rebasing onto current `main` (6.1.0-SNAPSHOT; tests skipped).
- Maven effective-POM checks confirmed the BOM inherits `waitMaxTime=7200`, a command-line override resolves to `10800`, and `autoPublish=true` / `waitUntil=published` remain configured. The normal build still has no active Central publishing plugin.
- Copyright checks, Maven formatting, and `git diff --check` passed. No live deployment was attempted.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

- [x] my pull request is self-contained
- [ ] I've added tests for the changes I made (configuration-only change; verified Maven's effective configuration instead)
- [x] I've applied code formatting
- [x] I've squashed my commits where necessary (single commit)
- [x] every commit message starts with the issue number (GH-0000 for this internal issue) followed by a meaningful description of the change
